### PR TITLE
Memoized wrapper for recursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,20 +224,20 @@ context.ensure_logic();
 
 let int = context.int_sort();
 // Option 1: extend incrementally
-let mut q_ctx = context.build_quantifier() ?;
-q_ctx.extend("x", int.clone()) ?.extend("y", int) ?;
+let mut q_ctx = context.build_quantifier()?;
+q_ctx.extend("x", int.clone())?.extend("y", int)?;
 
 // Option 2: provide domain upfront (equivalent)
-let mut q_ctx = context.build_quantifier_with_domain([("x", int.clone()), ("y", int)]) ?;
+let mut q_ctx = context.build_quantifier_with_domain([("x", int.clone()), ("y", int)])?;
 
 // Build terms using the local variables
 let body = q_ctx.typed_simp_app(">", [
-q_ctx.typed_symbol("x") ?,
-q_ctx.typed_symbol("y") ?,
-]) ?;
+q_ctx.typed_symbol("x")?,
+q_ctx.typed_symbol("y")?,
+])?;
 
 // Finalize — consumes the context
-let forall_term = q_ctx.typed_forall(body) ?;  // or .typed_exists(body)?
+let forall_term = q_ctx.typed_forall(body)?;  // or .typed_exists(body)?
 ```
 
 The body must be a `Bool`-sorted term. Duplicate variable names are rejected.
@@ -246,14 +246,14 @@ The body must be a `Bool`-sorted term. Duplicate variable names are rejected.
 
 ```rust
 // Bindings are provided at creation time (they are well-formed in the parent scope)
-let bound_term = context.typed_simp_app("+", [a.clone(), b.clone()]) ?;
-let mut l_ctx = context.build_let([("sum", bound_term)]) ?;
+let bound_term = context.typed_simp_app("+", [a.clone(), b.clone()])?;
+let mut l_ctx = context.build_let([("sum", bound_term)])?;
 
 // "sum" is now available as a local variable
 let body = l_ctx.typed_simp_app("*", [
-l_ctx.typed_symbol("sum") ?,
-l_ctx.typed_symbol("sum") ?,
-]) ?;
+l_ctx.typed_symbol("sum")?,
+l_ctx.typed_symbol("sum")?,
+])?;
 
 // Finalize
 let let_term = l_ctx.typed_let(body);
@@ -266,22 +266,22 @@ validated at context creation.
 
 ```rust
 // Assume List datatype is declared and l1 : (List Int)
-let mut m_ctx = context.build_matching(l1) ?;
+let mut m_ctx = context.build_matching(l1)?;
 
 // Build the nil arm (nullary constructor)
-let nil_arm = m_ctx.build_arm_nullary("nil") ?;
-nil_arm.typed_arm(some_body) ?;
+let nil_arm = m_ctx.build_arm_nullary("nil")?;
+nil_arm.typed_arm(some_body)?;
 
 // Build the cons arm with named variables
-let mut cons_arm = m_ctx.build_arm("cons", [Some("h"), Some("t")]) ?;
+let mut cons_arm = m_ctx.build_arm("cons", [Some("h"), Some("t")])?;
 // "h" and "t" are now in scope within cons_arm
-let h = cons_arm.typed_symbol("h") ?;
-let t = cons_arm.typed_symbol("t") ?;
+let h = cons_arm.typed_symbol("h")?;
+let t = cons_arm.typed_symbol("t")?;
 let body = /* ... build body using h and t ... */;
-cons_arm.typed_arm(body) ?;
+cons_arm.typed_arm(body)?;
 
 // Finalize — all constructors must be covered (or a wildcard must be present)
-let match_term = m_ctx.typed_matching() ?;
+let match_term = m_ctx.typed_matching()?;
 ```
 
 The match context tracks constructor coverage. `typed_matching()` returns `Err` if not all
@@ -294,10 +294,10 @@ arms. All arm bodies must have the same sort.
 let int = context.int_sort();
 let mut f_ctx = context.build_fun_out_sort(
 "double", [("x", int.clone())], int
-) ?;
-let x = f_ctx.typed_symbol("x") ?;
-let body = f_ctx.typed_simp_app("+", [x.clone(), x]) ?;
-let cmd = f_ctx.typed_define_fun(body) ?;
+)?;
+let x = f_ctx.typed_symbol("x")?;
+let body = f_ctx.typed_simp_app("+", [x.clone(), x])?;
+let cmd = f_ctx.typed_define_fun(body)?;
 // "double" is now in the global context
 ```
 
@@ -307,15 +307,15 @@ Use `build_fun` (without output sort) to let the sort be inferred from the body.
 
 ```rust
 let int = context.int_sort();
-let list_int = context.wf_sort_n("List", [int.clone()]) ?;
+let list_int = context.wf_sort_n("List", [int.clone()])?;
 let mut ctx = context.build_rec_funs([
 RecFunc::new("length", [("l", list_int.clone())], int.clone()),
-]) ?;
-let mut f_ctx = ctx.build_function("length") ?;
+])?;
+let mut f_ctx = ctx.build_function("length")?;
 // The function "length" is already in scope (for recursive calls)
 let body = /* ... */;
-f_ctx.typed_function(body) ?;
-let cmd = ctx.typed_define_funs_rec() ?;
+f_ctx.typed_function(body)?;
+let cmd = ctx.typed_define_funs_rec()?;
 ```
 
 All declared functions must be given a body before calling `typed_define_funs_rec()`.
@@ -324,17 +324,17 @@ All declared functions must be given a body before calling `typed_define_funs_re
 
 ```rust
 // Simple enum
-let cmd = context.typed_enum("Color", ["red", "green", "blue"]) ?;
+let cmd = context.typed_enum("Color", ["red", "green", "blue"])?;
 
 // Polymorphic datatype
-let mut d_ctx = context.build_datatypes([("List", ["X"])]) ?;
-let mut c_ctx = d_ctx.build_datatype("List") ?;
-c_ctx.build_datatype_constructor_nullary("nil") ?;
-let xvar = c_ctx.wf_sort("X") ?;  // sort parameter is in scope
-let list_x = c_ctx.wf_sort_n("List", [xvar.clone()]) ?;
-c_ctx.build_datatype_constructor("cons", [("car", xvar), ("cdr", list_x)]) ?;
-c_ctx.typed_datatype() ?;
-let cmd = d_ctx.typed_declare_datatypes() ?;
+let mut d_ctx = context.build_datatypes([("List", ["X"])])?;
+let mut c_ctx = d_ctx.build_datatype("List")?;
+c_ctx.build_datatype_constructor_nullary("nil")?;
+let xvar = c_ctx.wf_sort("X")?;  // sort parameter is in scope
+let list_x = c_ctx.wf_sort_n("List", [xvar.clone()])?;
+c_ctx.build_datatype_constructor("cons", [("car", xvar), ("cdr", list_x)])?;
+c_ctx.typed_datatype()?;
+let cmd = d_ctx.typed_declare_datatypes()?;
 ```
 
 Datatype contexts validate non-emptiness, constructor uniqueness, and selector name uniqueness.
@@ -345,8 +345,8 @@ global context (the operation is transactional).
 
 ```rust
 let int = context.int_sort();
-let s_ctx = context.build_sort_alias("MyInt", []) ?;
-let cmd = s_ctx.typed_define_sort(int) ?;
+let s_ctx = context.build_sort_alias("MyInt", [])?;
+let cmd = s_ctx.typed_define_sort(int)?;
 // "MyInt" is now an alias for Int
 ```
 
@@ -369,16 +369,16 @@ can create another `QuantifierContext`, and so on. Each nested context sees all 
 ancestors:
 
 ```rust
-let mut q_ctx = context.build_quantifier_with_domain([("x", int)]) ?;
-let inc_x = q_ctx.typed_simp_app("+", [q_ctx.typed_symbol("x") ?, one]) ?;
-let mut l_ctx = q_ctx.build_let([("y", inc_x)]) ?;
+let mut q_ctx = context.build_quantifier_with_domain([("x", int)])?;
+let inc_x = q_ctx.typed_simp_app("+", [q_ctx.typed_symbol("x")?, one])?;
+let mut l_ctx = q_ctx.build_let([("y", inc_x)])?;
 // "y" and "x" are both in scope here
 let body = l_ctx.typed_simp_app("*", [
-l_ctx.typed_symbol("x") ?,
-l_ctx.typed_symbol("y") ?,
-]) ?;
+l_ctx.typed_symbol("x")?,
+l_ctx.typed_symbol("y")?,
+])?;
 let let_term = l_ctx.typed_let(body);
-let forall = q_ctx.typed_forall(let_term) ?;
+let forall = q_ctx.typed_forall(let_term)?;
 ```
 
 ### Analyzing hashconsed objects
@@ -442,9 +442,8 @@ Here is the `depth` example rewritten using `TermRecursor`:
 use yaspar_ir::ast::alg::{
     Attribute, Constant, Local, PatternArm, QualifiedIdentifier, VarBinding,
 };
-use yaspar_ir::ast::{Sort, Str, Term, TermRecursor, TypedTermRecursor};
+use yaspar_ir::ast::{Bottom, Sort, Str, Term, TermRecursor, TypedTermRecursor};
 
-enum Bottom {}
 struct TermDepth;
 
 impl TermRecursor<Str, Sort, Term> for TermDepth {
@@ -509,14 +508,49 @@ impl TypedTermRecursor for TermDepth {}
 To use it:
 
 ```rust
-let depth = match TermDepth.recurse_on_term( & some_term) {
-Ok(d) => d,
-Err(b) => match b {},  // Bottom is uninhabited
+let depth = match TermDepth.recurse_on_term(&some_term) {
+    Ok(d) => d,
+    Err(b) => match b {},  // Bottom is uninhabited
 };
 ```
 
 The convenience trait `TypedTermRecursor` is a marker for recursors specialized to the typed AST
 (`Str`, `Sort`, `Term`). An analogous `UntypedTermRecursor` exists for untyped ASTs.
+
+### Memoized term recursion with `Memoize`
+
+Because typed terms are hashconsed, structurally identical sub-terms share the same identity. A
+plain `TermRecursor` traversal will re-visit such shared sub-terms every time they appear. The
+`Memoize` wrapper caches the `Out` result for each term node, so repeated encounters return the
+cached value immediately — skipping the entire sub-tree.
+
+Wrap any recursor with `Memoize::new(recursor)` to get automatic caching backed by a `HashMap`:
+
+```rust
+use yaspar_ir::ast::{Memoize, TermRecursor};
+
+// assuming TermDepth from the previous section
+let mut memo = Memoize::new(TermDepth);
+let depth = memo.recurse_on_term(&some_term).unwrap();
+```
+
+The cache is stored in the public `cache` field, so it can be reused across multiple traversals.
+Pass a pre-populated cache via `Memoize::with_cache` to avoid recomputing results for terms that
+were already visited:
+
+```rust
+// first traversal populates the cache
+let mut memo = Memoize::new(TermDepth);
+let _ = memo.recurse_on_term(&term_a).unwrap();
+
+// second traversal reuses the cache — shared sub-terms are not re-visited
+let mut memo2 = Memoize::with_cache(TermDepth, &mut memo.cache);
+let _ = memo2.recurse_on_term(&term_b).unwrap();
+```
+
+This is particularly beneficial for analyses over assertions that share many common sub-terms,
+where a non-memoized traversal would perform redundant work proportional to the number of
+shared occurrences.
 
 ### More examples
 
@@ -575,9 +609,13 @@ Currently, the crate provides the following functionalities:
    introduces let-bindings to terms, so that they can be compactly printed with let-bindings inserted for sub-terms
    appearing multiple times.
 9. Global and local substitutions; see `ast::Substitute` and `ast::GlobalSubst`.
-10. NNF and CNF conversion: see `ast::CNFConversion` . This functionality requires the feature `cnf`.
-11. Implicant computation: see `ast::FindImplicant`. This functionality requires the feature `implicant-generation`.
-12. Translation to cvc5: see the `cvc5` module and the `ConvertToCvc5` trait. This functionality requires the feature
+10. Stack-free recursors: see `ast::TermRecursor`, `ast::TypedTermRecursor`, `ast::u::UntypedTermRecursor` and `ast::Memoize`.
+    This functionality provides a stack-free, visitor-based implementation of a depth first traversal of `Term`s. General
+    recursions are still available, but for deeply nested terms, general recursions could hit the stack limit of the
+    operating system. Stack-free recursors do not have such risk. Plug-in memoization is also available.  
+11. NNF and CNF conversion: see `ast::CNFConversion` . This functionality requires the feature `cnf`.
+12. Implicant computation: see `ast::FindImplicant`. This functionality requires the feature `implicant-generation`.
+13. Translation to cvc5: see the `cvc5` module and the `ConvertToCvc5` trait. This functionality requires the feature
     `cvc5`. It translates typed `Sort`s, `Term`s, and `Command`s to their cvc5-rs counterparts, with caching and
     support for quantifier `:pattern` annotations.
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -52,6 +52,7 @@ pub use crate::ast::implicant::ImplicantIterator;
 pub use crate::ast::implicant::{FindImplicant, Model};
 pub use crate::raw::alg;
 pub use crate::raw::alg::rec::TermRecursor;
+pub use crate::raw::alg::rec_memo::Memoize;
 pub use crate::raw::letelim::*;
 pub use crate::raw::tc::{TC, TCEnv, Typecheck, unif::SortSubst};
 pub use crate::untyped as u;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -51,7 +51,7 @@ pub use crate::ast::implicant::ImplicantIterator;
 #[cfg(feature = "implicant-generation")]
 pub use crate::ast::implicant::{FindImplicant, Model};
 pub use crate::raw::alg;
-pub use crate::raw::alg::rec::TermRecursor;
+pub use crate::raw::alg::rec::{Bottom, TermRecursor};
 pub use crate::raw::alg::rec_memo::Memoize;
 pub use crate::raw::letelim::*;
 pub use crate::raw::tc::{TC, TCEnv, Typecheck, unif::SortSubst};

--- a/src/containers.rs
+++ b/src/containers.rs
@@ -7,10 +7,16 @@ use crate::traits::Contains;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 
+/// A read-only key-value mapping that supports lookup by key.
+///
+/// This trait abstracts over different mapping backends ([`HashMap`], [`Vec`], linked lists,
+/// etc.) so that algorithms can be written generically over the storage strategy.
+/// Values must be [`Clone`] because lookups return owned copies.
 pub trait Mapping {
     type Key;
     type Value: Clone;
 
+    /// Look up a key in the mapping, returning a clone of the associated value if present.
     fn lookup(&self, key: &Self::Key) -> Option<Self::Value>;
 }
 
@@ -78,7 +84,9 @@ where
     }
 }
 
+/// A [`Mapping`] that additionally supports inserting new key-value pairs.
 pub trait InsertableMapping: Mapping {
+    /// Insert a key-value pair into the mapping, overwriting any existing entry for the key.
     fn insert(&mut self, key: Self::Key, value: Self::Value);
 }
 

--- a/src/containers.rs
+++ b/src/containers.rs
@@ -20,7 +20,19 @@ pub trait Mapping {
     fn lookup(&self, key: &Self::Key) -> Option<Self::Value>;
 }
 
-impl<C> Mapping for Vec<C>
+impl<T> Mapping for Vec<T>
+where
+    [T]: Mapping,
+{
+    type Key = <[T] as Mapping>::Key;
+    type Value = <[T] as Mapping>::Value;
+
+    fn lookup(&self, key: &Self::Key) -> Option<Self::Value> {
+        self.as_slice().lookup(key)
+    }
+}
+
+impl<C> Mapping for [C]
 where
     C: Mapping,
 {
@@ -45,7 +57,7 @@ where
     }
 }
 
-impl<S, T> Mapping for Vec<VarBinding<S, T>>
+impl<S, T> Mapping for [VarBinding<S, T>]
 where
     S: Eq,
     T: Clone,
@@ -120,7 +132,7 @@ pub(crate) enum MemLinkedList<'a, T: ?Sized> {
     },
 }
 
-impl<C> Mapping for MemLinkedList<'_, C>
+impl<C: ?Sized> Mapping for MemLinkedList<'_, C>
 where
     C: Mapping,
 {
@@ -141,7 +153,7 @@ where
 /// a bounded number of [LocEnv::Cons]s as local variables, which only stores references. As a
 /// result, it forms a linked list in stack and automatically goes away as recursion finishes.
 /// The tricky part is lifetime, which luckily Rust is very good at sanitizing.
-pub(crate) type LocEnv<'b, S, T> = MemLinkedList<'b, Vec<VarBinding<S, T>>>;
+pub(crate) type LocEnv<'b, S, T> = MemLinkedList<'b, [VarBinding<S, T>]>;
 
 /// Valid character in a symbol.
 pub(crate) fn valid_symbol_char(c: char) -> bool {

--- a/src/containers.rs
+++ b/src/containers.rs
@@ -4,14 +4,12 @@
 use crate::ast::SymbolQuote;
 use crate::raw::alg::VarBinding;
 use crate::traits::Contains;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 
 pub(crate) trait Mapping {
     type Key;
     type Value: Clone;
-
-    fn empty() -> Self;
 
     fn lookup(&self, key: &Self::Key) -> Option<Self::Value>;
 }
@@ -23,12 +21,21 @@ where
     type Key = C::Key;
     type Value = C::Value;
 
-    fn empty() -> Self {
-        vec![]
-    }
-
     fn lookup(&self, key: &Self::Key) -> Option<Self::Value> {
         self.iter().rev().find_map(|l| l.lookup(key))
+    }
+}
+
+impl<K, V> Mapping for HashMap<K, V>
+where
+    K: Eq + Hash,
+    V: Clone,
+{
+    type Key = K;
+    type Value = V;
+
+    fn lookup(&self, key: &Self::Key) -> Option<Self::Value> {
+        self.get(key).cloned()
     }
 }
 
@@ -40,10 +47,6 @@ where
     type Key = S;
     type Value = (usize, T);
 
-    fn empty() -> Self {
-        vec![]
-    }
-
     fn lookup(&self, key: &Self::Key) -> Option<Self::Value> {
         self.iter()
             .find(|v| v.0 == *key)
@@ -51,8 +54,57 @@ where
     }
 }
 
+impl<C> Mapping for &C
+where
+    C: Mapping,
+{
+    type Key = C::Key;
+    type Value = C::Value;
+
+    fn lookup(&self, key: &Self::Key) -> Option<Self::Value> {
+        (*self).lookup(key)
+    }
+}
+
+impl<C> Mapping for &mut C
+where
+    C: Mapping,
+{
+    type Key = C::Key;
+    type Value = C::Value;
+
+    fn lookup(&self, key: &Self::Key) -> Option<Self::Value> {
+        <C>::lookup(self, key)
+    }
+}
+
+pub(crate) trait InsertableMapping: Mapping {
+    fn insert(&mut self, key: Self::Key, value: Self::Value);
+}
+
+impl<C> InsertableMapping for &mut C
+where
+    C: InsertableMapping,
+{
+    fn insert(&mut self, key: Self::Key, value: Self::Value) {
+        <C>::insert(self, key, value);
+    }
+}
+
+impl<K, V> InsertableMapping for HashMap<K, V>
+where
+    K: Eq + Hash,
+    V: Clone,
+{
+    fn insert(&mut self, key: Self::Key, value: Self::Value) {
+        self.insert(key, value);
+    }
+}
+
 /// An in-memory linked list
+#[derive(Default)]
 pub(crate) enum MemLinkedList<'a, T: ?Sized> {
+    #[default]
     Nil,
     Cons {
         car: &'a T,
@@ -66,10 +118,6 @@ where
 {
     type Key = C::Key;
     type Value = C::Value;
-
-    fn empty() -> Self {
-        MemLinkedList::Nil
-    }
 
     fn lookup(&self, key: &Self::Key) -> Option<Self::Value> {
         match self {

--- a/src/containers.rs
+++ b/src/containers.rs
@@ -7,7 +7,7 @@ use crate::traits::Contains;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 
-pub(crate) trait Mapping {
+pub trait Mapping {
     type Key;
     type Value: Clone;
 
@@ -78,7 +78,7 @@ where
     }
 }
 
-pub(crate) trait InsertableMapping: Mapping {
+pub trait InsertableMapping: Mapping {
     fn insert(&mut self, key: Self::Key, value: Self::Value);
 }
 

--- a/src/raw/alg.rs
+++ b/src/raw/alg.rs
@@ -32,6 +32,7 @@ use yaspar::{binary_to_string, hex_to_string};
 
 mod kind;
 pub(crate) mod rec;
+pub(crate) mod rec_memo;
 
 /// Represent a literal constant in SMTLib
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/raw/alg/rec.rs
+++ b/src/raw/alg/rec.rs
@@ -305,7 +305,7 @@ pub trait TermRecursor<Str, So, T> {
 /// `LetBindings` (processing binding RHS values left-to-right) then `LetBody` (processing
 /// the body after the scope callback). Similarly, `Ite` uses three frames (`IteB` → `IteT`
 /// → `IteE`) and `Implies` uses two (`ImpliesPremises` → `ImpliesConclusion`).
-enum Frame<'a, Str, So, T, R: TermRecursor<Str, So, T>> {
+pub(crate) enum Frame<'a, Str, So, T, R: TermRecursor<Str, So, T>> {
     /// Function application: collecting argument results left-to-right.
     App {
         current: &'a T,
@@ -425,7 +425,7 @@ enum Frame<'a, Str, So, T, R: TermRecursor<Str, So, T>> {
 
 /// Discriminant for the [`Nary`](Frame::Nary) variant.
 #[derive(Clone, Copy)]
-enum NaryKind {
+pub(crate) enum NaryKind {
     Distinct,
     And,
     Or,
@@ -433,7 +433,7 @@ enum NaryKind {
 }
 
 /// The traversal stack: a `Vec` of frames.
-type RStack<'a, R, Str, So, T> = Vec<Frame<'a, Str, So, T, R>>;
+pub(crate) type RStack<'a, R, Str, So, T> = Vec<Frame<'a, Str, So, T, R>>;
 
 /// Advance `anns_rec` past consecutive non-`Pattern` attributes starting at
 /// `anns[anns_rec.len()]`. Stops when a `Pattern` is encountered or all attributes
@@ -478,7 +478,7 @@ type PushResult<'a, R, Str, So, T> = Result<
 /// unprocessed children, it returns `Either::Right(frame)`, where `frame` is the top of the stack,
 /// so the main loop can push the frame back and expand the next child. Returns `Either::Left(result)`
 /// when the stack is empty (traversal complete).
-fn push_result<'a, R, Str, So, T>(
+pub(crate) fn push_result<'a, R, Str, So, T>(
     recursor: &mut R,
     stack: &mut RStack<'a, R, Str, So, T>,
     mut result: R::Out,
@@ -778,7 +778,7 @@ where
     }
 }
 
-fn next_child<'a, R, Str, So, T>(
+pub(crate) fn next_child<'a, R, Str, So, T>(
     recursor: &mut R,
     frame: &mut Frame<'a, Str, So, T, R>,
 ) -> Result<&'a T, R::Err>
@@ -853,7 +853,7 @@ where
 /// intermediate nodes, then resolve the leaf via the appropriate callback.
 ///
 /// Loops over [`expand_and_resolve_once`] until a leaf is reached.
-fn expand_and_resolve<'a, R, Str: 'a, So: 'a, T>(
+pub(crate) fn expand_and_resolve<'a, R, Str: 'a, So: 'a, T>(
     recursor: &mut R,
     stack: &mut RStack<'a, R, Str, So, T>,
     mut current: &'a T,
@@ -877,7 +877,7 @@ where
 /// Process a single term node: either push a [`Frame`] and return the next
 /// child to descend into (`Either::Left`), or resolve a leaf directly via
 /// its callback (`Either::Right`).
-fn expand_and_resolve_once<'a, R, Str: 'a, So: 'a, T>(
+pub(crate) fn expand_and_resolve_once<'a, R, Str: 'a, So: 'a, T>(
     recursor: &mut R,
     stack: &mut RStack<'a, R, Str, So, T>,
     current: &'a T,
@@ -1056,7 +1056,7 @@ where
     }
 }
 
-fn term_recursion<R, Str, So, T>(recursor: &mut R, term: &T) -> Result<R::Out, R::Err>
+pub(crate) fn term_recursion<R, Str, So, T>(recursor: &mut R, term: &T) -> Result<R::Out, R::Err>
 where
     R: TermRecursor<Str, So, T>,
     T: Contains<T: Repr<T = Term<Str, So, T>>>,

--- a/src/raw/alg/rec.rs
+++ b/src/raw/alg/rec.rs
@@ -35,6 +35,10 @@ use crate::ast::Repr;
 use crate::raw::alg::*;
 use either::Either;
 
+/// Use this type as the `Err` type in [TermRecursor] if no error is expected.
+#[derive(Clone, Debug, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
+pub enum Bottom {}
+
 /// A visitor trait for performing stack-safe, bottom-up recursion over [`Term`] trees.
 ///
 /// Implementors define one callback per `Term` variant. Leaf callbacks (`on_constant`,
@@ -225,7 +229,7 @@ pub trait TermRecursor<Str, So, T> {
         symbol: &Str,
     ) -> Result<Self::Attr, Self::Err>;
     /// Called for a `:named` attribute.
-    fn on_attribute_named(&mut self, current: &T, name: &Str) -> Result<Self::Attr, Self::Err>;
+    fn on_attribute_named(&mut self, name: &Str) -> Result<Self::Attr, Self::Err>;
     /// Called for a `:pattern` attribute after all pattern sub-terms have been recursed.
     fn on_attribute_pattern(
         &mut self,
@@ -441,7 +445,6 @@ pub(crate) type RStack<'a, R, Str, So, T> = Vec<Frame<'a, Str, So, T, R>>;
 /// `on_attribute_*` callbacks.
 fn advance_attributes_until_pattern<R, Str, So, T>(
     recursor: &mut R,
-    current: &T,
     anns: &[Attribute<Str, T>],
     anns_rec: &mut Vec<R::Attr>,
 ) -> Result<(), R::Err>
@@ -460,7 +463,7 @@ where
             Attribute::Keyword(k) => anns_rec.push(recursor.on_attribute_keyword(k)?),
             Attribute::Constant(k, c) => anns_rec.push(recursor.on_attribute_constant(k, c)?),
             Attribute::Symbol(k, s) => anns_rec.push(recursor.on_attribute_symbol(k, s)?),
-            Attribute::Named(s) => anns_rec.push(recursor.on_attribute_named(current, s)?),
+            Attribute::Named(s) => anns_rec.push(recursor.on_attribute_named(s)?),
         }
     }
     Ok(())
@@ -627,7 +630,7 @@ where
                 anns,
             } => {
                 let mut anns_rec: Vec<R::Attr> = vec![];
-                advance_attributes_until_pattern(recursor, current, anns, &mut anns_rec)?;
+                advance_attributes_until_pattern(recursor, anns, &mut anns_rec)?;
                 if anns_rec.len() >= anns.len() {
                     result = recursor.on_annotated(current, body, anns, result, anns_rec)?;
                 } else {
@@ -657,7 +660,7 @@ where
                 if cur_pattern_rec.len() >= pat_ts.len() {
                     anns_rec.push(recursor.on_attribute_pattern(pat_ts, cur_pattern_rec)?);
                     cur_pattern_rec = vec![];
-                    advance_attributes_until_pattern(recursor, current, anns, &mut anns_rec)?;
+                    advance_attributes_until_pattern(recursor, anns, &mut anns_rec)?;
                     if anns_rec.len() >= anns.len() {
                         result = recursor.on_annotated(current, body, anns, t_rec, anns_rec)?;
                     } else {
@@ -877,6 +880,7 @@ where
 /// Process a single term node: either push a [`Frame`] and return the next
 /// child to descend into (`Either::Left`), or resolve a leaf directly via
 /// its callback (`Either::Right`).
+#[inline]
 pub(crate) fn expand_and_resolve_once<'a, R, Str: 'a, So: 'a, T>(
     recursor: &mut R,
     stack: &mut RStack<'a, R, Str, So, T>,

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -1,6 +1,28 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Memoized term recursion via [`Memoize`], a caching wrapper around [`TermRecursor`].
+//!
+//! When terms implement [Eq] and [Hash], structurally identical sub-terms share the same identity.
+//! A plain [`TermRecursor`] traversal will re-visit such shared sub-terms every time they
+//! appear. [`Memoize`] wraps any [`TermRecursor`] and caches the `Out` result for each
+//! term node, so repeated encounters return the cached value immediately.
+//!
+//! # How it works
+//!
+//! [`Memoize`] holds an `inner` recursor and a `cache` mapping terms to results.
+//!
+//! - **On each `on_*` callback that produces `Out`**: the wrapper delegates to the inner
+//!   recursor, inserts the result into the cache, and returns it.
+//! - **On auxiliary callbacks** (`setup_*`, `on_let_binding`, `on_match_arm`,
+//!   `on_attribute_*`): the wrapper delegates directly without caching.
+//! - **During expansion** ([`memo_expand_and_resolve`]): before descending into a term,
+//!   the cache is checked. On a hit the cached result is returned without expanding the
+//!   node at all, short-circuiting the entire sub-tree.
+//!
+//! The cache type is generic (`M: `[`InsertableMapping`]), so callers can supply a
+//! [`HashMap`], a pre-populated cache from a previous run, or any custom mapping.
+
 use super::rec::*;
 use crate::ast::alg::{
     Attribute, Constant, Local, PatternArm, QualifiedIdentifier, Term, VarBinding,
@@ -11,12 +33,24 @@ use either::Either;
 use std::collections::HashMap;
 use yaspar::ast::Keyword;
 
+/// A caching wrapper that memoizes the `Out` results of a [`TermRecursor`].
+///
+/// Wrap any recursor with [`Memoize::new`] to get automatic caching backed by a
+/// [`HashMap`]. Use [`Memoize::with_cache`] to supply a pre-populated or
+/// custom cache.
+///
+/// The `inner` recursor and `cache` are public fields, so callers can inspect or reuse
+/// the cache after traversal.
 pub struct Memoize<R, M> {
+    /// The wrapped recursor whose callbacks are delegated to.
     pub inner: R,
+    /// The term-to-result cache. Publicly accessible so callers can inspect, reuse,
+    /// or pre-populate it across traversals.
     pub cache: M,
 }
 
 impl<R, T, Out> Memoize<R, HashMap<T, Out>> {
+    /// Create a new memoized recursor backed by an empty `HashMap`.
     pub fn new<Str, So>(inner: R) -> Self
     where
         R: TermRecursor<Str, So, T, Out = Out>,
@@ -29,6 +63,11 @@ impl<R, T, Out> Memoize<R, HashMap<T, Out>> {
 }
 
 impl<R, M> Memoize<R, M> {
+    /// Create a memoized recursor with a caller-supplied cache.
+    ///
+    /// This is useful for reusing a cache across multiple traversals, e.g. passing in
+    /// `previous.cache` or `&mut previous.cache` to avoid recomputing results for terms that were already
+    /// visited.
     pub fn with_cache<Str, So, T>(inner: R, cache: M) -> Self
     where
         R: TermRecursor<Str, So, T>,
@@ -345,6 +384,10 @@ where
     }
 }
 
+/// Like [`expand_and_resolve`], but checks the cache before descending.
+///
+/// If `current` is already in the cache, the cached result is returned immediately
+/// without pushing any frames or invoking any callbacks.
 fn memo_expand_and_resolve<'a, R, M, Str: 'a, So: 'a, T>(
     recursor: &mut Memoize<R, M>,
     stack: &mut RStack<'a, Memoize<R, M>, Str, So, T>,
@@ -371,6 +414,8 @@ where
     }
 }
 
+/// Entry point for memoized traversal. Same structure as [`term_recursion`] but uses
+/// [`memo_expand_and_resolve`] to short-circuit cached sub-trees.
 fn memo_term_recursion<R, M, Str, So, T>(
     recursor: &mut Memoize<R, M>,
     term: &T,

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -8,11 +8,34 @@ use crate::ast::alg::{
 use crate::containers::InsertableMapping;
 use crate::traits::{Contains, Repr};
 use either::Either;
+use std::collections::HashMap;
 use yaspar::ast::Keyword;
 
 pub struct Memoize<R, M> {
-    inner: R,
-    cache: M,
+    pub inner: R,
+    pub cache: M,
+}
+
+impl<R, T, Out> Memoize<R, HashMap<T, Out>> {
+    pub fn new<Str, So>(inner: R) -> Self
+    where
+        R: TermRecursor<Str, So, T, Out = Out>,
+    {
+        Self {
+            inner,
+            cache: HashMap::new(),
+        }
+    }
+}
+
+impl<R, M> Memoize<R, M> {
+    pub fn with_cache<Str, So, T>(inner: R, cache: M) -> Self
+    where
+        R: TermRecursor<Str, So, T>,
+        M: InsertableMapping<Key = T, Value = R::Out>,
+    {
+        Self { inner, cache }
+    }
 }
 
 impl<Str, So, T, R, M> TermRecursor<Str, So, T> for Memoize<R, M>
@@ -198,44 +221,36 @@ where
         Ok(r)
     }
 
-    fn on_attribute_keyword(
-        &mut self,
-        current: &T,
-        keyword: &Keyword,
-    ) -> Result<Self::Attr, Self::Err> {
-        self.inner.on_attribute_keyword(current, keyword)
+    fn on_attribute_keyword(&mut self, keyword: &Keyword) -> Result<Self::Attr, Self::Err> {
+        self.inner.on_attribute_keyword(keyword)
     }
 
     fn on_attribute_constant(
         &mut self,
-        current: &T,
         keyword: &Keyword,
         constant: &Constant<Str>,
     ) -> Result<Self::Attr, Self::Err> {
-        self.inner.on_attribute_constant(current, keyword, constant)
+        self.inner.on_attribute_constant(keyword, constant)
     }
 
     fn on_attribute_symbol(
         &mut self,
-        current: &T,
         keyword: &Keyword,
         symbol: &Str,
     ) -> Result<Self::Attr, Self::Err> {
-        self.inner.on_attribute_symbol(current, keyword, symbol)
+        self.inner.on_attribute_symbol(keyword, symbol)
     }
 
-    fn on_attribute_named(&mut self, current: &T, name: &Str) -> Result<Self::Attr, Self::Err> {
-        self.inner.on_attribute_named(current, name)
+    fn on_attribute_named(&mut self, name: &Str) -> Result<Self::Attr, Self::Err> {
+        self.inner.on_attribute_named(name)
     }
 
     fn on_attribute_pattern(
         &mut self,
-        current: &T,
         patterns: &[T],
         patterns_rec: Vec<Self::Out>,
     ) -> Result<Self::Attr, Self::Err> {
-        self.inner
-            .on_attribute_pattern(current, patterns, patterns_rec)
+        self.inner.on_attribute_pattern(patterns, patterns_rec)
     }
 
     fn on_eq(

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -1,0 +1,343 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::rec::*;
+use crate::ast::alg::{
+    Attribute, Constant, Local, PatternArm, QualifiedIdentifier, Term, VarBinding,
+};
+use crate::containers::{InsertableMapping, Mapping};
+use crate::traits::{Contains, Repr};
+use either::Either;
+use yaspar::ast::Keyword;
+
+pub struct Memoize<R, M> {
+    inner: R,
+    cache: M,
+}
+
+impl<Str, So, T, R, M> TermRecursor<Str, So, T> for Memoize<R, M>
+where
+    T: Clone,
+    R: TermRecursor<Str, So, T, Out: Clone>,
+    M: InsertableMapping<Key = T, Value = R::Out>,
+{
+    type Out = R::Out;
+    type Attr = R::Attr;
+    type Binding = R::Binding;
+    type Pattern = R::Pattern;
+    type Arm = R::Arm;
+    type Err = R::Err;
+
+    fn recurse_on_term(&mut self, t: &T) -> Result<Self::Out, Self::Err>
+    where
+        Self: Sized,
+        T: Contains<T: Repr<T = Term<Str, So, T>>>,
+    {
+        memo_term_recursion(self, t)
+    }
+
+    fn on_constant(
+        &mut self,
+        current: &T,
+        constant: &Constant<Str>,
+        sort: &Option<So>,
+    ) -> Result<Self::Out, Self::Err> {
+        let r = self.inner.on_constant(current, constant, sort)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
+    }
+
+    fn on_global(
+        &mut self,
+        current: &T,
+        id: &QualifiedIdentifier<Str, So>,
+        sort: &Option<So>,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn on_local(&mut self, current: &T, id: &Local<Str, So>) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn on_app(
+        &mut self,
+        current: &T,
+        id: &QualifiedIdentifier<Str, So>,
+        ts: &[T],
+        s: &Option<So>,
+        recs: Vec<Self::Out>,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn on_let_binding(
+        &mut self,
+        current: &T,
+        vs: &[VarBinding<Str, T>],
+        body: &T,
+        binding_idx: usize,
+        binding_rec: Self::Out,
+    ) -> Result<Self::Binding, Self::Err> {
+        todo!()
+    }
+
+    fn setup_let_scope(
+        &mut self,
+        current: &T,
+        vs: &[VarBinding<Str, T>],
+        body: &T,
+        vs_rec: &[Self::Binding],
+    ) -> Result<(), Self::Err> {
+        todo!()
+    }
+
+    fn on_let(
+        &mut self,
+        current: &T,
+        vs: &[VarBinding<Str, T>],
+        body: &T,
+        vs_rec: Vec<Self::Binding>,
+        body_rec: Self::Out,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn setup_quantifier_scope(
+        &mut self,
+        current: &T,
+        vs: &[VarBinding<Str, So>],
+        t: &T,
+        is_forall: bool,
+    ) -> Result<(), Self::Err> {
+        todo!()
+    }
+
+    fn on_exists(
+        &mut self,
+        current: &T,
+        vs: &[VarBinding<Str, So>],
+        t: &T,
+        t_rec: Self::Out,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn on_forall(
+        &mut self,
+        current: &T,
+        vs: &[VarBinding<Str, So>],
+        t: &T,
+        t_rec: Self::Out,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn setup_match_case_scope(
+        &mut self,
+        current: &T,
+        scrutinee: &T,
+        cases: &[PatternArm<Str, T>],
+        scrutinee_rec: &Self::Out,
+        case_idx: usize,
+    ) -> Result<Self::Pattern, Self::Err> {
+        todo!()
+    }
+
+    fn on_match_arm(
+        &mut self,
+        current: &T,
+        scrutinee: &T,
+        cases: &[PatternArm<Str, T>],
+        case_idx: usize,
+        current_pattern: Self::Pattern,
+        arm: Self::Out,
+    ) -> Result<Self::Arm, Self::Err> {
+        todo!()
+    }
+
+    fn on_match(
+        &mut self,
+        current: &T,
+        scrutinee: &T,
+        cases: &[PatternArm<Str, T>],
+        scrutinee_rec: Self::Out,
+        cases_rec: Vec<Self::Arm>,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn on_annotated(
+        &mut self,
+        current: &T,
+        t: &T,
+        anns: &[Attribute<Str, T>],
+        t_rec: Self::Out,
+        anns_rec: Vec<Self::Attr>,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn on_attribute_keyword(
+        &mut self,
+        current: &T,
+        keyword: &Keyword,
+    ) -> Result<Self::Attr, Self::Err> {
+        todo!()
+    }
+
+    fn on_attribute_constant(
+        &mut self,
+        current: &T,
+        keyword: &Keyword,
+        constant: &Constant<Str>,
+    ) -> Result<Self::Attr, Self::Err> {
+        todo!()
+    }
+
+    fn on_attribute_symbol(
+        &mut self,
+        current: &T,
+        keyword: &Keyword,
+        symbol: &Str,
+    ) -> Result<Self::Attr, Self::Err> {
+        todo!()
+    }
+
+    fn on_attribute_named(&mut self, current: &T, name: &Str) -> Result<Self::Attr, Self::Err> {
+        todo!()
+    }
+
+    fn on_attribute_pattern(
+        &mut self,
+        current: &T,
+        patterns: &[T],
+        patterns_rec: Vec<Self::Out>,
+    ) -> Result<Self::Attr, Self::Err> {
+        todo!()
+    }
+
+    fn on_eq(
+        &mut self,
+        current: &T,
+        a: &T,
+        b: &T,
+        a_rec: Self::Out,
+        b_rec: Self::Out,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn on_distinct(
+        &mut self,
+        current: &T,
+        ts: &[T],
+        ts_rec: Vec<Self::Out>,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn on_and(
+        &mut self,
+        current: &T,
+        ts: &[T],
+        ts_rec: Vec<Self::Out>,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn on_or(
+        &mut self,
+        current: &T,
+        ts: &[T],
+        ts_rec: Vec<Self::Out>,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn on_xor(
+        &mut self,
+        current: &T,
+        ts: &[T],
+        ts_rec: Vec<Self::Out>,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn on_not(&mut self, current: &T, t: &T, t_rec: Self::Out) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn on_implies(
+        &mut self,
+        current: &T,
+        ts: &[T],
+        t: &T,
+        ts_rec: Vec<Self::Out>,
+        t_rec: Self::Out,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+
+    fn on_ite(
+        &mut self,
+        current: &T,
+        b: &T,
+        t: &T,
+        e: &T,
+        b_rec: Self::Out,
+        t_rec: Self::Out,
+        e_rec: Self::Out,
+    ) -> Result<Self::Out, Self::Err> {
+        todo!()
+    }
+}
+
+fn memo_expand_and_resolve<'a, R, M, Str: 'a, So: 'a, T>(
+    recursor: &mut Memoize<R, M>,
+    stack: &mut RStack<'a, Memoize<R, M>, Str, So, T>,
+    mut current: &'a T,
+) -> Result<R::Out, R::Err>
+where
+    R: TermRecursor<Str, So, T, Out: Clone>,
+    M: InsertableMapping<Key = T, Value = R::Out>,
+    T: Contains<T: Repr<T = Term<Str, So, T>>> + Clone,
+{
+    loop {
+        if let Some(r) = recursor.cache.lookup(current) {
+            return Ok(r);
+        }
+
+        match expand_and_resolve_once(recursor, stack, current)? {
+            Either::Left(l) => {
+                current = l;
+            }
+            Either::Right(r) => {
+                return Ok(r);
+            }
+        }
+    }
+}
+
+fn memo_term_recursion<R, M, Str, So, T>(
+    recursor: &mut Memoize<R, M>,
+    term: &T,
+) -> Result<R::Out, R::Err>
+where
+    R: TermRecursor<Str, So, T, Out: Clone>,
+    M: InsertableMapping<Key = T, Value = R::Out>,
+    T: Contains<T: Repr<T = Term<Str, So, T>>> + Clone,
+{
+    let mut stack = vec![];
+    let mut result = memo_expand_and_resolve(recursor, &mut stack, term)?;
+    loop {
+        match push_result(recursor, &mut stack, result)? {
+            Either::Left(final_result) => return Ok(final_result),
+            Either::Right(mut frame) => {
+                let child = next_child(recursor, &mut frame)?;
+                stack.push(frame);
+                result = memo_expand_and_resolve(recursor, &mut stack, child)?;
+            }
+        }
+    }
+}

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -41,6 +41,8 @@ use yaspar::ast::Keyword;
 ///
 /// The `inner` recursor and `cache` are public fields, so callers can inspect or reuse
 /// the cache after traversal.
+///
+/// Be aware of recursors with side effects! A cache hit will not perform the side effect of that term!
 pub struct Memoize<R, M> {
     /// The wrapped recursor whose callbacks are delegated to.
     pub inner: R,

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -5,7 +5,7 @@ use super::rec::*;
 use crate::ast::alg::{
     Attribute, Constant, Local, PatternArm, QualifiedIdentifier, Term, VarBinding,
 };
-use crate::containers::{InsertableMapping, Mapping};
+use crate::containers::InsertableMapping;
 use crate::traits::{Contains, Repr};
 use either::Either;
 use yaspar::ast::Keyword;
@@ -30,7 +30,6 @@ where
 
     fn recurse_on_term(&mut self, t: &T) -> Result<Self::Out, Self::Err>
     where
-        Self: Sized,
         T: Contains<T: Repr<T = Term<Str, So, T>>>,
     {
         memo_term_recursion(self, t)
@@ -53,11 +52,15 @@ where
         id: &QualifiedIdentifier<Str, So>,
         sort: &Option<So>,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_global(current, id, sort)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn on_local(&mut self, current: &T, id: &Local<Str, So>) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_local(current, id)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn on_app(
@@ -68,7 +71,9 @@ where
         s: &Option<So>,
         recs: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_app(current, id, ts, s, recs)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn on_let_binding(
@@ -79,7 +84,8 @@ where
         binding_idx: usize,
         binding_rec: Self::Out,
     ) -> Result<Self::Binding, Self::Err> {
-        todo!()
+        self.inner
+            .on_let_binding(current, vs, body, binding_idx, binding_rec)
     }
 
     fn setup_let_scope(
@@ -89,7 +95,7 @@ where
         body: &T,
         vs_rec: &[Self::Binding],
     ) -> Result<(), Self::Err> {
-        todo!()
+        self.inner.setup_let_scope(current, vs, body, vs_rec)
     }
 
     fn on_let(
@@ -100,7 +106,9 @@ where
         vs_rec: Vec<Self::Binding>,
         body_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_let(current, vs, body, vs_rec, body_rec)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn setup_quantifier_scope(
@@ -110,7 +118,7 @@ where
         t: &T,
         is_forall: bool,
     ) -> Result<(), Self::Err> {
-        todo!()
+        self.inner.setup_quantifier_scope(current, vs, t, is_forall)
     }
 
     fn on_exists(
@@ -120,7 +128,9 @@ where
         t: &T,
         t_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_exists(current, vs, t, t_rec)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn on_forall(
@@ -130,7 +140,9 @@ where
         t: &T,
         t_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_forall(current, vs, t, t_rec)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn setup_match_case_scope(
@@ -141,7 +153,8 @@ where
         scrutinee_rec: &Self::Out,
         case_idx: usize,
     ) -> Result<Self::Pattern, Self::Err> {
-        todo!()
+        self.inner
+            .setup_match_case_scope(current, scrutinee, cases, scrutinee_rec, case_idx)
     }
 
     fn on_match_arm(
@@ -153,7 +166,8 @@ where
         current_pattern: Self::Pattern,
         arm: Self::Out,
     ) -> Result<Self::Arm, Self::Err> {
-        todo!()
+        self.inner
+            .on_match_arm(current, scrutinee, cases, case_idx, current_pattern, arm)
     }
 
     fn on_match(
@@ -164,7 +178,11 @@ where
         scrutinee_rec: Self::Out,
         cases_rec: Vec<Self::Arm>,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self
+            .inner
+            .on_match(current, scrutinee, cases, scrutinee_rec, cases_rec)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn on_annotated(
@@ -175,7 +193,9 @@ where
         t_rec: Self::Out,
         anns_rec: Vec<Self::Attr>,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_annotated(current, t, anns, t_rec, anns_rec)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn on_attribute_keyword(
@@ -183,7 +203,7 @@ where
         current: &T,
         keyword: &Keyword,
     ) -> Result<Self::Attr, Self::Err> {
-        todo!()
+        self.inner.on_attribute_keyword(current, keyword)
     }
 
     fn on_attribute_constant(
@@ -192,7 +212,7 @@ where
         keyword: &Keyword,
         constant: &Constant<Str>,
     ) -> Result<Self::Attr, Self::Err> {
-        todo!()
+        self.inner.on_attribute_constant(current, keyword, constant)
     }
 
     fn on_attribute_symbol(
@@ -201,11 +221,11 @@ where
         keyword: &Keyword,
         symbol: &Str,
     ) -> Result<Self::Attr, Self::Err> {
-        todo!()
+        self.inner.on_attribute_symbol(current, keyword, symbol)
     }
 
     fn on_attribute_named(&mut self, current: &T, name: &Str) -> Result<Self::Attr, Self::Err> {
-        todo!()
+        self.inner.on_attribute_named(current, name)
     }
 
     fn on_attribute_pattern(
@@ -214,7 +234,8 @@ where
         patterns: &[T],
         patterns_rec: Vec<Self::Out>,
     ) -> Result<Self::Attr, Self::Err> {
-        todo!()
+        self.inner
+            .on_attribute_pattern(current, patterns, patterns_rec)
     }
 
     fn on_eq(
@@ -225,7 +246,9 @@ where
         a_rec: Self::Out,
         b_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_eq(current, a, b, a_rec, b_rec)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn on_distinct(
@@ -234,7 +257,9 @@ where
         ts: &[T],
         ts_rec: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_distinct(current, ts, ts_rec)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn on_and(
@@ -243,7 +268,9 @@ where
         ts: &[T],
         ts_rec: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_and(current, ts, ts_rec)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn on_or(
@@ -252,7 +279,9 @@ where
         ts: &[T],
         ts_rec: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_or(current, ts, ts_rec)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn on_xor(
@@ -261,11 +290,15 @@ where
         ts: &[T],
         ts_rec: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_xor(current, ts, ts_rec)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn on_not(&mut self, current: &T, t: &T, t_rec: Self::Out) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_not(current, t, t_rec)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn on_implies(
@@ -276,7 +309,9 @@ where
         ts_rec: Vec<Self::Out>,
         t_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_implies(current, ts, t, ts_rec, t_rec)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 
     fn on_ite(
@@ -289,7 +324,9 @@ where
         t_rec: Self::Out,
         e_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
-        todo!()
+        let r = self.inner.on_ite(current, b, t, e, b_rec, t_rec, e_rec)?;
+        self.cache.insert(current.clone(), r.clone());
+        Ok(r)
     }
 }
 

--- a/src/raw/tc.rs
+++ b/src/raw/tc.rs
@@ -993,7 +993,7 @@ where
         ))
     }
 
-    fn on_attribute_named(&mut self, _current: &T, name: &St) -> TC<Self::Attr> {
+    fn on_attribute_named(&mut self, name: &St) -> TC<Self::Attr> {
         Ok(Attribute::Named(name.allocate(self.arena)))
     }
 

--- a/src/raw/tc.rs
+++ b/src/raw/tc.rs
@@ -138,21 +138,21 @@ impl<'a, Local> TCEnvGen<'a, Local>
 where
     Local: Mapping,
 {
-    pub(crate) fn with_empty_local<L: Mapping>(&mut self) -> TCEnvGen<'_, L> {
+    pub(crate) fn with_empty_local<L: Default>(&mut self) -> TCEnvGen<'_, L> {
         TCEnvGen {
             arena: self.arena,
             meta: self.meta,
             frame: self.frame,
-            local: L::empty(),
+            local: L::default(),
         }
     }
 
-    pub(crate) fn convert_to_empty_local<L: Mapping>(self) -> TCEnvGen<'a, L> {
+    pub(crate) fn convert_to_empty_local<L: Default>(self) -> TCEnvGen<'a, L> {
         TCEnvGen {
             arena: self.arena,
             meta: self.meta,
             frame: self.frame,
-            local: L::empty(),
+            local: L::default(),
         }
     }
 }
@@ -537,10 +537,6 @@ where
 {
     type Key = Str;
     type Value = (usize, T);
-
-    fn empty() -> Self {
-        Default::default()
-    }
 
     fn lookup(&self, key: &Self::Key) -> Option<Self::Value> {
         self.loc_inc.lookup(key).or_else(|| self.loc.lookup(key))

--- a/tests/rec_memo.rs
+++ b/tests/rec_memo.rs
@@ -1,20 +1,17 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
 use yaspar::ast::Keyword;
+use yaspar_ir::ast::Typecheck;
 use yaspar_ir::ast::alg::{
     Attribute, Constant, Local, PatternArm, QualifiedIdentifier, VarBinding,
 };
-use yaspar_ir::ast::{Bottom, CheckedApi, Context, Typecheck};
-use yaspar_ir::ast::{
-    ObjectAllocatorExt, Sort, Str, StrAllocator, Term, TermAllocator, TermRecursor,
-    TypedTermRecursor,
-};
+use yaspar_ir::ast::{Bottom, Context, Memoize, Sort, Str, Term, TermRecursor, TypedTermRecursor};
 use yaspar_ir::untyped::UntypedAst;
 
-struct TermSize;
+struct TouchedTermSize {
+    /// count the touched subterms; side effect to poke wheather cache is hit
+    counter: u128,
+}
 
-impl TermRecursor<Str, Sort, Term> for TermSize {
+impl TermRecursor<Str, Sort, Term> for TouchedTermSize {
     type Out = usize;
     type Attr = usize;
     type Binding = usize;
@@ -28,6 +25,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         _constant: &Constant<Str>,
         _sort: &Option<Sort>,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1)
     }
 
@@ -37,6 +35,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         _id: &QualifiedIdentifier<Str, Sort>,
         _sort: &Option<Sort>,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1)
     }
 
@@ -45,6 +44,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         _current: &Term,
         _id: &Local<Str, Sort>,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1)
     }
 
@@ -56,6 +56,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         _s: &Option<Sort>,
         recs: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + recs.into_iter().sum::<usize>())
     }
 
@@ -88,6 +89,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         vs_rec: Vec<Self::Out>,
         body_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + vs_rec.into_iter().sum::<usize>() + body_rec)
     }
 
@@ -108,6 +110,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         _t: &Term,
         t_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + t_rec)
     }
 
@@ -118,6 +121,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         _t: &Term,
         t_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + t_rec)
     }
 
@@ -152,6 +156,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         scrutinee_rec: Self::Out,
         cases_rec: Vec<Self::Arm>,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + scrutinee_rec + cases_rec.into_iter().sum::<usize>())
     }
 
@@ -163,6 +168,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         t_rec: Self::Out,
         anns_rec: Vec<Self::Attr>,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + t_rec + anns_rec.into_iter().sum::<usize>())
     }
 
@@ -206,6 +212,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         a_rec: Self::Out,
         b_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + a_rec + b_rec)
     }
 
@@ -215,6 +222,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         _ts: &[Term],
         ts_rec: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + ts_rec.into_iter().sum::<usize>())
     }
 
@@ -224,6 +232,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         _ts: &[Term],
         ts_rec: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + ts_rec.into_iter().sum::<usize>())
     }
 
@@ -233,6 +242,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         _ts: &[Term],
         ts_rec: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + ts_rec.into_iter().sum::<usize>())
     }
 
@@ -242,6 +252,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         _ts: &[Term],
         ts_rec: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + ts_rec.into_iter().sum::<usize>())
     }
 
@@ -251,6 +262,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         _t: &Term,
         t_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + t_rec)
     }
 
@@ -262,6 +274,7 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         ts_rec: Vec<Self::Out>,
         t_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + ts_rec.into_iter().sum::<usize>() + t_rec)
     }
 
@@ -275,22 +288,27 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         t_rec: Self::Out,
         e_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
+        self.counter += 1;
         Ok(1 + b_rec + t_rec + e_rec)
     }
 }
 
-impl TypedTermRecursor for TermSize {}
+impl TypedTermRecursor for TouchedTermSize {}
 
-fn size(ctx: &mut Context, s: &str) -> usize {
-    let t = UntypedAst
-        .parse_term_str(s)
-        .unwrap()
-        .type_check(ctx)
-        .unwrap();
-    match TermSize.recurse_on_term(&t) {
-        Ok(n) => n,
-        Err(b) => match b {},
-    }
+fn test_term_size(t: &Term, expected: usize) {
+    let other_recursor = TouchedTermSize { counter: 0 };
+    // memoization happens just by wrapping on top of another recursor!
+    let mut recursor = Memoize::new(other_recursor);
+    // memoization is automagic during recursion
+    let sz = recursor.recurse_on_term(t).unwrap();
+    assert_eq!(sz, expected);
+    // cache can be inherited
+    // see how we can just pass in a reference to the previous cache, instead of a new cache
+    let mut recursor = Memoize::with_cache(TouchedTermSize { counter: 0 }, &mut recursor.cache);
+    let sz = recursor.recurse_on_term(t).unwrap();
+    assert_eq!(sz, expected);
+    // cache should hit, so no subterm is touched
+    assert_eq!(recursor.inner.counter, 0);
 }
 
 fn setup(script: &str) -> Context {
@@ -303,201 +321,156 @@ fn setup(script: &str) -> Context {
     ctx
 }
 
+fn parse_term(ctx: &mut Context, s: &str) -> Term {
+    UntypedAst
+        .parse_term_str(s)
+        .unwrap()
+        .type_check(ctx)
+        .unwrap()
+}
+
 #[test]
-fn test_constant() {
+fn test_memo_constant() {
     let mut ctx = setup("(set-logic ALL)");
-    assert_eq!(size(&mut ctx, "42"), 1);
-    assert_eq!(size(&mut ctx, "true"), 1);
+    test_term_size(&parse_term(&mut ctx, "42"), 1);
+    test_term_size(&parse_term(&mut ctx, "true"), 1);
 }
 
 #[test]
-fn test_global() {
+fn test_memo_global() {
     let mut ctx = setup("(set-logic ALL)(declare-const x Int)");
-    assert_eq!(size(&mut ctx, "x"), 1);
+    test_term_size(&parse_term(&mut ctx, "x"), 1);
 }
 
 #[test]
-fn test_app() {
+fn test_memo_app() {
     let mut ctx = setup("(set-logic ALL)(declare-const x Int)(declare-const y Int)");
-    // (+ x y) = 1 (app) + 1 (x) + 1 (y) = 3
-    assert_eq!(size(&mut ctx, "(+ x y)"), 3);
-    // (+ x y 1) = 1 + 1 + 1 + 1 = 4
-    assert_eq!(size(&mut ctx, "(+ x y 1)"), 4);
+    test_term_size(&parse_term(&mut ctx, "(+ x y)"), 3);
+    test_term_size(&parse_term(&mut ctx, "(+ x y 1)"), 4);
 }
 
 #[test]
-fn test_not() {
+fn test_memo_not() {
     let mut ctx = setup("(set-logic ALL)(declare-const p Bool)");
-    // (not p) = 1 (not) + 1 (p) = 2
-    assert_eq!(size(&mut ctx, "(not p)"), 2);
+    test_term_size(&parse_term(&mut ctx, "(not p)"), 2);
 }
 
 #[test]
-fn test_and_or() {
+fn test_memo_and_or() {
     let mut ctx = setup("(set-logic ALL)(declare-const p Bool)(declare-const q Bool)");
-    // (and p q) = 1 + 1 + 1 = 3
-    assert_eq!(size(&mut ctx, "(and p q)"), 3);
-    assert_eq!(size(&mut ctx, "(or p q)"), 3);
+    test_term_size(&parse_term(&mut ctx, "(and p q)"), 3);
+    test_term_size(&parse_term(&mut ctx, "(or p q)"), 3);
 }
 
 #[test]
-fn test_xor() {
-    let mut ctx = setup("(set-logic ALL)(declare-const p Bool)(declare-const q Bool)");
-    assert_eq!(size(&mut ctx, "(xor p q)"), 3);
-}
-
-#[test]
-fn test_implies() {
-    let mut ctx = setup("(set-logic ALL)(declare-const p Bool)(declare-const q Bool)");
-    // (=> p q) = 1 + 1 + 1 = 3
-    assert_eq!(size(&mut ctx, "(=> p q)"), 3);
-}
-
-#[test]
-fn test_eq() {
+fn test_memo_eq() {
     let mut ctx = setup("(set-logic ALL)(declare-const x Int)(declare-const y Int)");
-    // (= x y) = 1 + 1 + 1 = 3
-    assert_eq!(size(&mut ctx, "(= x y)"), 3);
+    test_term_size(&parse_term(&mut ctx, "(= x y)"), 3);
 }
 
 #[test]
-fn test_distinct() {
-    let mut ctx = setup("(set-logic ALL)(declare-const x Int)(declare-const y Int)");
-    assert_eq!(size(&mut ctx, "(distinct x y)"), 3);
-}
-
-#[test]
-fn test_ite() {
+fn test_memo_ite() {
     let mut ctx =
         setup("(set-logic ALL)(declare-const p Bool)(declare-const x Int)(declare-const y Int)");
-    // (ite p x y) = 1 + 1 + 1 + 1 = 4
-    assert_eq!(size(&mut ctx, "(ite p x y)"), 4);
+    test_term_size(&parse_term(&mut ctx, "(ite p x y)"), 4);
 }
 
 #[test]
-fn test_let() {
+fn test_memo_let() {
     let mut ctx = setup("(set-logic ALL)(declare-const x Int)");
-    // (let ((y (+ x 1))) (+ y y)) = 1 (let) + 3 (+ x 1) + 3 (+ y y) = 7
-    assert_eq!(size(&mut ctx, "(let ((y (+ x 1))) (+ y y))"), 7);
+    test_term_size(&parse_term(&mut ctx, "(let ((y (+ x 1))) (+ y y))"), 7);
 }
 
 #[test]
-fn test_forall() {
+fn test_memo_forall() {
     let mut ctx = setup("(set-logic ALL)");
-    // (forall ((x Int)) (= x 0)) = 1 (forall) + 3 (= x 0) = 4
-    assert_eq!(size(&mut ctx, "(forall ((x Int)) (= x 0))"), 4);
+    test_term_size(&parse_term(&mut ctx, "(forall ((x Int)) (= x 0))"), 4);
 }
 
 #[test]
-fn test_exists() {
+fn test_memo_exists() {
     let mut ctx = setup("(set-logic ALL)");
-    assert_eq!(size(&mut ctx, "(exists ((x Int)) (= x 0))"), 4);
+    test_term_size(&parse_term(&mut ctx, "(exists ((x Int)) (= x 0))"), 4);
 }
 
 #[test]
-fn test_nested() {
+fn test_memo_nested() {
     let mut ctx = setup("(set-logic ALL)(declare-const x Int)(declare-const y Int)");
-    // (+ (+ x y) 1) = 1 + (1 + 1 + 1) + 1 = 5
-    assert_eq!(size(&mut ctx, "(+ (+ x y) 1)"), 5);
-    // (not (= (+ x 1) y)) = 1 + (1 + (1 + 1 + 1) + 1) = 6
-    assert_eq!(size(&mut ctx, "(not (= (+ x 1) y))"), 6);
+    test_term_size(&parse_term(&mut ctx, "(+ (+ x y) 1)"), 5);
+    test_term_size(&parse_term(&mut ctx, "(not (= (+ x 1) y))"), 6);
 }
 
 #[test]
-fn test_match() {
+fn test_memo_match() {
     let mut ctx = setup(
         "(set-logic ALL)
              (declare-datatype List (par (X) ((nil) (cons (car X) (cdr (List X))))))
              (declare-const l (List Int))",
     );
-    // (match l ((nil 0) ((cons h t) h)))
-    // = 1 (match) + 1 (scrutinee l) + 1 (nil arm: 0) + 1 (cons arm: h) = 4
-    assert_eq!(size(&mut ctx, "(match l ((nil 0) ((cons h t) h)))"), 4,);
-}
-
-#[test]
-fn test_annotated() {
-    let mut ctx = setup("(set-logic ALL)(declare-const x Int)");
-    // (! x :named foo) = 1 (annotated) + 1 (x) + 1 (:named) = 3
-    assert_eq!(size(&mut ctx, "(! x :named foo)"), 3);
-}
-
-fn term_size(t: &Term) -> usize {
-    match TermSize.recurse_on_term(t) {
-        Ok(n) => n,
-        Err(b) => match b {},
-    }
-}
-
-#[test]
-fn test_empty_and() {
-    let mut ctx = setup("(set-logic ALL)");
-    let t = ctx.and(vec![]);
-    assert_eq!(term_size(&t), 1);
-}
-
-#[test]
-fn test_empty_or() {
-    let mut ctx = setup("(set-logic ALL)");
-    let t = ctx.or(vec![]);
-    assert_eq!(term_size(&t), 1);
-}
-
-#[test]
-fn test_empty_distinct() {
-    let mut ctx = setup("(set-logic ALL)");
-    let t = ctx.distinct(vec![]);
-    assert_eq!(term_size(&t), 1);
-}
-
-#[test]
-fn test_empty_xor() {
-    let mut ctx = setup("(set-logic ALL)");
-    let t = ctx.xor(vec![]);
-    assert_eq!(term_size(&t), 1);
-}
-
-#[test]
-fn test_empty_implies() {
-    let mut ctx = setup("(set-logic ALL)(declare-const p Bool)");
-    let p = UntypedAst
-        .parse_term_str("p")
-        .unwrap()
-        .type_check(&mut ctx)
-        .unwrap();
-    let t = ctx.implies(vec![], p);
-    assert_eq!(term_size(&t), 2);
-}
-
-#[test]
-fn test_empty_app() {
-    let mut ctx = setup("(set-logic ALL)");
-    let bool_sort = ctx.bool_sort();
-    let f = ctx.allocate_symbol("f");
-    let t = ctx.app(QualifiedIdentifier::simple(f), vec![], Some(bool_sort));
-    assert_eq!(term_size(&t), 1);
-}
-
-#[test]
-fn test_empty_let() {
-    let mut ctx = setup("(set-logic ALL)(declare-const x Int)");
-    let x = UntypedAst
-        .parse_term_str("x")
-        .unwrap()
-        .type_check(&mut ctx)
-        .unwrap();
-    let t = ctx.let_term(vec![], x);
-    assert_eq!(term_size(&t), 2);
-}
-
-#[test]
-fn test_empty_match() {
-    let mut ctx = setup(
-        "(set-logic ALL)
-         (declare-datatype List (par (X) ((nil) (cons (car X) (cdr (List X))))))
-         (declare-const l (List Int))",
+    test_term_size(
+        &parse_term(&mut ctx, "(match l ((nil 0) ((cons h t) h)))"),
+        4,
     );
-    let l = ctx.typed_symbol("l").unwrap();
-    let t = ctx.matching(l, vec![]);
-    assert_eq!(term_size(&t), 2);
+}
+
+#[test]
+fn test_memo_annotated() {
+    let mut ctx = setup("(set-logic ALL)(declare-const x Int)");
+    test_term_size(&parse_term(&mut ctx, "(! x :named foo)"), 3);
+}
+
+#[test]
+fn test_memo_deep_not() {
+    let mut ctx = setup("(set-logic ALL)(declare-const p Bool)");
+    // (not (not (not ... (not p) ...))) — 10 layers of not + 1 leaf = 11
+    let term = "(not (not (not (not (not (not (not (not (not (not p))))))))))";
+    test_term_size(&parse_term(&mut ctx, term), 11);
+}
+
+#[test]
+fn test_memo_deep_add() {
+    let mut ctx = setup("(set-logic ALL)(declare-const x Int)");
+    // (+ (+ (+ ... (+ x 1) ... 1) 1) 1) — 10 apps, each with a numeral + nested child = 10*2 + 1 = 21
+    let term = "(+ (+ (+ (+ (+ (+ (+ (+ (+ (+ x 1) 1) 1) 1) 1) 1) 1) 1) 1) 1)";
+    test_term_size(&parse_term(&mut ctx, term), 21);
+}
+
+#[test]
+fn test_memo_deep_ite() {
+    let mut ctx =
+        setup("(set-logic ALL)(declare-const p Bool)(declare-const x Int)(declare-const y Int)");
+    // 10 nested ites: each ite node + condition p + else y = 3 overhead, plus the nested then-branch
+    // size = 10 * 3 + 1 (innermost x) = 31
+    let term = "(ite p (ite p (ite p (ite p (ite p (ite p (ite p (ite p (ite p (ite p x y) y) y) y) y) y) y) y) y) y)";
+    test_term_size(&parse_term(&mut ctx, term), 31);
+}
+
+#[test]
+fn test_memo_deep_and() {
+    let mut ctx = setup("(set-logic ALL)(declare-const p Bool)(declare-const q Bool)");
+    // (and (and (and ... (and p q) ... q) q) q) — 10 ands, each with q + nested child = 10*2 + 1 = 21
+    let term = "(and (and (and (and (and (and (and (and (and (and p q) q) q) q) q) q) q) q) q) q)";
+    test_term_size(&parse_term(&mut ctx, term), 21);
+}
+
+#[test]
+fn test_memo_deep_let() {
+    let mut ctx = setup("(set-logic ALL)(declare-const x Int)");
+    // 10 nested lets, each binding a fresh variable to 0, innermost body is (+ x 0)
+    // each let = 1 (let) + 1 (binding rhs 0) = 2 overhead, plus nested body
+    // size = 10 * 2 + 3 (+ x 0) = 23
+    let term = "\
+        (let ((a 0)) \
+        (let ((b 0)) \
+        (let ((c 0)) \
+        (let ((d 0)) \
+        (let ((e 0)) \
+        (let ((f 0)) \
+        (let ((g 0)) \
+        (let ((h 0)) \
+        (let ((i 0)) \
+        (let ((j 0)) \
+        (+ x 0)\
+        ))))))))))";
+    test_term_size(&parse_term(&mut ctx, term), 23);
 }

--- a/tests/rec_memo.rs
+++ b/tests/rec_memo.rs
@@ -10,7 +10,7 @@ use yaspar_ir::ast::{Bottom, Context, Memoize, Sort, Str, Term, TermRecursor, Ty
 use yaspar_ir::untyped::UntypedAst;
 
 struct TouchedTermSize {
-    /// count the touched subterms; side effect to poke wheather cache is hit
+    /// count the touched subterms; side effect to poke whether cache is hit
     counter: u128,
 }
 

--- a/tests/rec_memo.rs
+++ b/tests/rec_memo.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use yaspar::ast::Keyword;
 use yaspar_ir::ast::Typecheck;
 use yaspar_ir::ast::alg::{

--- a/tests/rec_memo.rs
+++ b/tests/rec_memo.rs
@@ -295,13 +295,14 @@ impl TermRecursor<Str, Sort, Term> for TouchedTermSize {
 
 impl TypedTermRecursor for TouchedTermSize {}
 
-fn test_term_size(t: &Term, expected: usize) {
+fn test_term_size(t: &Term, expected: usize, expected_cache_size: usize) {
     let other_recursor = TouchedTermSize { counter: 0 };
     // memoization happens just by wrapping on top of another recursor!
     let mut recursor = Memoize::new(other_recursor);
     // memoization is automagic during recursion
     let sz = recursor.recurse_on_term(t).unwrap();
     assert_eq!(sz, expected);
+    assert_eq!(recursor.cache.len(), expected_cache_size);
     // cache can be inherited
     // see how we can just pass in a reference to the previous cache, instead of a new cache
     let mut recursor = Memoize::with_cache(TouchedTermSize { counter: 0 }, &mut recursor.cache);
@@ -332,72 +333,72 @@ fn parse_term(ctx: &mut Context, s: &str) -> Term {
 #[test]
 fn test_memo_constant() {
     let mut ctx = setup("(set-logic ALL)");
-    test_term_size(&parse_term(&mut ctx, "42"), 1);
-    test_term_size(&parse_term(&mut ctx, "true"), 1);
+    test_term_size(&parse_term(&mut ctx, "42"), 1, 1);
+    test_term_size(&parse_term(&mut ctx, "true"), 1, 1);
 }
 
 #[test]
 fn test_memo_global() {
     let mut ctx = setup("(set-logic ALL)(declare-const x Int)");
-    test_term_size(&parse_term(&mut ctx, "x"), 1);
+    test_term_size(&parse_term(&mut ctx, "x"), 1, 1);
 }
 
 #[test]
 fn test_memo_app() {
     let mut ctx = setup("(set-logic ALL)(declare-const x Int)(declare-const y Int)");
-    test_term_size(&parse_term(&mut ctx, "(+ x y)"), 3);
-    test_term_size(&parse_term(&mut ctx, "(+ x y 1)"), 4);
+    test_term_size(&parse_term(&mut ctx, "(+ x y)"), 3, 3);
+    test_term_size(&parse_term(&mut ctx, "(+ x y 1)"), 4, 4);
 }
 
 #[test]
 fn test_memo_not() {
     let mut ctx = setup("(set-logic ALL)(declare-const p Bool)");
-    test_term_size(&parse_term(&mut ctx, "(not p)"), 2);
+    test_term_size(&parse_term(&mut ctx, "(not p)"), 2, 2);
 }
 
 #[test]
 fn test_memo_and_or() {
     let mut ctx = setup("(set-logic ALL)(declare-const p Bool)(declare-const q Bool)");
-    test_term_size(&parse_term(&mut ctx, "(and p q)"), 3);
-    test_term_size(&parse_term(&mut ctx, "(or p q)"), 3);
+    test_term_size(&parse_term(&mut ctx, "(and p q)"), 3, 3);
+    test_term_size(&parse_term(&mut ctx, "(or p q)"), 3, 3);
 }
 
 #[test]
 fn test_memo_eq() {
     let mut ctx = setup("(set-logic ALL)(declare-const x Int)(declare-const y Int)");
-    test_term_size(&parse_term(&mut ctx, "(= x y)"), 3);
+    test_term_size(&parse_term(&mut ctx, "(= x y)"), 3, 3);
 }
 
 #[test]
 fn test_memo_ite() {
     let mut ctx =
         setup("(set-logic ALL)(declare-const p Bool)(declare-const x Int)(declare-const y Int)");
-    test_term_size(&parse_term(&mut ctx, "(ite p x y)"), 4);
+    test_term_size(&parse_term(&mut ctx, "(ite p x y)"), 4, 4);
 }
 
 #[test]
 fn test_memo_let() {
     let mut ctx = setup("(set-logic ALL)(declare-const x Int)");
-    test_term_size(&parse_term(&mut ctx, "(let ((y (+ x 1))) (+ y y))"), 7);
+    test_term_size(&parse_term(&mut ctx, "(let ((y (+ x 1))) (+ y y))"), 7, 6);
 }
 
 #[test]
 fn test_memo_forall() {
     let mut ctx = setup("(set-logic ALL)");
-    test_term_size(&parse_term(&mut ctx, "(forall ((x Int)) (= x 0))"), 4);
+    test_term_size(&parse_term(&mut ctx, "(forall ((x Int)) (= x 0))"), 4, 4);
 }
 
 #[test]
 fn test_memo_exists() {
     let mut ctx = setup("(set-logic ALL)");
-    test_term_size(&parse_term(&mut ctx, "(exists ((x Int)) (= x 0))"), 4);
+    test_term_size(&parse_term(&mut ctx, "(exists ((x Int)) (= x 0))"), 4, 4);
 }
 
 #[test]
 fn test_memo_nested() {
     let mut ctx = setup("(set-logic ALL)(declare-const x Int)(declare-const y Int)");
-    test_term_size(&parse_term(&mut ctx, "(+ (+ x y) 1)"), 5);
-    test_term_size(&parse_term(&mut ctx, "(not (= (+ x 1) y))"), 6);
+    test_term_size(&parse_term(&mut ctx, "(+ (+ x y) 1)"), 5, 5);
+    test_term_size(&parse_term(&mut ctx, "(not (= (+ x 1) y))"), 6, 6);
 }
 
 #[test]
@@ -410,13 +411,14 @@ fn test_memo_match() {
     test_term_size(
         &parse_term(&mut ctx, "(match l ((nil 0) ((cons h t) h)))"),
         4,
+        4,
     );
 }
 
 #[test]
 fn test_memo_annotated() {
     let mut ctx = setup("(set-logic ALL)(declare-const x Int)");
-    test_term_size(&parse_term(&mut ctx, "(! x :named foo)"), 3);
+    test_term_size(&parse_term(&mut ctx, "(! x :named foo)"), 3, 2);
 }
 
 #[test]
@@ -424,7 +426,7 @@ fn test_memo_deep_not() {
     let mut ctx = setup("(set-logic ALL)(declare-const p Bool)");
     // (not (not (not ... (not p) ...))) — 10 layers of not + 1 leaf = 11
     let term = "(not (not (not (not (not (not (not (not (not (not p))))))))))";
-    test_term_size(&parse_term(&mut ctx, term), 11);
+    test_term_size(&parse_term(&mut ctx, term), 11, 11);
 }
 
 #[test]
@@ -432,7 +434,7 @@ fn test_memo_deep_add() {
     let mut ctx = setup("(set-logic ALL)(declare-const x Int)");
     // (+ (+ (+ ... (+ x 1) ... 1) 1) 1) — 10 apps, each with a numeral + nested child = 10*2 + 1 = 21
     let term = "(+ (+ (+ (+ (+ (+ (+ (+ (+ (+ x 1) 1) 1) 1) 1) 1) 1) 1) 1) 1)";
-    test_term_size(&parse_term(&mut ctx, term), 21);
+    test_term_size(&parse_term(&mut ctx, term), 21, 12);
 }
 
 #[test]
@@ -442,7 +444,7 @@ fn test_memo_deep_ite() {
     // 10 nested ites: each ite node + condition p + else y = 3 overhead, plus the nested then-branch
     // size = 10 * 3 + 1 (innermost x) = 31
     let term = "(ite p (ite p (ite p (ite p (ite p (ite p (ite p (ite p (ite p (ite p x y) y) y) y) y) y) y) y) y) y)";
-    test_term_size(&parse_term(&mut ctx, term), 31);
+    test_term_size(&parse_term(&mut ctx, term), 31, 13);
 }
 
 #[test]
@@ -450,7 +452,7 @@ fn test_memo_deep_and() {
     let mut ctx = setup("(set-logic ALL)(declare-const p Bool)(declare-const q Bool)");
     // (and (and (and ... (and p q) ... q) q) q) — 10 ands, each with q + nested child = 10*2 + 1 = 21
     let term = "(and (and (and (and (and (and (and (and (and (and p q) q) q) q) q) q) q) q) q) q)";
-    test_term_size(&parse_term(&mut ctx, term), 21);
+    test_term_size(&parse_term(&mut ctx, term), 21, 12);
 }
 
 #[test]
@@ -472,5 +474,72 @@ fn test_memo_deep_let() {
         (let ((j 0)) \
         (+ x 0)\
         ))))))))))";
-    test_term_size(&parse_term(&mut ctx, term), 23);
+    test_term_size(&parse_term(&mut ctx, term), 23, 13);
+}
+
+/// Like `test_term_size`, but also asserts the number of touched nodes on the first
+/// traversal. When sub-terms are shared via hashconsing, the cache is hit during the
+/// first pass, so `expected_touched` can be less than `expected_size`.
+fn test_term_size_with_hits(
+    t: &Term,
+    expected_size: usize,
+    expected_cache_size: usize,
+    expected_touched: usize,
+) {
+    let mut recursor = Memoize::new(TouchedTermSize { counter: 0 });
+    let sz = recursor.recurse_on_term(t).unwrap();
+    assert_eq!(sz, expected_size);
+    assert_eq!(recursor.cache.len(), expected_cache_size);
+    assert_eq!(recursor.inner.counter as usize, expected_touched);
+}
+
+#[test]
+fn test_memo_shared_and() {
+    // (and (> x 0) (> x 0)) — the two arguments are identical hashconsed terms.
+    // term size = 1 (and) + 3 (> x 0) + 3 (> x 0) = 7
+    // but the second (> x 0) is a cache hit, so only 4 unique nodes are touched.
+    let mut ctx = setup("(set-logic ALL)(declare-const x Int)");
+    let t = parse_term(&mut ctx, "(and (> x 0) (> x 0))");
+    test_term_size_with_hits(&t, 7, 4, 4);
+}
+
+#[test]
+fn test_memo_shared_eq() {
+    // (= (+ x y) (+ x y)) — both sides are the same hashconsed term.
+    // term size = 1 (=) + 3 (+ x y) + 3 (+ x y) = 7
+    // cache hits on the second (+ x y), so 4 unique nodes touched.
+    let mut ctx = setup("(set-logic ALL)(declare-const x Int)(declare-const y Int)");
+    let t = parse_term(&mut ctx, "(= (+ x y) (+ x y))");
+    test_term_size_with_hits(&t, 7, 4, 4);
+}
+
+#[test]
+fn test_memo_shared_ite_branches() {
+    // (ite p (+ x 1) (+ x 1)) — both branches are the same hashconsed term.
+    // term size = 1 (ite) + 1 (p) + 3 (+ x 1) + 3 (+ x 1) = 8
+    // cache hits on the second (+ x 1), so 5 unique nodes touched.
+    let mut ctx = setup("(set-logic ALL)(declare-const p Bool)(declare-const x Int)");
+    let t = parse_term(&mut ctx, "(ite p (+ x 1) (+ x 1))");
+    test_term_size_with_hits(&t, 8, 5, 5);
+}
+
+#[test]
+fn test_memo_shared_nested() {
+    // (and (or p q) (or p q) (or p q)) — three identical sub-terms.
+    // term size = 1 (and) + 3 * 3 (or p q) = 10
+    // only the first (or p q) is traversed; the other two are cache hits.
+    // unique nodes touched = 1 (and) + 3 (or p q) = 4
+    let mut ctx = setup("(set-logic ALL)(declare-const p Bool)(declare-const q Bool)");
+    let t = parse_term(&mut ctx, "(and (or p q) (or p q) (or p q))");
+    test_term_size_with_hits(&t, 10, 4, 4);
+}
+
+#[test]
+fn test_memo_shared_deep() {
+    // (and (not (not (not p))) (not (not (not p)))) — two identical deep sub-terms.
+    // term size = 1 (and) + 4 (not (not (not p))) + 4 = 9
+    // second branch is a full cache hit, so 5 unique nodes touched.
+    let mut ctx = setup("(set-logic ALL)(declare-const p Bool)");
+    let t = parse_term(&mut ctx, "(and (not (not (not p))) (not (not (not p))))");
+    test_term_size_with_hits(&t, 9, 5, 5);
 }


### PR DESCRIPTION
*Issue #, if available:*
Closes #50 

*Description of changes:*

This change allows `Memoize::new(recursor)` to provide an out-of-box memoized version of the recursive algorithm implemented by recursor.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
