### PR TITLE
Port cvc5 module to use cvc5 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ default = ["none"]
 all = ["cnf", "implicant-generation"]
 cnf = ["dep:sat-interface", "cache"]
 implicant-generation = ["cnf"]
-cvc5 = ["dep:cvc5-rs"]
+cvc5 = ["dep:cvc5"]
 cache = []
 none = []
 
 [dependencies]
 yaspar = "2.7"
 sat-interface = { version = "0.1", optional = true }
-cvc5-rs = { version = "0.3.2", optional = true }
+cvc5 = { version = "0.4", optional = true, features = ["static"] }
 dashu = { version = "0.4.2", features = ["serde", "num-traits", "num-order"] }
 hashconsing = "1.6"
 paste = "1"

--- a/README.md
+++ b/README.md
@@ -616,19 +616,20 @@ Currently, the crate provides the following functionalities:
 11. NNF and CNF conversion: see `ast::CNFConversion` . This functionality requires the feature `cnf`.
 12. Implicant computation: see `ast::FindImplicant`. This functionality requires the feature `implicant-generation`.
 13. Translation to cvc5: see the `cvc5` module and the `ConvertToCvc5` trait. This functionality requires the feature
-    `cvc5`. It translates typed `Sort`s, `Term`s, and `Command`s to their cvc5-rs counterparts, with caching and
-    support for quantifier `:pattern` annotations.
+    `cvc5`. It translates typed `Sort`s, `Term`s, and `Command`s to their cvc5 counterparts, with memoized caching
+    and support for quantifier `:pattern` annotations.
 
 ### Translation to cvc5
 
-The `cvc5` module exposes the `ConvertToCvc5<Env, A>` trait, which provides a uniform `.to_cvc5(env, ctx)` method for
+The `cvc5` module exposes the `ConvertToCvc5<Env>` trait, which provides a uniform `.to_cvc5(env)` method for
 translating sorts, terms, and commands. Two environment types are used:
 
-- `Cvc5Env` — wraps a `TermManager` and caches. Used for translating `Sort`s and `Term`s.
+- `Cvc5Env` — a memoized wrapper around `Cvc5EnvInner` that caches term translations. Used for
+  translating `Sort`s and `Term`s.
 - `Cvc5EnvSolver` — wraps a `Cvc5Env` and a `Solver`. Used for translating `Command`s.
 
 ```rust
-use cvc5_rs::{Solver, TermManager};
+use cvc5::{Solver, TermManager};
 use yaspar_ir::ast::{Context, Typecheck};
 use yaspar_ir::cvc5::{ConvertToCvc5, Cvc5Env, Cvc5EnvSolver};
 use yaspar_ir::untyped::UntypedAst;
@@ -648,20 +649,20 @@ fn main() {
 
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
 
     // translate commands (which internally translate sorts and terms)
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     for cmd in &cmds {
-        cmd.to_cvc5(&mut es, &mut ctx).unwrap();
+        cmd.to_cvc5(&mut es).unwrap();
     }
 
     // sorts and terms can also be translated individually
     let int = ctx.int_sort();
-    let cvc5_int = int.to_cvc5(&mut env, &mut ctx).unwrap();
+    let cvc5_int = int.to_cvc5(&mut env).unwrap();
 
     let term = UntypedAst.parse_term_str("(+ x 1)").unwrap().type_check(&mut ctx).unwrap();
-    let cvc5_term = term.to_cvc5(&mut env, &mut ctx).unwrap();
+    let cvc5_term = term.to_cvc5(&mut env).unwrap();
 }
 ```
 

--- a/src/ast/boilerplates.rs
+++ b/src/ast/boilerplates.rs
@@ -199,6 +199,7 @@ where
         _current: &Term,
         _scrutinee: &Term,
         cases: &[PatternArm],
+        _scrutinee_rec: &Self::Out,
         case_idx: usize,
         _current_pattern: Self::Pattern,
         arm: Self::Out,

--- a/src/ast/ctx/checked.rs
+++ b/src/ast/ctx/checked.rs
@@ -548,10 +548,10 @@ impl Context {
         match &opt {
             Attribute::Keyword(_) => {}
             Attribute::Constant(kw, c) => match kw {
-                Keyword::DiagnosticOutputChannel | Keyword::RegularOutputChannel => {
-                    if !matches!(c, alg::Constant::String(_)) {
-                        return Err(format!("TC: keyword {kw} expected a string!"));
-                    }
+                Keyword::DiagnosticOutputChannel | Keyword::RegularOutputChannel
+                    if !matches!(c, alg::Constant::String(_)) =>
+                {
+                    return Err(format!("TC: keyword {kw} expected a string!"));
                 }
                 Keyword::GlobalDeclarations
                 | Keyword::InteractiveMode
@@ -561,15 +561,15 @@ impl Context {
                 | Keyword::ProduceModels
                 | Keyword::ProduceProofs
                 | Keyword::ProduceUnsatAssumptions
-                | Keyword::ProduceUnsatCores => {
-                    if !matches!(c, alg::Constant::Bool(_)) {
-                        return Err(format!("TC: keyword {kw} expected a bool!"));
-                    }
+                | Keyword::ProduceUnsatCores
+                    if !matches!(c, alg::Constant::Bool(_)) =>
+                {
+                    return Err(format!("TC: keyword {kw} expected a bool!"));
                 }
-                Keyword::RandomSeed | Keyword::ReproducibleResourceLimit | Keyword::Verbosity => {
-                    if !matches!(c, alg::Constant::Numeral(_)) {
-                        return Err(format!("TC: keyword {kw} expected a number!"));
-                    }
+                Keyword::RandomSeed | Keyword::ReproducibleResourceLimit | Keyword::Verbosity
+                    if !matches!(c, alg::Constant::Numeral(_)) =>
+                {
+                    return Err(format!("TC: keyword {kw} expected a number!"));
                 }
                 _ => {}
             },

--- a/src/ast/fv.rs
+++ b/src/ast/fv.rs
@@ -175,6 +175,7 @@ impl TermRecursor<Str, Sort, Term> for FreeLocalVariableFinder {
         _current: &Term,
         _scrutinee: &Term,
         cases: &[PatternArm],
+        _scrutinee_rec: &Self::Out,
         case_idx: usize,
         _current_pattern: Self::Pattern,
         _arm: Self::Out,

--- a/src/ast/letelim.rs
+++ b/src/ast/letelim.rs
@@ -234,6 +234,7 @@ impl<E: HasArena> TermRecursor<Str, Sort, Term> for LetEliminatorInner<'_, E> {
         _: &Term,
         _: &Term,
         cases: &[PatternArm],
+        scrutinee_rec: &Term,
         idx: usize,
         _: (),
         body: Term,

--- a/src/ast/letelim.rs
+++ b/src/ast/letelim.rs
@@ -234,7 +234,7 @@ impl<E: HasArena> TermRecursor<Str, Sort, Term> for LetEliminatorInner<'_, E> {
         _: &Term,
         _: &Term,
         cases: &[PatternArm],
-        scrutinee_rec: &Term,
+        _scrutinee_rec: &Term,
         idx: usize,
         _: (),
         body: Term,

--- a/src/ast/mono.rs
+++ b/src/ast/mono.rs
@@ -398,6 +398,7 @@ impl<E: HasArena> TermRecursor<Str, Sort, Term> for MonomorphizerInner<'_, E> {
         _: &Term,
         _: &Term,
         cases: &[PatternArm],
+        scrutinee_rec: &Term,
         idx: usize,
         _: (),
         body: Term,

--- a/src/ast/mono.rs
+++ b/src/ast/mono.rs
@@ -398,7 +398,7 @@ impl<E: HasArena> TermRecursor<Str, Sort, Term> for MonomorphizerInner<'_, E> {
         _: &Term,
         _: &Term,
         cases: &[PatternArm],
-        scrutinee_rec: &Term,
+        _scrutinee_rec: &Term,
         idx: usize,
         _: (),
         body: Term,

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -49,12 +49,14 @@
 //! Quantifier `:pattern` annotations are translated to cvc5 `INST_PATTERN` / `INST_PATTERN_LIST`
 //! terms, which guide quantifier instantiation. Other annotations are ignored.
 
+use crate::ast::alg::VarBinding;
 use crate::ast::*;
 use crate::raw::alg;
 use crate::raw::alg::CheckIdentifier;
 use crate::traits::{Contains, Repr};
 pub use cvc5::{Kind, ProofComponent, Solver, TermManager};
 use std::collections::HashMap;
+use yaspar::ast::Keyword;
 use yaspar::{binary_to_string, hex_to_string};
 
 pub type CSort<'tm> = cvc5::Sort<'tm>;
@@ -94,10 +96,33 @@ pub struct Cvc5Env<'tm> {
     tm: &'tm TermManager,
     sort: HashMap<Str, CSort<'tm>>,
     globals: HashMap<Str, CTerm<'tm>>,
-    locals: HashMap<usize, CTerm<'tm>>,
+    locals: HashMap<usize, WithPattern<'tm>>,
     sort_cache: HashMap<Sort, CSort<'tm>>,
     term_cache: HashMap<Term, CTerm<'tm>>,
     dt_sorts: HashMap<Str, CSort<'tm>>,
+    scope_stack: Vec<Vec<CTerm<'tm>>>,
+    sort_subst_map: HashMap<Term, Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)>>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+struct WithPattern<'tm> {
+    term: CTerm<'tm>,
+    patterns: Vec<CTerm<'tm>>,
+}
+
+impl<'tm> From<WithPattern<'tm>> for CTerm<'tm> {
+    fn from(value: WithPattern<'tm>) -> Self {
+        value.term
+    }
+}
+
+impl<'tm> From<CTerm<'tm>> for WithPattern<'tm> {
+    fn from(value: CTerm<'tm>) -> Self {
+        WithPattern {
+            term: value,
+            patterns: vec![],
+        }
+    }
 }
 
 impl<'tm> Cvc5Env<'tm> {
@@ -110,6 +135,7 @@ impl<'tm> Cvc5Env<'tm> {
             sort_cache: HashMap::new(),
             term_cache: HashMap::new(),
             dt_sorts: HashMap::new(),
+            scope_stack: vec![],
         }
     }
 }
@@ -127,7 +153,7 @@ impl<'a, 'tm> Cvc5EnvSolver<'a, 'tm> {
 }
 
 // ── Sort translation ─────────────────────────────────────────
-impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5Env<'tm>, A> for Sort {
+impl<'tm, A> ConvertToCvc5<Cvc5Env<'tm>, A> for Sort {
     type Output = CSort<'tm>;
 
     fn to_cvc5(&self, env: &mut Cvc5Env<'tm>, arena: &mut A) -> Res<CSort<'tm>> {
@@ -140,7 +166,7 @@ impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5Env<'tm>, A> for Sort {
     }
 }
 
-fn translate_sort_inner<'tm, A: HasArenaAlt>(
+fn translate_sort_inner<'tm, A>(
     sort: &Sort,
     env: &mut Cvc5Env<'tm>,
     arena: &mut A,
@@ -296,7 +322,7 @@ fn ident_kind_to_cvc5(k: &alg::IdentifierKind<Str>) -> Option<Kind> {
 }
 
 // ── Term translation ─────────────────────────────────────────
-impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5Env<'tm>, A> for Term {
+impl<'tm, A> ConvertToCvc5<Cvc5Env<'tm>, A> for Term {
     type Output = CTerm<'tm>;
 
     fn to_cvc5(&self, env: &mut Cvc5Env<'tm>, arena: &mut A) -> Res<CTerm<'tm>> {
@@ -309,85 +335,345 @@ impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5Env<'tm>, A> for Term {
     }
 }
 
-fn translate_term_inner<'tm, A: HasArenaAlt>(
-    term: &Term,
-    env: &mut Cvc5Env<'tm>,
-    arena: &mut A,
-) -> Res<CTerm<'tm>> {
-    use alg::Term as AT;
-    match term.repr() {
-        AT::Constant(c, _) => env.translate_constant(c),
-        AT::Global(qid, sort) => {
-            // it's fine due to typed invariant
-            let sort = sort.as_ref().unwrap();
-            env.translate_global(qid, sort, arena)
-        }
-        AT::Local(loc) => env
-            .locals
-            .get(&loc.id)
+fn to_term_vec(terms: Vec<WithPattern>) -> Vec<CTerm> {
+    terms.into_iter().map(|t| t.into()).collect()
+}
+
+impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm> {
+    type Out = WithPattern<'tm>;
+    type Attr = Vec<CTerm<'tm>>;
+    type Binding = (usize, WithPattern<'tm>);
+    type Pattern = ();
+    type Arm = CTerm<'tm>;
+    type Err = String;
+
+    fn on_constant(
+        &mut self,
+        current: &Term,
+        constant: &Constant,
+        sort: &Option<Sort>,
+    ) -> Res<WithPattern<'tm>> {
+        self.translate_constant(constant, sort.as_ref().unwrap())
+    }
+
+    fn on_global(
+        &mut self,
+        current: &Term,
+        id: &QualifiedIdentifier,
+        sort: &Option<Sort>,
+    ) -> Res<WithPattern<'tm>> {
+        // it's fine due to typed invariant
+        let sort = sort.as_ref().unwrap();
+        self.translate_global(id, sort)
+    }
+
+    fn on_local(&mut self, current: &Term, id: &Local) -> Res<WithPattern<'tm>> {
+        self.locals
+            .get(&id.id)
             .cloned()
-            .ok_or_else(|| format!("unbound local: {}", loc.symbol)),
-        AT::Not(t) => {
-            let nt = t.to_cvc5(env, arena)?;
-            Ok(env.tm.mk_term(Kind::Not, &[nt]))
+            .ok_or_else(|| format!("unbound local: {}", id.symbol))
+    }
+
+    fn on_app(
+        &mut self,
+        current: &Term,
+        id: &QualifiedIdentifier,
+        ts: &[Term],
+        s: &Option<Sort>,
+        recs: Vec<WithPattern<'tm>>,
+    ) -> Res<WithPattern<'tm>> {
+        self.translate_app(
+            id,
+            recs.into_iter().map(|t| t.into()).collect(),
+            s.as_ref().unwrap(),
+        )
+    }
+
+    fn on_annotated(
+        &mut self,
+        current: &Term,
+        t: &Term,
+        anns: &[Attribute],
+        t_rec: WithPattern<'tm>,
+        anns_rec: Vec<Vec<CTerm<'tm>>>,
+    ) -> Res<WithPattern<'tm>> {
+        // do not handle other annotations
+        let mut pats = t_rec.patterns;
+        anns_rec.into_iter().for_each(|ps| pats.extend(ps));
+        Ok(WithPattern {
+            term: t_rec.term,
+            patterns: pats,
+        })
+    }
+    fn on_eq(
+        &mut self,
+        current: &Term,
+        a: &Term,
+        b: &Term,
+        a_rec: WithPattern<'tm>,
+        b_rec: WithPattern<'tm>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self
+            .tm
+            .mk_term(Kind::Equal, &[a_rec.into(), b_rec.into()])
+            .into())
+    }
+    fn on_distinct(
+        &mut self,
+        current: &Term,
+        ts: &[Term],
+        ts_rec: Vec<WithPattern<'tm>>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self.tm.mk_term(Kind::Distinct, &to_term_vec(ts_rec)).into())
+    }
+    fn on_and(
+        &mut self,
+        current: &Term,
+        ts: &[Term],
+        ts_rec: Vec<WithPattern<'tm>>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self.tm.mk_term(Kind::And, &to_term_vec(ts_rec)).into())
+    }
+    fn on_or(
+        &mut self,
+        current: &Term,
+        ts: &[Term],
+        ts_rec: Vec<WithPattern<'tm>>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self.tm.mk_term(Kind::Or, &&to_term_vec(ts_rec)).into())
+    }
+    fn on_xor(
+        &mut self,
+        current: &Term,
+        ts: &[Term],
+        ts_rec: Vec<WithPattern<'tm>>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self.tm.mk_term(Kind::Xor, &to_term_vec(ts_rec)).into())
+    }
+    fn on_not(
+        &mut self,
+        current: &Term,
+        t: &Term,
+        t_rec: WithPattern<'tm>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self.tm.mk_term(Kind::Not, &[t_rec.into()]).into())
+    }
+    fn on_implies(
+        &mut self,
+        current: &Term,
+        ts: &[Term],
+        t: &Term,
+        ts_rec: Vec<WithPattern<'tm>>,
+        t_rec: WithPattern<'tm>,
+    ) -> Res<WithPattern<'tm>> {
+        let mut all = ts_rec;
+        all.push(t_rec);
+        Ok(self.tm.mk_term(Kind::Implies, &to_term_vec(all)).into())
+    }
+    fn on_ite(
+        &mut self,
+        current: &Term,
+        b: &Term,
+        t: &Term,
+        e: &Term,
+        b_rec: WithPattern<'tm>,
+        t_rec: WithPattern<'tm>,
+        e_rec: WithPattern<'tm>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self
+            .tm
+            .mk_term(Kind::Ite, &[b_rec.into(), t_rec.into(), e_rec.into()])
+            .into())
+    }
+
+    fn on_attribute_keyword(&mut self, keyword: &Keyword) -> Res<Vec<CTerm<'tm>>> {
+        Ok(vec![])
+    }
+    fn on_attribute_constant(
+        &mut self,
+        keyword: &Keyword,
+        constant: &Constant,
+    ) -> Res<Vec<CTerm<'tm>>> {
+        Ok(vec![])
+    }
+    fn on_attribute_symbol(&mut self, keyword: &Keyword, symbol: &Str) -> Res<Vec<CTerm<'tm>>> {
+        Ok(vec![])
+    }
+    fn on_attribute_named(&mut self, name: &Str) -> Res<Vec<CTerm<'tm>>> {
+        Ok(vec![])
+    }
+    fn on_attribute_pattern(
+        &mut self,
+        patterns: &[Term],
+        patterns_rec: Vec<WithPattern<'tm>>,
+    ) -> Res<Vec<CTerm<'tm>>> {
+        Ok(to_term_vec(patterns_rec))
+    }
+
+    fn setup_quantifier_scope(
+        &mut self,
+        current: &Term,
+        vs: &[VarBinding<Str, Sort>],
+        t: &Term,
+        is_forall: bool,
+    ) -> Res<()> {
+        self.bind_vars(vs)
+    }
+
+    fn on_exists(
+        &mut self,
+        current: &Term,
+        vs: &[VarBinding<Str, Sort>],
+        t: &Term,
+        t_rec: WithPattern<'tm>,
+    ) -> Res<WithPattern<'tm>> {
+        let bound = self.unbind_vars(vs)?;
+        self.translate_quantifier_body(Kind::Exists, bound, t_rec)
+    }
+
+    fn on_forall(
+        &mut self,
+        current: &Term,
+        vs: &[VarBinding<Str, Sort>],
+        t: &Term,
+        t_rec: Self::Out,
+    ) -> Res<WithPattern<'tm>> {
+        let bound = self.unbind_vars(vs)?;
+        self.translate_quantifier_body(Kind::Forall, bound, t_rec)
+    }
+
+    fn on_let_binding(
+        &mut self,
+        current: &Term,
+        vs: &[VarBinding<Str, Term>],
+        body: &Term,
+        binding_idx: usize,
+        binding_rec: WithPattern<'tm>,
+    ) -> Res<Self::Binding> {
+        let idx = vs[binding_idx].1;
+        Ok((idx, binding_rec))
+    }
+
+    fn setup_let_scope(
+        &mut self,
+        current: &Term,
+        vs: &[VarBinding<Str, Term>],
+        body: &Term,
+        vs_rec: &[Self::Binding],
+    ) -> Res<()> {
+        for (idx, t) in vs_rec {
+            self.locals.insert(*idx, t.clone());
         }
-        AT::Eq(a, b) => {
-            let (ca, cb) = (a.to_cvc5(env, arena)?, b.to_cvc5(env, arena)?);
-            Ok(env.tm.mk_term(Kind::Equal, &[ca, cb]))
+        Ok(())
+    }
+
+    fn on_let(
+        &mut self,
+        current: &Term,
+        vs: &[VarBinding<Str, Term>],
+        body: &Term,
+        vs_rec: Vec<Self::Binding>,
+        body_rec: WithPattern<'tm>,
+    ) -> Res<WithPattern<'tm>> {
+        for (idx, _) in vs_rec {
+            self.locals.remove(&idx);
         }
-        AT::Distinct(ts) => {
-            let cts = ts.to_cvc5(env, arena)?;
-            Ok(env.tm.mk_term(Kind::Distinct, &cts))
+        Ok(body_rec)
+    }
+
+    fn setup_match_case_scope(
+        &mut self,
+        current: &Term,
+        scrutinee: &Term,
+        cases: &[PatternArm],
+        scrutinee_rec: &Self::Out,
+        case_idx: usize,
+    ) -> Res<Self::Pattern> {
+        let scr_sort = scrutinee_rec.term.sort();
+        let dt = scr_sort.datatype();
+        if !self.sort_subst_map.contains_key(scrutinee) {
+            // For parametric datatypes, selector codomain sorts are uninstantiated (e.g. X).
+            // We need to substitute the sort parameters with the actual instantiated parameters.
+            let subst: Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)> = if dt.is_parametric() {
+                let params = dt.parameters();
+                let inst_params = scr_sort.instantiated_parameters();
+                Some((params, inst_params))
+            } else {
+                None
+            };
+            self.sort_subst_map.insert(scrutinee.clone(), subst);
         }
-        AT::And(ts) => {
-            let cts = ts.to_cvc5(env, arena)?;
-            Ok(env.tm.mk_term(Kind::And, &cts))
-        }
-        AT::Or(ts) => {
-            let cts = ts.to_cvc5(env, arena)?;
-            Ok(env.tm.mk_term(Kind::Or, &cts))
-        }
-        AT::Xor(ts) => {
-            let cts = ts.to_cvc5(env, arena)?;
-            let mut r = cts[0].clone();
-            for c in &cts[1..] {
-                r = env.tm.mk_term(Kind::Xor, &[r, CTerm::clone(c)]);
+        let subst = self.sort_subst_map.get(scrutinee).unwrap();
+        match &cases[case_idx].pattern {
+            Pattern::Wildcard(v) => {
+                let pv = match v {
+                    None => self.tm.mk_anonymous_var(scr_sort.clone()),
+                    Some((name, id)) => {
+                        let v = self.tm.mk_var(scr_sort.clone(), &name);
+                        self.locals.insert(*id, v.clone().into());
+                        v
+                    }
+                };
+                self.scope_stack.push(vec![pv]);
             }
-            Ok(r)
+            Pattern::Ctor(_) => {
+                self.bind_vars(&[])?;
+            }
+            Pattern::Applied { ctor, arguments } => {
+                let ctor = dt.constructor_by_name(ctor);
+                let mut pattern_args = Vec::new();
+                for (i, arg) in arguments.iter().enumerate() {
+                    let mut sel_sort = ctor.selector(i).codomain_sort();
+                    if let Some((params, inst)) = subst {
+                        sel_sort = sel_sort.substitute_sorts(params, inst);
+                    }
+                    let pv = match arg {
+                        Some((name, id)) => {
+                            let bv = self.tm.mk_var(sel_sort, name);
+                            self.locals.insert(*id, bv.clone().into());
+                            bv
+                        }
+                        None => self.tm.mk_anonymous_var(sel_sort),
+                    };
+                    pattern_args.push(pv);
+                }
+                self.scope_stack.push(pattern_args);
+            }
         }
-        AT::Implies(premises, concl) => {
-            let mut all = premises.to_cvc5(env, arena)?;
-            all.push(concl.to_cvc5(env, arena)?);
-            Ok(env.tm.mk_term(Kind::Implies, &all))
-        }
-        AT::Ite(c, t, e) => {
-            let (cc, ct, ce) = (
-                c.to_cvc5(env, arena)?,
-                t.to_cvc5(env, arena)?,
-                e.to_cvc5(env, arena)?,
-            );
-            Ok(env.tm.mk_term(Kind::Ite, &[cc, ct, ce]))
-        }
-        AT::Forall(vars, body) => {
-            env.translate_quantifier(Kind::Forall, vars, body, arena)
-        }
-        AT::Exists(vars, body) => {
-            env.translate_quantifier(Kind::Exists, vars, body, arena)
-        }
-        AT::Let(bindings, body) => env.translate_let(bindings, body, arena),
-        AT::App(qid, args, ret) => {
-            // it's fine due to typed invariant
-            env.translate_app(qid, args, ret.as_ref().unwrap(), arena)
-        }
-        AT::Annotated(t, _) => {
-            // do not handle other annotations
-            t.to_cvc5(env, arena)
-        }
-        AT::Matching(scrutinee, arms) => env.translate_matching(scrutinee, arms, arena),
+
+        Ok(())
+    }
+
+    fn on_match_arm(
+        &mut self,
+        current: &Term,
+        scrutinee: &Term,
+        cases: &[PatternArm],
+        scrutinee_rec: &Self::Out,
+        case_idx: usize,
+        current_pattern: Self::Pattern,
+        arm: Self::Out,
+    ) -> Res<Self::Arm> {
+        let scr_sort = scrutinee_rec.term.sort();
+        let dt = scr_sort.datatype();
+        todo!()
+    }
+
+    fn on_match(
+        &mut self,
+        current: &Term,
+        scrutinee: &Term,
+        cases: &[PatternArm],
+        scrutinee_rec: Self::Out,
+        cases_rec: Vec<Self::Arm>,
+    ) -> Res<WithPattern<'tm>> {
+        todo!()
     }
 }
 
-impl<'tm, T, A: HasArenaAlt, E> ConvertToCvc5<Cvc5Env<'tm>, A> for [T]
+impl<'tm> TypedTermRecursor for Cvc5Env<'tm> {}
+
+impl<'tm, T, A, E> ConvertToCvc5<Cvc5Env<'tm>, A> for [T]
 where
     T: ConvertToCvc5<Cvc5Env<'tm>, A, Output = E>,
 {
@@ -399,20 +685,26 @@ where
 }
 
 impl<'tm> Cvc5Env<'tm> {
-    fn translate_constant(&self, c: &Constant) -> Res<CTerm<'tm>> {
+    fn translate_constant(&self, c: &Constant, s: &Sort) -> Res<WithPattern<'tm>> {
         use alg::Constant::*;
         match c {
-            Bool(true) => Ok(self.tm.mk_true()),
-            Bool(false) => Ok(self.tm.mk_false()),
-            Numeral(n) => Ok(self.tm.mk_integer_from_str(&n.to_string())),
-            Decimal(d) => Ok(self.tm.mk_real_from_str(&d.to_string())),
-            String(s) => Ok(self.tm.mk_string(s, false)),
+            Bool(true) => Ok(self.tm.mk_true().into()),
+            Bool(false) => Ok(self.tm.mk_false().into()),
+            Numeral(n) => {
+                if s.is_real() {
+                    Ok(self.tm.mk_real_from_str(&n.to_string()).into())
+                } else {
+                    Ok(self.tm.mk_integer_from_str(&n.to_string()).into())
+                }
+            }
+            Decimal(d) => Ok(self.tm.mk_real_from_str(&d.to_string()).into()),
+            String(s) => Ok(self.tm.mk_string(s, false).into()),
             Binary(bytes, len) => {
                 let bits = binary_to_string(bytes, *len);
                 let w: u32 = (*len)
                     .try_into()
                     .map_err(|_| format!("binary literal width too large: {len}"))?;
-                Ok(self.tm.mk_bv_from_str(w, &bits, 2))
+                Ok(self.tm.mk_bv_from_str(w, &bits, 2).into())
             }
             Hexadecimal(bytes, len) => {
                 let hex = hex_to_string(bytes, *len);
@@ -420,7 +712,7 @@ impl<'tm> Cvc5Env<'tm> {
                     .checked_mul(4)
                     .and_then(|n| n.try_into().ok())
                     .ok_or_else(|| format!("hex literal width too large: {len}"))?;
-                Ok(self.tm.mk_bv_from_str(w, &hex, 16))
+                Ok(self.tm.mk_bv_from_str(w, &hex, 16).into())
             }
         }
     }
@@ -434,17 +726,12 @@ impl<'tm> Cvc5Env<'tm> {
     /// Look up a constructor by name in the datatype behind `sort`, returning its
     /// instantiated term if the datatype is parametric. Returns `None` when the sort
     /// is not in the sort table, the datatype is not parametric, or no constructor matches.
-    fn resolve_parametric_ctor<A: HasArenaAlt>(
-        &mut self,
-        name: &str,
-        sort: &Sort,
-        arena: &mut A,
-    ) -> Res<Option<CTerm<'tm>>> {
+    fn resolve_parametric_ctor(&mut self, name: &str, sort: &Sort) -> Res<Option<CTerm<'tm>>> {
         let sort_name = sort.repr().sort_name();
         if let Some(base_sort) = self.sort.get(sort_name).cloned() {
             let dt = base_sort.datatype();
             if dt.is_parametric() {
-                let crs = sort.to_cvc5(self, arena)?;
+                let crs = sort.to_cvc5(self, &mut ())?;
                 for i in 0..dt.num_constructors() {
                     let ctor = dt.constructor(i);
                     if ctor.name() == name {
@@ -456,21 +743,23 @@ impl<'tm> Cvc5Env<'tm> {
         Ok(None)
     }
 
-    fn translate_global<A: HasArenaAlt>(
+    fn translate_global(
         &mut self,
         qid: &QualifiedIdentifier,
         sort: &Sort,
-        arena: &mut A,
-    ) -> Res<CTerm<'tm>> {
+    ) -> Res<WithPattern<'tm>> {
         use alg::IdentifierKind::*;
         let name = qid.id_str();
         match qid.get_kind() {
-            Some(Char(hex, _)) => Ok(self.tm.mk_string(
-                &String::from_utf8(hex).map_err(|err| {
-                    format!("symbol {qid} cannot be converted to a String: {err}")
-                })?,
-                false,
-            )),
+            Some(Char(hex, _)) => Ok(self
+                .tm
+                .mk_string(
+                    &String::from_utf8(hex).map_err(|err| {
+                        format!("symbol {qid} cannot be converted to a String: {err}")
+                    })?,
+                    false,
+                )
+                .into()),
             _ => {
                 // For sort-ascribed parametric constructors like (as nil (List Int)),
                 // resolve via the instantiated sort using instantiated_term
@@ -481,115 +770,68 @@ impl<'tm> Cvc5Env<'tm> {
                     .ok_or_else(|| format!("unknown global symbol: {name}"))?;
                 let is_ctor = t.sort().is_dt_constructor();
                 if is_ctor {
-                    if let Some(ct) = self.resolve_parametric_ctor(name, sort, arena)? {
-                        Ok(self.tm.mk_term(Kind::ApplyConstructor, &[ct]))
+                    if let Some(ct) = self.resolve_parametric_ctor(name, sort)? {
+                        Ok(self.tm.mk_term(Kind::ApplyConstructor, &[ct]).into())
                     } else {
-                        Ok(self.tm.mk_term(Kind::ApplyConstructor, &[t]))
+                        Ok(self.tm.mk_term(Kind::ApplyConstructor, &[t]).into())
                     }
                 } else {
-                    Ok(t)
+                    Ok(t.into())
                 }
             }
         }
     }
 
     /// Translate sorted variable bindings into cvc5 bound variables, inserting them into `locals`.
-    fn bind_vars<A: HasArenaAlt>(
-        &mut self,
-        vars: &[alg::VarBinding<Str, Sort>],
-        arena: &mut A,
-    ) -> Res<Vec<CTerm<'tm>>> {
+    fn bind_vars(&mut self, vars: &[VarBinding<Str, Sort>]) -> Res<()> {
         let mut bound = Vec::with_capacity(vars.len());
         for v in vars {
-            let cs = v.2.to_cvc5(self, arena)?;
+            let cs = v.2.to_cvc5(self, &mut ())?;
             let bv = self.tm.mk_var(cs, &v.0);
-            self.locals.insert(v.1, bv.clone());
+            self.locals.insert(v.1, bv.clone().into());
             bound.push(bv);
         }
-        Ok(bound)
+        self.scope_stack.push(bound);
+        Ok(())
     }
 
     /// Remove variable bindings from `locals`.
-    fn unbind_vars(&mut self, vars: &[alg::VarBinding<Str, Sort>]) {
+    fn unbind_vars(&mut self, vars: &[VarBinding<Str, Sort>]) -> Res<Vec<CTerm<'tm>>> {
         for v in vars {
             self.locals.remove(&v.1);
         }
+        self.scope_stack
+            .pop()
+            .ok_or_else(|| "invariance violation: scope management failure".into())
     }
 
-    fn translate_quantifier<A: HasArenaAlt>(
+    fn translate_quantifier_body(
         &mut self,
         kind: Kind,
-        vars: &[alg::VarBinding<Str, Sort>],
-        body: &Term,
-        arena: &mut A,
-    ) -> Res<CTerm<'tm>> {
-        let bound = self.bind_vars(vars, arena)?;
-        let result = self.translate_quantifier_body(kind, body, &bound, arena);
-        self.unbind_vars(vars);
-        result
-    }
-
-    fn translate_quantifier_body<A: HasArenaAlt>(
-        &mut self,
-        kind: Kind,
-        body: &Term,
-        bound: &[CTerm<'tm>],
-        arena: &mut A,
-    ) -> Res<CTerm<'tm>> {
-        let bvl = self.tm.mk_term(Kind::VariableList, bound);
+        bound: Vec<CTerm<'tm>>,
+        t_rec: WithPattern<'tm>,
+    ) -> Res<WithPattern<'tm>> {
+        let bvl = self.tm.mk_term(Kind::VariableList, &bound);
 
         // Peel off annotations from the body to extract :pattern triggers
-        let (inner_body, attrs) = match body.repr() {
-            ATerm::Annotated(t, attrs) => (t, Some(attrs)),
-            _ => (body, None),
-        };
-        let cbody = inner_body.to_cvc5(self, arena)?;
+        let cbody = t_rec.term;
 
         // Build INST_PATTERN_LIST from :pattern annotations
-        if let Some(attrs) = attrs {
-            let mut pats = Vec::new();
-            for attr in attrs {
-                if let Attribute::Pattern(terms) = attr {
-                    let cterms = terms.to_cvc5(self, arena)?;
-                    pats.push(self.tm.mk_term(Kind::InstPattern, &cterms));
-                }
-            }
-            if !pats.is_empty() {
-                let plist = self.tm.mk_term(Kind::InstPatternList, &pats);
-                return Ok(self.tm.mk_term(kind, &[bvl, cbody, plist]));
-            }
+        if !t_rec.patterns.is_empty() {
+            let pats = self.tm.mk_term(Kind::InstPattern, &t_rec.patterns);
+            let plist = self
+                .tm
+                .mk_term(Kind::InstPatternList, std::slice::from_ref(&pats));
+            return Ok(self.tm.mk_term(kind, &[bvl, cbody, plist]).into());
         }
-
-        Ok(self.tm.mk_term(kind, &[bvl, cbody]))
+        Ok(self.tm.mk_term(kind, &[bvl, cbody]).into())
     }
 
-    fn translate_let<A: HasArenaAlt>(
+    fn translate_matching(
         &mut self,
-        bindings: &[alg::VarBinding<Str, Term>],
-        body: &Term,
-        arena: &mut A,
-    ) -> Res<CTerm<'tm>> {
-        let new_bindings = bindings
-            .iter()
-            .map(|b| Ok((b.1, b.2.to_cvc5(self, arena)?)))
-            .collect::<Res<Vec<_>>>()?;
-        for b in new_bindings {
-            self.locals.insert(b.0, b.1);
-        }
-        let result = body.to_cvc5(self, arena);
-        for b in bindings {
-            self.locals.remove(&b.1);
-        }
-        result
-    }
-
-    fn translate_matching<A: HasArenaAlt>(
-        &mut self,
-        scrutinee: &Term,
+        cscrutinee: &CTerm<'tm>,
         arms: &[alg::PatternArm<Str, Term>],
-        arena: &mut A,
     ) -> Res<CTerm<'tm>> {
-        let cscrutinee = scrutinee.to_cvc5(self, arena)?;
         let scr_sort = cscrutinee.sort();
         let dt = scr_sort.datatype();
         // For parametric datatypes, selector codomain sorts are uninstantiated (e.g. X).
@@ -612,12 +854,9 @@ impl<'tm> Cvc5Env<'tm> {
                     } else {
                         ctor.term()
                     };
-                    let ctor_app = self
-                        .tm
-                        .mk_term(Kind::ApplyConstructor, &[ctor_term]);
+                    let ctor_app = self.tm.mk_term(Kind::ApplyConstructor, &[ctor_term]);
                     let cbody = arm.body.to_cvc5(self, arena)?;
-                    self.tm
-                        .mk_term(Kind::MatchCase, &[ctor_app, cbody])
+                    self.tm.mk_term(Kind::MatchCase, &[ctor_app, cbody])
                 }
                 alg::Pattern::Applied {
                     ctor: name,
@@ -633,30 +872,22 @@ impl<'tm> Cvc5Env<'tm> {
                         if let Some((ref params, ref inst)) = subst {
                             sel_sort = sel_sort.substitute_sorts(params, inst);
                         }
-                        let bv = match arg {
+                        let pv = match arg {
                             Some((_, id)) => {
-                                // todo: mk_var allows NULL name in C. cyc5-rs should expose this.
-                                // cvc5 should be responsible for handling fresh names.
-                                let fresh = arena.arena_alt().fresh_x().to_string();
-                                let bv = self.tm.mk_var(sel_sort, &fresh);
+                                let bv = self.tm.mk_anonymous_var(sel_sort);
                                 self.locals.insert(*id, bv.clone());
                                 bv
                             }
-                            None => {
-                                let fresh = arena.arena_alt().fresh_x().to_string();
-                                self.tm.mk_var(sel_sort, &fresh)
-                            }
+                            None => self.tm.mk_anonymous_var(sel_sort),
                         };
-                        vars.push(bv.clone());
-                        pattern_args.push(bv);
+                        vars.push(pv.clone());
+                        pattern_args.push(pv);
                     }
                     let mut pat_children = vec![ctor.term()];
                     pat_children.extend(pattern_args);
-                    let pattern = self
-                        .tm
-                        .mk_term(Kind::ApplyConstructor, &pat_children);
+                    let pattern = self.tm.mk_term(Kind::ApplyConstructor, &pat_children);
                     let vlist = self.tm.mk_term(Kind::VariableList, &vars);
-                    let cbody = arm.body.to_cvc5(self, arena);
+                    let cbody = arm.body.to_cvc5(self, &mut ());
                     for (_, id) in arguments.iter().flatten() {
                         self.locals.remove(id);
                     }
@@ -665,21 +896,19 @@ impl<'tm> Cvc5Env<'tm> {
                         .mk_term(Kind::MatchBindCase, &[vlist, pattern, cbody])
                 }
                 alg::Pattern::Wildcard(binding) => {
-                    let fresh = arena.arena_alt().fresh_x().to_string();
-                    let bv = self.tm.mk_var(scr_sort.clone(), &fresh);
+                    let pv = self.tm.mk_anonymous_var(scr_sort.clone());
                     if let Some((_, id)) = binding {
-                        self.locals.insert(*id, bv.clone());
+                        self.locals.insert(*id, pv.clone());
                     }
                     let vlist = self
                         .tm
-                        .mk_term(Kind::VariableList, std::slice::from_ref(&bv));
+                        .mk_term(Kind::VariableList, std::slice::from_ref(&pv));
                     let cbody = arm.body.to_cvc5(self, arena);
                     if let Some((_, id)) = binding {
                         self.locals.remove(id);
                     }
                     let cbody = cbody?;
-                    self.tm
-                        .mk_term(Kind::MatchBindCase, &[vlist, bv, cbody])
+                    self.tm.mk_term(Kind::MatchBindCase, &[vlist, pv, cbody])
                 }
             };
             cases.push(case);
@@ -690,14 +919,12 @@ impl<'tm> Cvc5Env<'tm> {
         Ok(self.tm.mk_term(Kind::Match, &match_children))
     }
 
-    fn translate_app<A: HasArenaAlt>(
+    fn translate_app(
         &mut self,
         qid: &QualifiedIdentifier,
-        args: &[Term],
+        cargs: Vec<CTerm<'tm>>,
         rs: &Sort,
-        arena: &mut A,
-    ) -> Res<CTerm<'tm>> {
-        let cargs = args.to_cvc5(self, arena)?;
+    ) -> Res<WithPattern<'tm>> {
         let id = &qid.0;
         let kind = id.get_kind();
         // Handle unary minus: (- x) → NEG
@@ -716,7 +943,7 @@ impl<'tm> Cvc5Env<'tm> {
         if let Some(f) = self.globals.get(name).cloned() {
             let fs = f.sort();
             if fs.is_dt_constructor() {
-                if let Some(ct) = self.resolve_parametric_ctor(name, rs, arena)? {
+                if let Some(ct) = self.resolve_parametric_ctor(name, rs)? {
                     Ok(self.mk_applied(Kind::ApplyConstructor, ct, cargs))
                 } else {
                     Ok(self.mk_applied(Kind::ApplyConstructor, f, cargs))
@@ -733,7 +960,11 @@ impl<'tm> Cvc5Env<'tm> {
         }
     }
 
-    fn translate_indexed_app(&self, ik: &IdentifierKind, cargs: Vec<CTerm<'tm>>) -> Res<CTerm<'tm>> {
+    fn translate_indexed_app(
+        &self,
+        ik: &IdentifierKind,
+        cargs: Vec<CTerm<'tm>>,
+    ) -> Res<CTerm<'tm>> {
         use alg::IdentifierKind::*;
         let mk = |kind, indices: &[u32]| {
             let op = self.tm.mk_op(kind, indices);
@@ -743,18 +974,13 @@ impl<'tm> Cvc5Env<'tm> {
             n.try_into().map_err(|_| format!("index too large: {n}"))
         };
         match ik {
-            Extract(hi, lo) => mk(
-                Kind::BitvectorExtract,
-                &[to_u32(hi)?, to_u32(lo)?],
-            ),
+            Extract(hi, lo) => mk(Kind::BitvectorExtract, &[to_u32(hi)?, to_u32(lo)?]),
             Repeat(n) => mk(Kind::BitvectorRepeat, &[to_u32(n)?]),
             ZeroExtend(n) => mk(Kind::BitvectorZeroExtend, &[to_u32(n)?]),
             SignExtend(n) => mk(Kind::BitvectorSignExtend, &[to_u32(n)?]),
             RotateLeft(n) => mk(Kind::BitvectorRotateLeft, &[to_u32(n)?]),
             RotateRight(n) => mk(Kind::BitvectorRotateRight, &[to_u32(n)?]),
-            IntToBv(n) | Int2Bv(n) | Nat2Bv(n) => {
-                mk(Kind::IntToBitvector, &[to_u32(n)?])
-            }
+            IntToBv(n) | Int2Bv(n) | Nat2Bv(n) => mk(Kind::IntToBitvector, &[to_u32(n)?]),
             RePower(n) => mk(Kind::RegexpRepeat, &[to_u32(n)?]),
             ReLoop(lo, hi) => mk(Kind::RegexpLoop, &[to_u32(lo)?, to_u32(hi)?]),
             Is(cname) => {
@@ -944,9 +1170,9 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm> {
     ) -> Res<CommandResult<'tm>> {
         let env = &mut *self.env;
         let out = fd.out_sort.to_cvc5(env, arena)?;
-        let vars = env.bind_vars(&fd.vars, arena)?;
+        env.bind_vars(&fd.vars)?;
         let body = fd.body.to_cvc5(env, arena);
-        env.unbind_vars(&fd.vars);
+        let vars = env.unbind_vars(&fd.vars)?;
         let body = body?;
         let ct = if recursive {
             self.solver.define_fun_rec(&fd.name, &vars, out, body, true)
@@ -986,9 +1212,9 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm> {
         let mut all_vars = Vec::with_capacity(fds.len());
         let mut bodies = Vec::with_capacity(fds.len());
         for fd in fds {
-            let vars = env.bind_vars(&fd.vars, arena)?;
+            env.bind_vars(&fd.vars)?;
             let body = fd.body.to_cvc5(env, arena);
-            env.unbind_vars(&fd.vars);
+            let vars = env.unbind_vars(&fd.vars)?;
             all_vars.push(vars);
             bodies.push(body?);
         }
@@ -1034,7 +1260,8 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm> {
         let mut decls = Vec::with_capacity(defs.len());
         for def in defs {
             let params = &def.dec.params;
-            let cvc5_params: Vec<CSort<'tm>> = params.iter().map(|p| env.tm.mk_param_sort(p)).collect();
+            let cvc5_params: Vec<CSort<'tm>> =
+                params.iter().map(|p| env.tm.mk_param_sort(p)).collect();
             for (p, cs) in params.iter().zip(&cvc5_params) {
                 env.dt_sorts.insert(p.clone(), cs.clone());
             }

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -11,7 +11,7 @@
 //! - [`ConvertToCvc5<Env, A>`] — the core trait, implemented for [`Sort`], [`Term`], and [`Command`].
 //! - [`Cvc5Env`] — holds a [`cvc5::TermManager`] and caches for sort/term/symbol translation.
 //!   Used as the environment for `Sort::to_cvc5` and `Term::to_cvc5`.
-//! - [`Cvc5EnvSolver`] — wraps a [`Cvc5Env`] and a [`Solver`]. Used as the environment
+//! - [`Cvc5EnvSolver`] — wraps a [`Cvc5EnvInner`] and a [`Solver`]. Used as the environment
 //!   for `Command::to_cvc5`, since commands may interact with the solver (e.g. `assert`,
 //!   `check-sat`, `define-fun`).
 //!
@@ -32,7 +32,7 @@
 //!
 //! let tm = TermManager::new();
 //! let mut solver = Solver::new(&tm);
-//! let mut env = Cvc5Env::new(&tm);
+//! let mut env = Cvc5Env::create(&tm);
 //! let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
 //! for cmd in &cmds {
 //!     cmd.to_cvc5(&mut es, &mut ctx).unwrap();
@@ -91,19 +91,6 @@ pub trait ConvertToCvc5<Env, A> {
     fn to_cvc5(&self, env: &mut Env, arena: &mut A) -> Res<Self::Output>;
 }
 
-/// Environment for translating yaspar-ir ASTs to cvc5 objects.
-pub struct Cvc5Env<'tm> {
-    tm: &'tm TermManager,
-    sort: HashMap<Str, CSort<'tm>>,
-    globals: HashMap<Str, CTerm<'tm>>,
-    locals: HashMap<usize, WithPattern<'tm>>,
-    sort_cache: HashMap<Sort, CSort<'tm>>,
-    term_cache: HashMap<Term, CTerm<'tm>>,
-    dt_sorts: HashMap<Str, CSort<'tm>>,
-    scope_stack: Vec<Vec<CTerm<'tm>>>,
-    sort_subst_map: HashMap<Term, Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)>>,
-}
-
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct WithPattern<'tm> {
     term: CTerm<'tm>,
@@ -125,7 +112,19 @@ impl<'tm> From<CTerm<'tm>> for WithPattern<'tm> {
     }
 }
 
-impl<'tm> Cvc5Env<'tm> {
+/// Environment for translating yaspar-ir ASTs to cvc5 objects.
+pub struct Cvc5EnvInner<'tm> {
+    tm: &'tm TermManager,
+    sort: HashMap<Str, CSort<'tm>>,
+    globals: HashMap<Str, CTerm<'tm>>,
+    locals: HashMap<usize, WithPattern<'tm>>,
+    sort_cache: HashMap<Sort, CSort<'tm>>,
+    dt_sorts: HashMap<Str, CSort<'tm>>,
+    scope_stack: Vec<Vec<CTerm<'tm>>>,
+    sort_subst_map: HashMap<Term, Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)>>,
+}
+
+impl<'tm> Cvc5EnvInner<'tm> {
     pub fn new(tm: &'tm TermManager) -> Self {
         Self {
             tm,
@@ -133,14 +132,21 @@ impl<'tm> Cvc5Env<'tm> {
             globals: HashMap::new(),
             locals: HashMap::new(),
             sort_cache: HashMap::new(),
-            term_cache: HashMap::new(),
             dt_sorts: HashMap::new(),
             scope_stack: vec![],
+            sort_subst_map: Default::default(),
         }
     }
 }
+pub type Cvc5Env<'tm> = Memoize<Cvc5EnvInner<'tm>, HashMap<Term, WithPattern<'tm>>>;
 
-/// Environment combining a [`Cvc5Env`] with a [`Solver`] for translating commands.
+impl<'tm> Cvc5Env<'tm> {
+    pub fn create(tm: &'tm TermManager) -> Self {
+        Self::new(Cvc5EnvInner::new(tm))
+    }
+}
+
+/// Environment combining a [`Cvc5EnvInner`] with a [`Solver`] for translating commands.
 pub struct Cvc5EnvSolver<'a, 'tm> {
     pub env: &'a mut Cvc5Env<'tm>,
     pub solver: &'a mut Solver<'tm>,
@@ -153,10 +159,10 @@ impl<'a, 'tm> Cvc5EnvSolver<'a, 'tm> {
 }
 
 // ── Sort translation ─────────────────────────────────────────
-impl<'tm, A> ConvertToCvc5<Cvc5Env<'tm>, A> for Sort {
+impl<'tm, A> ConvertToCvc5<Cvc5EnvInner<'tm>, A> for Sort {
     type Output = CSort<'tm>;
 
-    fn to_cvc5(&self, env: &mut Cvc5Env<'tm>, arena: &mut A) -> Res<CSort<'tm>> {
+    fn to_cvc5(&self, env: &mut Cvc5EnvInner<'tm>, arena: &mut A) -> Res<CSort<'tm>> {
         if let Some(cs) = env.sort_cache.get(self) {
             return Ok(cs.clone());
         }
@@ -168,7 +174,7 @@ impl<'tm, A> ConvertToCvc5<Cvc5Env<'tm>, A> for Sort {
 
 fn translate_sort_inner<'tm, A>(
     sort: &Sort,
-    env: &mut Cvc5Env<'tm>,
+    env: &mut Cvc5EnvInner<'tm>,
     arena: &mut A,
 ) -> Res<CSort<'tm>> {
     let s = sort.repr();
@@ -221,6 +227,15 @@ fn translate_sort_inner<'tm, A>(
     }
 
     Err(format!("unsupported sort: {sort}"))
+}
+
+impl<'tm, A> ConvertToCvc5<Cvc5Env<'tm>, A> for Sort {
+    type Output = CSort<'tm>;
+
+    #[inline]
+    fn to_cvc5(&self, env: &mut Cvc5Env<'tm>, arena: &mut A) -> Res<Self::Output> {
+        self.to_cvc5(&mut env.inner, arena)
+    }
 }
 
 // ── Identifier kind → cvc5 Kind mapping ─────────────────────
@@ -326,12 +341,7 @@ impl<'tm, A> ConvertToCvc5<Cvc5Env<'tm>, A> for Term {
     type Output = CTerm<'tm>;
 
     fn to_cvc5(&self, env: &mut Cvc5Env<'tm>, arena: &mut A) -> Res<CTerm<'tm>> {
-        if let Some(ct) = env.term_cache.get(self) {
-            return Ok(ct.clone());
-        }
-        let ct = translate_term_inner(self, env, arena)?;
-        env.term_cache.insert(self.clone(), ct.clone());
-        Ok(ct)
+        env.recurse_on_term(self).map(|t| t.into())
     }
 }
 
@@ -339,7 +349,7 @@ fn to_term_vec(terms: Vec<WithPattern>) -> Vec<CTerm> {
     terms.into_iter().map(|t| t.into()).collect()
 }
 
-impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm> {
+impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
     type Out = WithPattern<'tm>;
     type Attr = Vec<CTerm<'tm>>;
     type Binding = (usize, WithPattern<'tm>);
@@ -706,20 +716,20 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm> {
     }
 }
 
-impl<'tm> TypedTermRecursor for Cvc5Env<'tm> {}
+impl<'tm> TypedTermRecursor for Cvc5EnvInner<'tm> {}
 
-impl<'tm, T, A, E> ConvertToCvc5<Cvc5Env<'tm>, A> for [T]
+impl<'tm, T, A, E> ConvertToCvc5<Cvc5EnvInner<'tm>, A> for [T]
 where
-    T: ConvertToCvc5<Cvc5Env<'tm>, A, Output = E>,
+    T: ConvertToCvc5<Cvc5EnvInner<'tm>, A, Output = E>,
 {
     type Output = Vec<E>;
 
-    fn to_cvc5(&self, env: &mut Cvc5Env<'tm>, arena: &mut A) -> Res<Vec<E>> {
+    fn to_cvc5(&self, env: &mut Cvc5EnvInner<'tm>, arena: &mut A) -> Res<Vec<E>> {
         self.iter().map(|t| t.to_cvc5(env, arena)).collect()
     }
 }
 
-impl<'tm> Cvc5Env<'tm> {
+impl<'tm> Cvc5EnvInner<'tm> {
     fn translate_constant(&self, c: &Constant, s: &Sort) -> Res<WithPattern<'tm>> {
         use alg::Constant::*;
         match c {
@@ -1204,7 +1214,7 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm> {
     }
 
     fn build_dt_decls<A: HasArenaAlt>(
-        env: &mut Cvc5Env<'tm>,
+        env: &mut Cvc5EnvInner<'tm>,
         defs: &[alg::DatatypeDef<Str, Sort>],
         arena: &mut A,
     ) -> Res<Vec<cvc5::DatatypeDecl<'tm>>> {
@@ -1239,7 +1249,7 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm> {
     }
 
     fn register_dt_functions<A: HasArenaAlt>(
-        env: &mut Cvc5Env<'tm>,
+        env: &mut Cvc5EnvInner<'tm>,
         sort: CSort<'tm>,
         dec: &DatatypeDec,
         arena: &mut A,

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -389,159 +389,6 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm> {
         )
     }
 
-    fn on_annotated(
-        &mut self,
-        current: &Term,
-        t: &Term,
-        anns: &[Attribute],
-        t_rec: WithPattern<'tm>,
-        anns_rec: Vec<Vec<CTerm<'tm>>>,
-    ) -> Res<WithPattern<'tm>> {
-        // do not handle other annotations
-        let mut pats = t_rec.patterns;
-        anns_rec.into_iter().for_each(|ps| pats.extend(ps));
-        Ok(WithPattern {
-            term: t_rec.term,
-            patterns: pats,
-        })
-    }
-    fn on_eq(
-        &mut self,
-        current: &Term,
-        a: &Term,
-        b: &Term,
-        a_rec: WithPattern<'tm>,
-        b_rec: WithPattern<'tm>,
-    ) -> Res<WithPattern<'tm>> {
-        Ok(self
-            .tm
-            .mk_term(Kind::Equal, &[a_rec.into(), b_rec.into()])
-            .into())
-    }
-    fn on_distinct(
-        &mut self,
-        current: &Term,
-        ts: &[Term],
-        ts_rec: Vec<WithPattern<'tm>>,
-    ) -> Res<WithPattern<'tm>> {
-        Ok(self.tm.mk_term(Kind::Distinct, &to_term_vec(ts_rec)).into())
-    }
-    fn on_and(
-        &mut self,
-        current: &Term,
-        ts: &[Term],
-        ts_rec: Vec<WithPattern<'tm>>,
-    ) -> Res<WithPattern<'tm>> {
-        Ok(self.tm.mk_term(Kind::And, &to_term_vec(ts_rec)).into())
-    }
-    fn on_or(
-        &mut self,
-        current: &Term,
-        ts: &[Term],
-        ts_rec: Vec<WithPattern<'tm>>,
-    ) -> Res<WithPattern<'tm>> {
-        Ok(self.tm.mk_term(Kind::Or, &&to_term_vec(ts_rec)).into())
-    }
-    fn on_xor(
-        &mut self,
-        current: &Term,
-        ts: &[Term],
-        ts_rec: Vec<WithPattern<'tm>>,
-    ) -> Res<WithPattern<'tm>> {
-        Ok(self.tm.mk_term(Kind::Xor, &to_term_vec(ts_rec)).into())
-    }
-    fn on_not(
-        &mut self,
-        current: &Term,
-        t: &Term,
-        t_rec: WithPattern<'tm>,
-    ) -> Res<WithPattern<'tm>> {
-        Ok(self.tm.mk_term(Kind::Not, &[t_rec.into()]).into())
-    }
-    fn on_implies(
-        &mut self,
-        current: &Term,
-        ts: &[Term],
-        t: &Term,
-        ts_rec: Vec<WithPattern<'tm>>,
-        t_rec: WithPattern<'tm>,
-    ) -> Res<WithPattern<'tm>> {
-        let mut all = ts_rec;
-        all.push(t_rec);
-        Ok(self.tm.mk_term(Kind::Implies, &to_term_vec(all)).into())
-    }
-    fn on_ite(
-        &mut self,
-        current: &Term,
-        b: &Term,
-        t: &Term,
-        e: &Term,
-        b_rec: WithPattern<'tm>,
-        t_rec: WithPattern<'tm>,
-        e_rec: WithPattern<'tm>,
-    ) -> Res<WithPattern<'tm>> {
-        Ok(self
-            .tm
-            .mk_term(Kind::Ite, &[b_rec.into(), t_rec.into(), e_rec.into()])
-            .into())
-    }
-
-    fn on_attribute_keyword(&mut self, keyword: &Keyword) -> Res<Vec<CTerm<'tm>>> {
-        Ok(vec![])
-    }
-    fn on_attribute_constant(
-        &mut self,
-        keyword: &Keyword,
-        constant: &Constant,
-    ) -> Res<Vec<CTerm<'tm>>> {
-        Ok(vec![])
-    }
-    fn on_attribute_symbol(&mut self, keyword: &Keyword, symbol: &Str) -> Res<Vec<CTerm<'tm>>> {
-        Ok(vec![])
-    }
-    fn on_attribute_named(&mut self, name: &Str) -> Res<Vec<CTerm<'tm>>> {
-        Ok(vec![])
-    }
-    fn on_attribute_pattern(
-        &mut self,
-        patterns: &[Term],
-        patterns_rec: Vec<WithPattern<'tm>>,
-    ) -> Res<Vec<CTerm<'tm>>> {
-        Ok(to_term_vec(patterns_rec))
-    }
-
-    fn setup_quantifier_scope(
-        &mut self,
-        current: &Term,
-        vs: &[VarBinding<Str, Sort>],
-        t: &Term,
-        is_forall: bool,
-    ) -> Res<()> {
-        self.bind_vars(vs)
-    }
-
-    fn on_exists(
-        &mut self,
-        current: &Term,
-        vs: &[VarBinding<Str, Sort>],
-        t: &Term,
-        t_rec: WithPattern<'tm>,
-    ) -> Res<WithPattern<'tm>> {
-        let bound = self.unbind_vars(vs)?;
-        self.translate_quantifier_body(Kind::Exists, bound, t_rec)
-    }
-
-    fn on_forall(
-        &mut self,
-        current: &Term,
-        vs: &[VarBinding<Str, Sort>],
-        t: &Term,
-        t_rec: Self::Out,
-    ) -> Res<WithPattern<'tm>> {
-        let bound = self.unbind_vars(vs)?;
-        self.translate_quantifier_body(Kind::Forall, bound, t_rec)
-    }
-
     fn on_let_binding(
         &mut self,
         current: &Term,
@@ -553,7 +400,6 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm> {
         let idx = vs[binding_idx].1;
         Ok((idx, binding_rec))
     }
-
     fn setup_let_scope(
         &mut self,
         current: &Term,
@@ -566,7 +412,6 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm> {
         }
         Ok(())
     }
-
     fn on_let(
         &mut self,
         current: &Term,
@@ -580,7 +425,35 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm> {
         }
         Ok(body_rec)
     }
-
+    fn setup_quantifier_scope(
+        &mut self,
+        current: &Term,
+        vs: &[VarBinding<Str, Sort>],
+        t: &Term,
+        is_forall: bool,
+    ) -> Res<()> {
+        self.bind_vars(vs)
+    }
+    fn on_exists(
+        &mut self,
+        current: &Term,
+        vs: &[VarBinding<Str, Sort>],
+        t: &Term,
+        t_rec: WithPattern<'tm>,
+    ) -> Res<WithPattern<'tm>> {
+        let bound = self.unbind_vars(vs, |v| &v.1)?;
+        self.translate_quantifier_body(Kind::Exists, bound, t_rec)
+    }
+    fn on_forall(
+        &mut self,
+        current: &Term,
+        vs: &[VarBinding<Str, Sort>],
+        t: &Term,
+        t_rec: Self::Out,
+    ) -> Res<WithPattern<'tm>> {
+        let bound = self.unbind_vars(vs, |v| &v.1)?;
+        self.translate_quantifier_body(Kind::Forall, bound, t_rec)
+    }
     fn setup_match_case_scope(
         &mut self,
         current: &Term,
@@ -643,7 +516,6 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm> {
 
         Ok(())
     }
-
     fn on_match_arm(
         &mut self,
         current: &Term,
@@ -656,9 +528,41 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm> {
     ) -> Res<Self::Arm> {
         let scr_sort = scrutinee_rec.term.sort();
         let dt = scr_sort.datatype();
-        todo!()
+        let mut args = self.unbind_vars(&cases[case_idx].pattern.variables_and_ids(), |v| &v.1)?;
+        let subst = self.sort_subst_map.get(scrutinee).unwrap();
+        match &cases[case_idx].pattern {
+            Pattern::Wildcard(_) => {
+                // we know there is only one variable
+                let pv = args.remove(0);
+                let vlist = self
+                    .tm
+                    .mk_term(Kind::VariableList, std::slice::from_ref(&pv));
+                Ok(self
+                    .tm
+                    .mk_term(Kind::MatchBindCase, &[vlist, pv, arm.into()]))
+            }
+            Pattern::Ctor(name) => {
+                let ctor = dt.constructor_by_name(name);
+                let ctor_term = if dt.is_parametric() {
+                    ctor.instantiated_term(scr_sort.clone())
+                } else {
+                    ctor.term()
+                };
+                let ctor_app = self.tm.mk_term(Kind::ApplyConstructor, &[ctor_term]);
+                Ok(self.tm.mk_term(Kind::MatchCase, &[ctor_app, arm.into()]))
+            }
+            Pattern::Applied { ctor, .. } => {
+                let ctor = dt.constructor_by_name(ctor);
+                let mut pat_children = vec![ctor.term()];
+                pat_children.extend(args.clone());
+                let pattern = self.tm.mk_term(Kind::ApplyConstructor, &pat_children);
+                let vlist = self.tm.mk_term(Kind::VariableList, &args);
+                Ok(self
+                    .tm
+                    .mk_term(Kind::MatchBindCase, &[vlist, pattern, arm.into()]))
+            }
+        }
     }
-
     fn on_match(
         &mut self,
         current: &Term,
@@ -667,7 +571,138 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm> {
         scrutinee_rec: Self::Out,
         cases_rec: Vec<Self::Arm>,
     ) -> Res<WithPattern<'tm>> {
-        todo!()
+        let mut match_children = vec![scrutinee_rec.into()];
+        match_children.extend(cases_rec);
+        Ok(self.tm.mk_term(Kind::Match, &match_children).into())
+    }
+
+    fn on_annotated(
+        &mut self,
+        current: &Term,
+        t: &Term,
+        anns: &[Attribute],
+        t_rec: WithPattern<'tm>,
+        anns_rec: Vec<Vec<CTerm<'tm>>>,
+    ) -> Res<WithPattern<'tm>> {
+        // do not handle other annotations
+        let mut pats = t_rec.patterns;
+        anns_rec.into_iter().for_each(|ps| pats.extend(ps));
+        Ok(WithPattern {
+            term: t_rec.term,
+            patterns: pats,
+        })
+    }
+    fn on_attribute_keyword(&mut self, keyword: &Keyword) -> Res<Vec<CTerm<'tm>>> {
+        Ok(vec![])
+    }
+    fn on_attribute_constant(
+        &mut self,
+        keyword: &Keyword,
+        constant: &Constant,
+    ) -> Res<Vec<CTerm<'tm>>> {
+        Ok(vec![])
+    }
+    fn on_attribute_symbol(&mut self, keyword: &Keyword, symbol: &Str) -> Res<Vec<CTerm<'tm>>> {
+        Ok(vec![])
+    }
+    fn on_attribute_named(&mut self, name: &Str) -> Res<Vec<CTerm<'tm>>> {
+        Ok(vec![])
+    }
+
+    fn on_attribute_pattern(
+        &mut self,
+        patterns: &[Term],
+        patterns_rec: Vec<WithPattern<'tm>>,
+    ) -> Res<Vec<CTerm<'tm>>> {
+        Ok(to_term_vec(patterns_rec))
+    }
+
+    fn on_eq(
+        &mut self,
+        current: &Term,
+        a: &Term,
+        b: &Term,
+        a_rec: WithPattern<'tm>,
+        b_rec: WithPattern<'tm>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self
+            .tm
+            .mk_term(Kind::Equal, &[a_rec.into(), b_rec.into()])
+            .into())
+    }
+
+    fn on_distinct(
+        &mut self,
+        current: &Term,
+        ts: &[Term],
+        ts_rec: Vec<WithPattern<'tm>>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self.tm.mk_term(Kind::Distinct, &to_term_vec(ts_rec)).into())
+    }
+
+    fn on_and(
+        &mut self,
+        current: &Term,
+        ts: &[Term],
+        ts_rec: Vec<WithPattern<'tm>>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self.tm.mk_term(Kind::And, &to_term_vec(ts_rec)).into())
+    }
+
+    fn on_or(
+        &mut self,
+        current: &Term,
+        ts: &[Term],
+        ts_rec: Vec<WithPattern<'tm>>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self.tm.mk_term(Kind::Or, &&to_term_vec(ts_rec)).into())
+    }
+
+    fn on_xor(
+        &mut self,
+        current: &Term,
+        ts: &[Term],
+        ts_rec: Vec<WithPattern<'tm>>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self.tm.mk_term(Kind::Xor, &to_term_vec(ts_rec)).into())
+    }
+
+    fn on_not(
+        &mut self,
+        current: &Term,
+        t: &Term,
+        t_rec: WithPattern<'tm>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self.tm.mk_term(Kind::Not, &[t_rec.into()]).into())
+    }
+
+    fn on_implies(
+        &mut self,
+        current: &Term,
+        ts: &[Term],
+        t: &Term,
+        ts_rec: Vec<WithPattern<'tm>>,
+        t_rec: WithPattern<'tm>,
+    ) -> Res<WithPattern<'tm>> {
+        let mut all = ts_rec;
+        all.push(t_rec);
+        Ok(self.tm.mk_term(Kind::Implies, &to_term_vec(all)).into())
+    }
+
+    fn on_ite(
+        &mut self,
+        current: &Term,
+        b: &Term,
+        t: &Term,
+        e: &Term,
+        b_rec: WithPattern<'tm>,
+        t_rec: WithPattern<'tm>,
+        e_rec: WithPattern<'tm>,
+    ) -> Res<WithPattern<'tm>> {
+        Ok(self
+            .tm
+            .mk_term(Kind::Ite, &[b_rec.into(), t_rec.into(), e_rec.into()])
+            .into())
     }
 }
 
@@ -718,9 +753,14 @@ impl<'tm> Cvc5Env<'tm> {
     }
 
     /// Build `(kind head args...)`.
-    fn mk_applied(&self, kind: Kind, head: CTerm<'tm>, mut args: Vec<CTerm<'tm>>) -> CTerm<'tm> {
+    fn mk_applied(
+        &self,
+        kind: Kind,
+        head: CTerm<'tm>,
+        mut args: Vec<CTerm<'tm>>,
+    ) -> WithPattern<'tm> {
         args.insert(0, head);
-        self.tm.mk_term(kind, &args)
+        self.tm.mk_term(kind, &args).into()
     }
 
     /// Look up a constructor by name in the datatype behind `sort`, returning its
@@ -796,9 +836,12 @@ impl<'tm> Cvc5Env<'tm> {
     }
 
     /// Remove variable bindings from `locals`.
-    fn unbind_vars(&mut self, vars: &[VarBinding<Str, Sort>]) -> Res<Vec<CTerm<'tm>>> {
+    fn unbind_vars<T, F>(&mut self, vars: &[T], f: F) -> Res<Vec<CTerm<'tm>>>
+    where
+        F: Fn(&T) -> &usize,
+    {
         for v in vars {
-            self.locals.remove(&v.1);
+            self.locals.remove(f(v));
         }
         self.scope_stack
             .pop()
@@ -827,98 +870,6 @@ impl<'tm> Cvc5Env<'tm> {
         Ok(self.tm.mk_term(kind, &[bvl, cbody]).into())
     }
 
-    fn translate_matching(
-        &mut self,
-        cscrutinee: &CTerm<'tm>,
-        arms: &[alg::PatternArm<Str, Term>],
-    ) -> Res<CTerm<'tm>> {
-        let scr_sort = cscrutinee.sort();
-        let dt = scr_sort.datatype();
-        // For parametric datatypes, selector codomain sorts are uninstantiated (e.g. X).
-        // We need to substitute the sort parameters with the actual instantiated parameters.
-        let subst: Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)> = if dt.is_parametric() {
-            let params = dt.parameters();
-            let inst_params = scr_sort.instantiated_parameters();
-            Some((params, inst_params))
-        } else {
-            None
-        };
-
-        let mut cases = Vec::with_capacity(arms.len());
-        for arm in arms {
-            let case = match &arm.pattern {
-                alg::Pattern::Ctor(name) => {
-                    let ctor = dt.constructor_by_name(name);
-                    let ctor_term = if dt.is_parametric() {
-                        ctor.instantiated_term(scr_sort.clone())
-                    } else {
-                        ctor.term()
-                    };
-                    let ctor_app = self.tm.mk_term(Kind::ApplyConstructor, &[ctor_term]);
-                    let cbody = arm.body.to_cvc5(self, arena)?;
-                    self.tm.mk_term(Kind::MatchCase, &[ctor_app, cbody])
-                }
-                alg::Pattern::Applied {
-                    ctor: name,
-                    arguments,
-                } => {
-                    // Use the scrutinee's (instantiated) datatype for pattern constructors
-                    // and selector sorts.
-                    let ctor = dt.constructor_by_name(name);
-                    let mut vars = Vec::with_capacity(arguments.len());
-                    let mut pattern_args = Vec::new();
-                    for (i, arg) in arguments.iter().enumerate() {
-                        let mut sel_sort = ctor.selector(i).codomain_sort();
-                        if let Some((ref params, ref inst)) = subst {
-                            sel_sort = sel_sort.substitute_sorts(params, inst);
-                        }
-                        let pv = match arg {
-                            Some((_, id)) => {
-                                let bv = self.tm.mk_anonymous_var(sel_sort);
-                                self.locals.insert(*id, bv.clone());
-                                bv
-                            }
-                            None => self.tm.mk_anonymous_var(sel_sort),
-                        };
-                        vars.push(pv.clone());
-                        pattern_args.push(pv);
-                    }
-                    let mut pat_children = vec![ctor.term()];
-                    pat_children.extend(pattern_args);
-                    let pattern = self.tm.mk_term(Kind::ApplyConstructor, &pat_children);
-                    let vlist = self.tm.mk_term(Kind::VariableList, &vars);
-                    let cbody = arm.body.to_cvc5(self, &mut ());
-                    for (_, id) in arguments.iter().flatten() {
-                        self.locals.remove(id);
-                    }
-                    let cbody = cbody?;
-                    self.tm
-                        .mk_term(Kind::MatchBindCase, &[vlist, pattern, cbody])
-                }
-                alg::Pattern::Wildcard(binding) => {
-                    let pv = self.tm.mk_anonymous_var(scr_sort.clone());
-                    if let Some((_, id)) = binding {
-                        self.locals.insert(*id, pv.clone());
-                    }
-                    let vlist = self
-                        .tm
-                        .mk_term(Kind::VariableList, std::slice::from_ref(&pv));
-                    let cbody = arm.body.to_cvc5(self, arena);
-                    if let Some((_, id)) = binding {
-                        self.locals.remove(id);
-                    }
-                    let cbody = cbody?;
-                    self.tm.mk_term(Kind::MatchBindCase, &[vlist, pv, cbody])
-                }
-            };
-            cases.push(case);
-        }
-
-        let mut match_children = vec![cscrutinee];
-        match_children.extend(cases);
-        Ok(self.tm.mk_term(Kind::Match, &match_children))
-    }
-
     fn translate_app(
         &mut self,
         qid: &QualifiedIdentifier,
@@ -931,10 +882,10 @@ impl<'tm> Cvc5Env<'tm> {
         if let Some(IdentifierKind::Sub) = kind
             && cargs.len() == 1
         {
-            return Ok(self.tm.mk_term(Kind::Neg, &cargs));
+            return Ok(self.tm.mk_term(Kind::Neg, &cargs).into());
         }
         if let Some(kind) = kind.as_ref().and_then(ident_kind_to_cvc5) {
-            return Ok(self.tm.mk_term(kind, &cargs));
+            return Ok(self.tm.mk_term(kind, &cargs).into());
         }
         if let Some(ref ik) = kind {
             return self.translate_indexed_app(ik, cargs);
@@ -964,11 +915,11 @@ impl<'tm> Cvc5Env<'tm> {
         &self,
         ik: &IdentifierKind,
         cargs: Vec<CTerm<'tm>>,
-    ) -> Res<CTerm<'tm>> {
+    ) -> Res<WithPattern<'tm>> {
         use alg::IdentifierKind::*;
         let mk = |kind, indices: &[u32]| {
             let op = self.tm.mk_op(kind, indices);
-            Ok(self.tm.mk_term_from_op(op, &cargs))
+            Ok(self.tm.mk_term_from_op(op, &cargs).into())
         };
         let to_u32 = |n: &dashu::integer::UBig| -> Res<u32> {
             n.try_into().map_err(|_| format!("index too large: {n}"))

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -35,7 +35,7 @@
 //! let mut env = Cvc5Env::create(&tm);
 //! let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
 //! for cmd in &cmds {
-//!     cmd.to_cvc5(&mut es, &mut ctx).unwrap();
+//!     cmd.to_cvc5(&mut es).unwrap();
 //! }
 //! ```
 //!
@@ -86,13 +86,13 @@ pub enum CommandResult<'tm> {
 }
 
 /// Convert a yaspar-ir typed AST node to its cvc5 counterpart.
-pub trait ConvertToCvc5<Env, A> {
+pub trait ConvertToCvc5<Env> {
     type Output;
-    fn to_cvc5(&self, env: &mut Env, arena: &mut A) -> Res<Self::Output>;
+    fn to_cvc5(&self, env: &mut Env) -> Res<Self::Output>;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-struct WithPattern<'tm> {
+pub struct WithPattern<'tm> {
     term: CTerm<'tm>,
     patterns: Vec<CTerm<'tm>>,
 }
@@ -115,11 +115,11 @@ impl<'tm> From<CTerm<'tm>> for WithPattern<'tm> {
 /// Environment for translating yaspar-ir ASTs to cvc5 objects.
 pub struct Cvc5EnvInner<'tm> {
     tm: &'tm TermManager,
-    sort: HashMap<Str, CSort<'tm>>,
-    globals: HashMap<Str, CTerm<'tm>>,
+    sort: HashMap<String, CSort<'tm>>,
+    globals: HashMap<String, CTerm<'tm>>,
     locals: HashMap<usize, WithPattern<'tm>>,
     sort_cache: HashMap<Sort, CSort<'tm>>,
-    dt_sorts: HashMap<Str, CSort<'tm>>,
+    dt_sorts: HashMap<String, CSort<'tm>>,
     scope_stack: Vec<Vec<CTerm<'tm>>>,
     sort_subst_map: HashMap<Term, Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)>>,
 }
@@ -159,26 +159,22 @@ impl<'a, 'tm> Cvc5EnvSolver<'a, 'tm> {
 }
 
 // ── Sort translation ─────────────────────────────────────────
-impl<'tm, A> ConvertToCvc5<Cvc5EnvInner<'tm>, A> for Sort {
+impl<'tm> ConvertToCvc5<Cvc5EnvInner<'tm>> for Sort {
     type Output = CSort<'tm>;
 
-    fn to_cvc5(&self, env: &mut Cvc5EnvInner<'tm>, arena: &mut A) -> Res<CSort<'tm>> {
+    fn to_cvc5(&self, env: &mut Cvc5EnvInner<'tm>) -> Res<CSort<'tm>> {
         if let Some(cs) = env.sort_cache.get(self) {
             return Ok(cs.clone());
         }
-        let cs = translate_sort_inner(self, env, arena)?;
+        let cs = translate_sort_inner(self, env)?;
         env.sort_cache.insert(self.clone(), cs.clone());
         Ok(cs)
     }
 }
 
-fn translate_sort_inner<'tm, A>(
-    sort: &Sort,
-    env: &mut Cvc5EnvInner<'tm>,
-    arena: &mut A,
-) -> Res<CSort<'tm>> {
+fn translate_sort_inner<'tm>(sort: &Sort, env: &mut Cvc5EnvInner<'tm>) -> Res<CSort<'tm>> {
     let s = sort.repr();
-    let name = s.sort_name();
+    let name = &s.sort_name().to_string();
     if let Some(n) = s.is_bv() {
         let w: u32 = n
             .clone()
@@ -194,7 +190,7 @@ fn translate_sort_inner<'tm, A>(
         if s.1.is_empty() {
             return Ok(cs);
         }
-        let params: Vec<CSort> = s.1.to_cvc5(env, arena)?;
+        let params: Vec<CSort> = s.1.to_cvc5(env)?;
         return Ok(cs.instantiate(&params));
     }
     if let Some(cs) = env.sort.get(name).cloned() {
@@ -202,7 +198,7 @@ fn translate_sort_inner<'tm, A>(
             return Ok(cs);
         }
         // Parametric sort: instantiate with translated parameters
-        let params: Vec<CSort> = s.1.to_cvc5(env, arena)?;
+        let params: Vec<CSort> = s.1.to_cvc5(env)?;
         return Ok(cs.instantiate(&params));
     }
     if sort.is_bool() {
@@ -221,20 +217,20 @@ fn translate_sort_inner<'tm, A>(
         return Ok(env.tm.regexp_sort());
     }
     if let Some((idx, elem)) = sort.is_array() {
-        let ci = idx.to_cvc5(env, arena)?;
-        let ce = elem.to_cvc5(env, arena)?;
+        let ci = idx.to_cvc5(env)?;
+        let ce = elem.to_cvc5(env)?;
         return Ok(env.tm.mk_array_sort(ci, ce));
     }
 
     Err(format!("unsupported sort: {sort}"))
 }
 
-impl<'tm, A> ConvertToCvc5<Cvc5Env<'tm>, A> for Sort {
+impl<'tm> ConvertToCvc5<Cvc5Env<'tm>> for Sort {
     type Output = CSort<'tm>;
 
     #[inline]
-    fn to_cvc5(&self, env: &mut Cvc5Env<'tm>, arena: &mut A) -> Res<Self::Output> {
-        self.to_cvc5(&mut env.inner, arena)
+    fn to_cvc5(&self, env: &mut Cvc5Env<'tm>) -> Res<Self::Output> {
+        self.to_cvc5(&mut env.inner)
     }
 }
 
@@ -337,10 +333,10 @@ fn ident_kind_to_cvc5(k: &alg::IdentifierKind<Str>) -> Option<Kind> {
 }
 
 // ── Term translation ─────────────────────────────────────────
-impl<'tm, A> ConvertToCvc5<Cvc5Env<'tm>, A> for Term {
+impl<'tm> ConvertToCvc5<Cvc5Env<'tm>> for Term {
     type Output = CTerm<'tm>;
 
-    fn to_cvc5(&self, env: &mut Cvc5Env<'tm>, arena: &mut A) -> Res<CTerm<'tm>> {
+    fn to_cvc5(&self, env: &mut Cvc5Env<'tm>) -> Res<Self::Output> {
         env.recurse_on_term(self).map(|t| t.into())
     }
 }
@@ -718,14 +714,14 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
 impl<'tm> TypedTermRecursor for Cvc5EnvInner<'tm> {}
 
-impl<'tm, T, A, E> ConvertToCvc5<Cvc5EnvInner<'tm>, A> for [T]
+impl<T, Env, E> ConvertToCvc5<Env> for [T]
 where
-    T: ConvertToCvc5<Cvc5EnvInner<'tm>, A, Output = E>,
+    T: ConvertToCvc5<Env, Output = E>,
 {
     type Output = Vec<E>;
 
-    fn to_cvc5(&self, env: &mut Cvc5EnvInner<'tm>, arena: &mut A) -> Res<Vec<E>> {
-        self.iter().map(|t| t.to_cvc5(env, arena)).collect()
+    fn to_cvc5(&self, env: &mut Env) -> Res<Self::Output> {
+        self.iter().map(|t| t.to_cvc5(env)).collect()
     }
 }
 
@@ -777,11 +773,11 @@ impl<'tm> Cvc5EnvInner<'tm> {
     /// instantiated term if the datatype is parametric. Returns `None` when the sort
     /// is not in the sort table, the datatype is not parametric, or no constructor matches.
     fn resolve_parametric_ctor(&mut self, name: &str, sort: &Sort) -> Res<Option<CTerm<'tm>>> {
-        let sort_name = sort.repr().sort_name();
+        let sort_name = &sort.sort_name().to_string();
         if let Some(base_sort) = self.sort.get(sort_name).cloned() {
             let dt = base_sort.datatype();
             if dt.is_parametric() {
-                let crs = sort.to_cvc5(self, &mut ())?;
+                let crs = sort.to_cvc5(self)?;
                 for i in 0..dt.num_constructors() {
                     let ctor = dt.constructor(i);
                     if ctor.name() == name {
@@ -799,7 +795,7 @@ impl<'tm> Cvc5EnvInner<'tm> {
         sort: &Sort,
     ) -> Res<WithPattern<'tm>> {
         use alg::IdentifierKind::*;
-        let name = qid.id_str();
+        let name = &qid.id_str().to_string();
         match qid.get_kind() {
             Some(Char(hex, _)) => Ok(self
                 .tm
@@ -836,7 +832,7 @@ impl<'tm> Cvc5EnvInner<'tm> {
     fn bind_vars(&mut self, vars: &[VarBinding<Str, Sort>]) -> Res<()> {
         let mut bound = Vec::with_capacity(vars.len());
         for v in vars {
-            let cs = v.2.to_cvc5(self, &mut ())?;
+            let cs = v.2.to_cvc5(self)?;
             let bv = self.tm.mk_var(cs, &v.0);
             self.locals.insert(v.1, bv.clone().into());
             bound.push(bv);
@@ -900,7 +896,7 @@ impl<'tm> Cvc5EnvInner<'tm> {
         if let Some(ref ik) = kind {
             return self.translate_indexed_app(ik, cargs);
         }
-        let name = &id.symbol;
+        let name = &id.symbol.to_string();
         if let Some(f) = self.globals.get(name).cloned() {
             let fs = f.sort();
             if fs.is_dt_constructor() {
@@ -967,10 +963,10 @@ impl<'tm> Cvc5EnvInner<'tm> {
 }
 
 // ── Command translation ──────────────────────────────────────
-impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm>, A> for Command {
+impl<'tm> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm>> for Command {
     type Output = CommandResult<'tm>;
 
-    fn to_cvc5(&self, es: &mut Cvc5EnvSolver<'_, 'tm>, arena: &mut A) -> Res<CommandResult<'tm>> {
+    fn to_cvc5(&self, es: &mut Cvc5EnvSolver<'_, 'tm>) -> Res<Self::Output> {
         use alg::Command as AC;
         let env = &mut *es.env;
         let solver = &mut *es.solver;
@@ -996,21 +992,21 @@ impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm>, A> for Command {
                 Ok(CommandResult::None)
             }
             AC::DeclareConst(name, sort) => {
-                let cs = sort.to_cvc5(env, arena)?;
+                let cs = sort.to_cvc5(env)?;
                 let ct = env.tm.mk_const(cs, name);
-                env.globals.insert(name.clone(), ct);
+                env.globals.insert(name.to_string(), ct);
                 Ok(CommandResult::None)
             }
             AC::DeclareFun(name, inp, out) => {
-                let co = out.to_cvc5(env, arena)?;
+                let co = out.to_cvc5(env)?;
                 if inp.is_empty() {
                     let ct = env.tm.mk_const(co, name);
-                    env.globals.insert(name.clone(), ct);
+                    env.globals.insert(name.to_string(), ct);
                 } else {
-                    let ci = inp.to_cvc5(env, arena)?;
+                    let ci = inp.to_cvc5(env)?;
                     let fs = env.tm.mk_fun_sort(&ci, co);
                     let ct = env.tm.mk_const(fs, name);
-                    env.globals.insert(name.clone(), ct);
+                    env.globals.insert(name.to_string(), ct);
                 }
                 Ok(CommandResult::None)
             }
@@ -1020,7 +1016,7 @@ impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm>, A> for Command {
                 } else {
                     env.tm.mk_uninterpreted_sort_constructor_sort(*arity, name)
                 };
-                env.sort.insert(name.clone(), cs);
+                env.sort.insert(name.to_string(), cs);
                 Ok(CommandResult::None)
             }
             AC::DefineSort(..) => {
@@ -1028,21 +1024,18 @@ impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm>, A> for Command {
                 Ok(CommandResult::None)
             }
             AC::DefineConst(name, _sort, body) => {
-                let cbody = body.to_cvc5(env, arena)?;
-                env.globals.insert(name.clone(), cbody);
+                let cbody = body.to_cvc5(env)?;
+                env.globals.insert(name.to_string(), cbody);
                 Ok(CommandResult::None)
             }
-            AC::DefineFun(fd) => es.translate_define_fun(fd, false, arena),
-            AC::DefineFunRec(fd) => es.translate_define_fun(fd, true, arena),
-            AC::DefineFunsRec(fds) => es.translate_define_funs_rec(fds, arena),
-            AC::DeclareDatatype(name, dec) => es.translate_declare_datatypes(
-                &[alg::DatatypeDef {
-                    name: name.clone(),
-                    dec: dec.clone(),
-                }],
-                arena,
-            ),
-            AC::DeclareDatatypes(defs) => es.translate_declare_datatypes(defs, arena),
+            AC::DefineFun(fd) => es.translate_define_fun(fd, false),
+            AC::DefineFunRec(fd) => es.translate_define_fun(fd, true),
+            AC::DefineFunsRec(fds) => es.translate_define_funs_rec(fds),
+            AC::DeclareDatatype(name, dec) => es.translate_declare_datatypes(&[alg::DatatypeDef {
+                name: name.clone(),
+                dec: dec.clone(),
+            }]),
+            AC::DeclareDatatypes(defs) => es.translate_declare_datatypes(defs),
             AC::Assert(t) => {
                 // Peel outermost :named annotations
                 let mut names = Vec::new();
@@ -1055,9 +1048,9 @@ impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm>, A> for Command {
                     }
                     cur = inner;
                 }
-                let ct = cur.to_cvc5(env, arena)?;
+                let ct = cur.to_cvc5(env)?;
                 for name in names {
-                    env.globals.insert(name, ct.clone());
+                    env.globals.insert(name.to_string(), ct.clone());
                 }
                 solver.assert_formula(CTerm::clone(&ct));
                 Ok(CommandResult::None)
@@ -1067,12 +1060,12 @@ impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm>, A> for Command {
                 Ok(CommandResult::CheckSat(r))
             }
             AC::CheckSatAssuming(terms) => {
-                let cts = terms.to_cvc5(env, arena)?;
+                let cts = terms.to_cvc5(env)?;
                 let r = solver.check_sat_assuming(&cts);
                 Ok(CommandResult::CheckSat(r))
             }
             AC::GetValue(terms) => {
-                let cts = terms.to_cvc5(env, arena)?;
+                let cts = terms.to_cvc5(env)?;
                 let vals = solver.get_values(&cts);
                 Ok(CommandResult::GetValue(vals))
             }
@@ -1123,31 +1116,29 @@ impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm>, A> for Command {
 
 // ── Command helper methods ───────────────────────────────────
 impl<'tm> Cvc5EnvSolver<'_, 'tm> {
-    fn translate_define_fun<A: HasArenaAlt>(
+    fn translate_define_fun(
         &mut self,
         fd: &alg::FunctionDef<Str, Sort, Term>,
         recursive: bool,
-        arena: &mut A,
     ) -> Res<CommandResult<'tm>> {
         let env = &mut *self.env;
-        let out = fd.out_sort.to_cvc5(env, arena)?;
+        let out = fd.out_sort.to_cvc5(env)?;
         env.bind_vars(&fd.vars)?;
-        let body = fd.body.to_cvc5(env, arena);
-        let vars = env.unbind_vars(&fd.vars)?;
+        let body = fd.body.to_cvc5(env);
+        let vars = env.unbind_vars(&fd.vars, |v| &v.1)?;
         let body = body?;
         let ct = if recursive {
             self.solver.define_fun_rec(&fd.name, &vars, out, body, true)
         } else {
             self.solver.define_fun(&fd.name, &vars, out, body, true)
         };
-        self.env.globals.insert(fd.name.clone(), ct);
+        self.env.globals.insert(fd.name.to_string(), ct);
         Ok(CommandResult::None)
     }
 
-    fn translate_define_funs_rec<A: HasArenaAlt>(
+    fn translate_define_funs_rec(
         &mut self,
         fds: &[alg::FunctionDef<Str, Sort, Term>],
-        arena: &mut A,
     ) -> Res<CommandResult<'tm>> {
         let env = &mut *self.env;
         // First pass: declare all function constants so they can reference each other
@@ -1156,9 +1147,9 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm> {
         for fd in fds {
             let mut inp = Vec::with_capacity(fd.vars.len());
             for v in &fd.vars {
-                inp.push(v.2.to_cvc5(env, arena)?);
+                inp.push(v.2.to_cvc5(env)?);
             }
-            let out = fd.out_sort.to_cvc5(env, arena)?;
+            let out = fd.out_sort.to_cvc5(env)?;
             out_sorts.push(out.clone());
             let fs = if inp.is_empty() {
                 out.clone()
@@ -1166,7 +1157,7 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm> {
                 env.tm.mk_fun_sort(&inp, out)
             };
             let ct = env.tm.mk_const(fs, &fd.name);
-            env.globals.insert(fd.name.clone(), ct.clone());
+            env.globals.insert(fd.name.to_string(), ct.clone());
             funs.push(ct);
         }
         // Second pass: translate bodies
@@ -1174,8 +1165,8 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm> {
         let mut bodies = Vec::with_capacity(fds.len());
         for fd in fds {
             env.bind_vars(&fd.vars)?;
-            let body = fd.body.to_cvc5(env, arena);
-            let vars = env.unbind_vars(&fd.vars)?;
+            let body = fd.body.to_cvc5(env);
+            let vars = env.unbind_vars(&fd.vars, |v| &v.1)?;
             all_vars.push(vars);
             bodies.push(body?);
         }
@@ -1184,39 +1175,37 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm> {
         Ok(CommandResult::None)
     }
 
-    fn translate_declare_datatypes<A: HasArenaAlt>(
+    fn translate_declare_datatypes(
         &mut self,
         defs: &[alg::DatatypeDef<Str, Sort>],
-        arena: &mut A,
     ) -> Res<CommandResult<'tm>> {
         let env = &mut *self.env;
         // Pre-register unresolved sorts so self/mutual references resolve
         for def in defs {
             let arity = def.dec.params.len();
             let us = env.tm.mk_unresolved_dt_sort(&def.name, arity);
-            env.dt_sorts.insert(def.name.clone(), us);
+            env.dt_sorts.insert(def.name.to_string(), us);
         }
-        let result = Self::build_dt_decls(env, defs, arena);
+        let result = Self::build_dt_decls(env, defs);
         env.dt_sorts.clear();
         let decls = result?;
         if decls.len() == 1 {
             let cs = env.tm.mk_dt_sort(&decls[0]);
-            env.sort.insert(defs[0].name.clone(), cs.clone());
-            Self::register_dt_functions(env, cs, &defs[0].dec, arena);
+            env.sort.insert(defs[0].name.to_string(), cs.clone());
+            Self::register_dt_functions(env, cs, &defs[0].dec);
         } else {
             let sorts = env.tm.mk_dt_sorts(&decls);
             for (def, cs) in defs.iter().zip(sorts) {
-                env.sort.insert(def.name.clone(), cs.clone());
-                Self::register_dt_functions(env, cs, &def.dec, arena);
+                env.sort.insert(def.name.to_string(), cs.clone());
+                Self::register_dt_functions(env, cs, &def.dec);
             }
         }
         Ok(CommandResult::None)
     }
 
-    fn build_dt_decls<A: HasArenaAlt>(
+    fn build_dt_decls(
         env: &mut Cvc5EnvInner<'tm>,
         defs: &[alg::DatatypeDef<Str, Sort>],
-        arena: &mut A,
     ) -> Res<Vec<cvc5::DatatypeDecl<'tm>>> {
         let mut decls = Vec::with_capacity(defs.len());
         for def in defs {
@@ -1224,7 +1213,7 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm> {
             let cvc5_params: Vec<CSort<'tm>> =
                 params.iter().map(|p| env.tm.mk_param_sort(p)).collect();
             for (p, cs) in params.iter().zip(&cvc5_params) {
-                env.dt_sorts.insert(p.clone(), cs.clone());
+                env.dt_sorts.insert(p.to_string(), cs.clone());
             }
             let mut dt_decl = if cvc5_params.is_empty() {
                 env.tm.mk_dt_decl(&def.name, false)
@@ -1235,36 +1224,29 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm> {
             for ctor in &def.dec.constructors {
                 let mut ctor_decl = env.tm.mk_dt_cons_decl(&ctor.ctor);
                 for sel in &ctor.args {
-                    let ss = sel.2.to_cvc5(env, arena)?;
+                    let ss = sel.2.to_cvc5(env)?;
                     ctor_decl.add_selector(&sel.0, ss);
                 }
                 dt_decl.add_constructor(&ctor_decl);
             }
             for p in params {
-                env.dt_sorts.remove(p);
+                env.dt_sorts.remove(p.as_str());
             }
             decls.push(dt_decl);
         }
         Ok(decls)
     }
 
-    fn register_dt_functions<A: HasArenaAlt>(
-        env: &mut Cvc5EnvInner<'tm>,
-        sort: CSort<'tm>,
-        dec: &DatatypeDec,
-        arena: &mut A,
-    ) {
-        let a = arena.arena_alt();
+    fn register_dt_functions(env: &mut Cvc5EnvInner<'tm>, sort: CSort<'tm>, dec: &DatatypeDec) {
         let dt = sort.datatype();
         for (i, ctor_dec) in dec.constructors.iter().enumerate() {
             let ctor = dt.constructor(i);
-            env.globals.insert(ctor_dec.ctor.clone(), ctor.term());
+            env.globals.insert(ctor_dec.ctor.to_string(), ctor.term());
             let tester = ctor.tester_term();
-            let is_name = a.allocate_symbol(&format!("is-{}", ctor.name()));
-            env.globals.insert(is_name, tester);
+            env.globals.insert(format!("is-{}", ctor.name()), tester);
             for (j, sel_dec) in ctor_dec.args.iter().enumerate() {
                 let sel = ctor.selector(j);
-                env.globals.insert(sel_dec.0.clone(), sel.term());
+                env.globals.insert(sel_dec.0.to_string(), sel.term());
             }
         }
     }

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -1,15 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Translation from yaspar-ir typed ASTs to cvc5-rs objects.
+//! Translation from yaspar-ir typed ASTs to cvc5 objects.
 //!
 //! This module provides the [`ConvertToCvc5`] trait and two environment types for translating
-//! yaspar-ir typed ASTs into their cvc5-rs counterparts. It requires the `cvc5` feature.
+//! yaspar-ir typed ASTs into their cvc5 counterparts. It requires the `cvc5` feature.
 //!
 //! # Overview
 //!
 //! - [`ConvertToCvc5<Env, A>`] — the core trait, implemented for [`Sort`], [`Term`], and [`Command`].
-//! - [`Cvc5Env`] — holds a [`cvc5_rs::TermManager`] and caches for sort/term/symbol translation.
+//! - [`Cvc5Env`] — holds a [`cvc5::TermManager`] and caches for sort/term/symbol translation.
 //!   Used as the environment for `Sort::to_cvc5` and `Term::to_cvc5`.
 //! - [`Cvc5EnvSolver`] — wraps a [`Cvc5Env`] and a [`Solver`]. Used as the environment
 //!   for `Command::to_cvc5`, since commands may interact with the solver (e.g. `assert`,
@@ -18,7 +18,7 @@
 //! # Example
 //!
 //! ```rust
-//! use cvc5_rs::{Solver, TermManager};
+//! use cvc5::{Solver, TermManager};
 //! use yaspar_ir::ast::{Context, Typecheck};
 //! use yaspar_ir::cvc5::{ConvertToCvc5, Cvc5Env, Cvc5EnvSolver};
 //! use yaspar_ir::untyped::UntypedAst;
@@ -53,58 +53,57 @@ use crate::ast::*;
 use crate::raw::alg;
 use crate::raw::alg::CheckIdentifier;
 use crate::traits::{Contains, Repr};
-pub use cvc5_rs::{Kind, ProofComponent, Solver, TermManager};
-use std::borrow::Borrow;
+pub use cvc5::{Kind, ProofComponent, Solver, TermManager};
 use std::collections::HashMap;
 use yaspar::{binary_to_string, hex_to_string};
 
-pub type CSort = cvc5_rs::Sort;
-pub type CTerm = cvc5_rs::Term;
-pub type CResult = cvc5_rs::Result;
-pub type CProof = cvc5_rs::Proof;
+pub type CSort<'tm> = cvc5::Sort<'tm>;
+pub type CTerm<'tm> = cvc5::Term<'tm>;
+pub type CResult<'tm> = cvc5::Result<'tm>;
+pub type CProof<'tm> = cvc5::Proof<'tm>;
 type Res<T> = std::result::Result<T, String>;
 
 /// The result of translating and executing a single SMTLib command via cvc5.
 #[derive(Debug)]
-pub enum CommandResult {
+pub enum CommandResult<'tm> {
     /// No meaningful return value (declarations, definitions, `assert`, `set-logic`,
     /// `set-info`, `set-option`, `define-sort`, `reset-assertions`, `echo`, `exit`).
     None,
     /// Result of `check-sat` or `check-sat-assuming`.
-    CheckSat(CResult),
+    CheckSat(CResult<'tm>),
     /// Result of `get-value`: a list of terms.
-    GetValue(Vec<CTerm>),
+    GetValue(Vec<CTerm<'tm>>),
     /// Result of `get-model`: the model as a string.
     GetModel(String),
     /// Result of `get-assertions`, `get-unsat-core`, or `get-unsat-assumptions`: a list of terms.
-    Terms(Vec<CTerm>),
+    Terms(Vec<CTerm<'tm>>),
     /// Result of `get-info` or `get-option`: a string response.
     Info(String),
     /// Result of `get-proof`: the full proof tree.
-    GetProof(Vec<CProof>),
+    GetProof(Vec<CProof<'tm>>),
 }
 
-/// Convert a yaspar-ir typed AST node to its cvc5-rs counterpart.
+/// Convert a yaspar-ir typed AST node to its cvc5 counterpart.
 pub trait ConvertToCvc5<Env, A> {
     type Output;
     fn to_cvc5(&self, env: &mut Env, arena: &mut A) -> Res<Self::Output>;
 }
 
-/// Environment for translating yaspar-ir ASTs to cvc5-rs objects.
-pub struct Cvc5Env {
-    tm: TermManager,
-    sort: HashMap<Str, CSort>,
-    globals: HashMap<Str, CTerm>,
-    locals: HashMap<usize, CTerm>,
-    sort_cache: HashMap<Sort, CSort>,
-    term_cache: HashMap<Term, CTerm>,
-    dt_sorts: HashMap<Str, CSort>,
+/// Environment for translating yaspar-ir ASTs to cvc5 objects.
+pub struct Cvc5Env<'tm> {
+    tm: &'tm TermManager,
+    sort: HashMap<Str, CSort<'tm>>,
+    globals: HashMap<Str, CTerm<'tm>>,
+    locals: HashMap<usize, CTerm<'tm>>,
+    sort_cache: HashMap<Sort, CSort<'tm>>,
+    term_cache: HashMap<Term, CTerm<'tm>>,
+    dt_sorts: HashMap<Str, CSort<'tm>>,
 }
 
-impl Cvc5Env {
-    pub fn new(tm: impl Borrow<TermManager>) -> Self {
+impl<'tm> Cvc5Env<'tm> {
+    pub fn new(tm: &'tm TermManager) -> Self {
         Self {
-            tm: tm.borrow().clone(),
+            tm,
             sort: HashMap::new(),
             globals: HashMap::new(),
             locals: HashMap::new(),
@@ -116,22 +115,22 @@ impl Cvc5Env {
 }
 
 /// Environment combining a [`Cvc5Env`] with a [`Solver`] for translating commands.
-pub struct Cvc5EnvSolver<'a> {
-    pub env: &'a mut Cvc5Env,
-    pub solver: &'a mut Solver,
+pub struct Cvc5EnvSolver<'a, 'tm> {
+    pub env: &'a mut Cvc5Env<'tm>,
+    pub solver: &'a mut Solver<'tm>,
 }
 
-impl<'a> Cvc5EnvSolver<'a> {
-    pub fn new(env: &'a mut Cvc5Env, solver: &'a mut Solver) -> Self {
+impl<'a, 'tm> Cvc5EnvSolver<'a, 'tm> {
+    pub fn new(env: &'a mut Cvc5Env<'tm>, solver: &'a mut Solver<'tm>) -> Self {
         Self { env, solver }
     }
 }
 
 // ── Sort translation ─────────────────────────────────────────
-impl<A: HasArenaAlt> ConvertToCvc5<Cvc5Env, A> for Sort {
-    type Output = CSort;
+impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5Env<'tm>, A> for Sort {
+    type Output = CSort<'tm>;
 
-    fn to_cvc5(&self, env: &mut Cvc5Env, arena: &mut A) -> Res<CSort> {
+    fn to_cvc5(&self, env: &mut Cvc5Env<'tm>, arena: &mut A) -> Res<CSort<'tm>> {
         if let Some(cs) = env.sort_cache.get(self) {
             return Ok(cs.clone());
         }
@@ -141,11 +140,11 @@ impl<A: HasArenaAlt> ConvertToCvc5<Cvc5Env, A> for Sort {
     }
 }
 
-fn translate_sort_inner<A: HasArenaAlt>(
+fn translate_sort_inner<'tm, A: HasArenaAlt>(
     sort: &Sort,
-    env: &mut Cvc5Env,
+    env: &mut Cvc5Env<'tm>,
     arena: &mut A,
-) -> Res<CSort> {
+) -> Res<CSort<'tm>> {
     let s = sort.repr();
     let name = s.sort_name();
     if let Some(n) = s.is_bv() {
@@ -202,105 +201,105 @@ fn translate_sort_inner<A: HasArenaAlt>(
 fn ident_kind_to_cvc5(k: &alg::IdentifierKind<Str>) -> Option<Kind> {
     use alg::IdentifierKind::*;
     Some(match k {
-        Add => Kind::CVC5_KIND_ADD,
-        Sub => Kind::CVC5_KIND_SUB,
-        Mul => Kind::CVC5_KIND_MULT,
-        Idiv => Kind::CVC5_KIND_INTS_DIVISION,
-        Rdiv => Kind::CVC5_KIND_DIVISION,
-        Mod => Kind::CVC5_KIND_INTS_MODULUS,
-        Abs => Kind::CVC5_KIND_ABS,
-        Le => Kind::CVC5_KIND_LEQ,
-        Lt => Kind::CVC5_KIND_LT,
-        Ge => Kind::CVC5_KIND_GEQ,
-        Gt => Kind::CVC5_KIND_GT,
-        ToReal => Kind::CVC5_KIND_TO_REAL,
-        ToInt => Kind::CVC5_KIND_TO_INTEGER,
-        IsInt => Kind::CVC5_KIND_IS_INTEGER,
-        Select => Kind::CVC5_KIND_SELECT,
-        Store => Kind::CVC5_KIND_STORE,
-        StrConcat => Kind::CVC5_KIND_STRING_CONCAT,
-        StrLen => Kind::CVC5_KIND_STRING_LENGTH,
-        StrLt => Kind::CVC5_KIND_STRING_LT,
-        StrLe => Kind::CVC5_KIND_STRING_LEQ,
-        StrAt => Kind::CVC5_KIND_STRING_CHARAT,
-        StrSubstr => Kind::CVC5_KIND_STRING_SUBSTR,
-        StrPrefixof => Kind::CVC5_KIND_STRING_PREFIX,
-        StrSuffixof => Kind::CVC5_KIND_STRING_SUFFIX,
-        StrContains => Kind::CVC5_KIND_STRING_CONTAINS,
-        StrIndexof => Kind::CVC5_KIND_STRING_INDEXOF,
-        StrReplace => Kind::CVC5_KIND_STRING_REPLACE,
-        StrReplaceAll => Kind::CVC5_KIND_STRING_REPLACE_ALL,
-        StrReplaceRe => Kind::CVC5_KIND_STRING_REPLACE_RE,
-        StrReplaceReAll => Kind::CVC5_KIND_STRING_REPLACE_RE_ALL,
-        StrToRe => Kind::CVC5_KIND_STRING_TO_REGEXP,
-        StrInRe => Kind::CVC5_KIND_STRING_IN_REGEXP,
-        StrIsDigit => Kind::CVC5_KIND_STRING_IS_DIGIT,
-        StrToCode => Kind::CVC5_KIND_STRING_TO_CODE,
-        StrFromCode => Kind::CVC5_KIND_STRING_FROM_CODE,
-        StrToInt => Kind::CVC5_KIND_STRING_TO_INT,
-        StrFromInt => Kind::CVC5_KIND_STRING_FROM_INT,
-        ReNone => Kind::CVC5_KIND_REGEXP_NONE,
-        ReAll => Kind::CVC5_KIND_REGEXP_ALL,
-        ReAllChar => Kind::CVC5_KIND_REGEXP_ALLCHAR,
-        ReConcat => Kind::CVC5_KIND_REGEXP_CONCAT,
-        ReUnion => Kind::CVC5_KIND_REGEXP_UNION,
-        ReInter => Kind::CVC5_KIND_REGEXP_INTER,
-        ReStar => Kind::CVC5_KIND_REGEXP_STAR,
-        ReComp => Kind::CVC5_KIND_REGEXP_COMPLEMENT,
-        ReDiff => Kind::CVC5_KIND_REGEXP_DIFF,
-        ReAdd => Kind::CVC5_KIND_REGEXP_PLUS,
-        ReOpt => Kind::CVC5_KIND_REGEXP_OPT,
-        ReRange => Kind::CVC5_KIND_REGEXP_RANGE,
-        Concat => Kind::CVC5_KIND_BITVECTOR_CONCAT,
-        BvNot => Kind::CVC5_KIND_BITVECTOR_NOT,
-        BvNeg => Kind::CVC5_KIND_BITVECTOR_NEG,
-        BvAnd => Kind::CVC5_KIND_BITVECTOR_AND,
-        BvOr => Kind::CVC5_KIND_BITVECTOR_OR,
-        BvAdd => Kind::CVC5_KIND_BITVECTOR_ADD,
-        BvMul => Kind::CVC5_KIND_BITVECTOR_MULT,
-        BvUdiv => Kind::CVC5_KIND_BITVECTOR_UDIV,
-        BvUrem => Kind::CVC5_KIND_BITVECTOR_UREM,
-        BvShl => Kind::CVC5_KIND_BITVECTOR_SHL,
-        BvLshr => Kind::CVC5_KIND_BITVECTOR_LSHR,
-        BvUlt => Kind::CVC5_KIND_BITVECTOR_ULT,
-        BvNand => Kind::CVC5_KIND_BITVECTOR_NAND,
-        BvNor => Kind::CVC5_KIND_BITVECTOR_NOR,
-        BvXor => Kind::CVC5_KIND_BITVECTOR_XOR,
-        BvNxor => Kind::CVC5_KIND_BITVECTOR_XNOR,
-        BvComp => Kind::CVC5_KIND_BITVECTOR_COMP,
-        BvSub => Kind::CVC5_KIND_BITVECTOR_SUB,
-        BvSdiv => Kind::CVC5_KIND_BITVECTOR_SDIV,
-        BvSrem => Kind::CVC5_KIND_BITVECTOR_SREM,
-        BvSmod => Kind::CVC5_KIND_BITVECTOR_SMOD,
-        BvAShr => Kind::CVC5_KIND_BITVECTOR_ASHR,
-        BvUle => Kind::CVC5_KIND_BITVECTOR_ULE,
-        BvUgt => Kind::CVC5_KIND_BITVECTOR_UGT,
-        BvUge => Kind::CVC5_KIND_BITVECTOR_UGE,
-        BvSlt => Kind::CVC5_KIND_BITVECTOR_SLT,
-        BvSle => Kind::CVC5_KIND_BITVECTOR_SLE,
-        BvSgt => Kind::CVC5_KIND_BITVECTOR_SGT,
-        BvSge => Kind::CVC5_KIND_BITVECTOR_SGE,
-        BvNego => Kind::CVC5_KIND_BITVECTOR_NEGO,
-        BvUaddo => Kind::CVC5_KIND_BITVECTOR_UADDO,
-        BvSaddo => Kind::CVC5_KIND_BITVECTOR_SADDO,
-        BvUmulo => Kind::CVC5_KIND_BITVECTOR_UMULO,
-        BvSmulo => Kind::CVC5_KIND_BITVECTOR_SMULO,
-        UbvToInt => Kind::CVC5_KIND_BITVECTOR_UBV_TO_INT,
-        SbvToInt => Kind::CVC5_KIND_BITVECTOR_SBV_TO_INT,
-        Bv2Nat => Kind::CVC5_KIND_BITVECTOR_SBV_TO_INT,
-        Bv2Int => Kind::CVC5_KIND_BITVECTOR_SBV_TO_INT,
-        BvUsubo => Kind::CVC5_KIND_BITVECTOR_USUBO,
-        BvSsubo => Kind::CVC5_KIND_BITVECTOR_SSUBO,
-        BvSdivo => Kind::CVC5_KIND_BITVECTOR_SDIVO,
+        Add => Kind::Add,
+        Sub => Kind::Sub,
+        Mul => Kind::Mult,
+        Idiv => Kind::IntsDivision,
+        Rdiv => Kind::Division,
+        Mod => Kind::IntsModulus,
+        Abs => Kind::Abs,
+        Le => Kind::Leq,
+        Lt => Kind::Lt,
+        Ge => Kind::Geq,
+        Gt => Kind::Gt,
+        ToReal => Kind::ToReal,
+        ToInt => Kind::ToInteger,
+        IsInt => Kind::IsInteger,
+        Select => Kind::Select,
+        Store => Kind::Store,
+        StrConcat => Kind::StringConcat,
+        StrLen => Kind::StringLength,
+        StrLt => Kind::StringLt,
+        StrLe => Kind::StringLeq,
+        StrAt => Kind::StringCharat,
+        StrSubstr => Kind::StringSubstr,
+        StrPrefixof => Kind::StringPrefix,
+        StrSuffixof => Kind::StringSuffix,
+        StrContains => Kind::StringContains,
+        StrIndexof => Kind::StringIndexof,
+        StrReplace => Kind::StringReplace,
+        StrReplaceAll => Kind::StringReplaceAll,
+        StrReplaceRe => Kind::StringReplaceRe,
+        StrReplaceReAll => Kind::StringReplaceReAll,
+        StrToRe => Kind::StringToRegexp,
+        StrInRe => Kind::StringInRegexp,
+        StrIsDigit => Kind::StringIsDigit,
+        StrToCode => Kind::StringToCode,
+        StrFromCode => Kind::StringFromCode,
+        StrToInt => Kind::StringToInt,
+        StrFromInt => Kind::StringFromInt,
+        ReNone => Kind::RegexpNone,
+        ReAll => Kind::RegexpAll,
+        ReAllChar => Kind::RegexpAllchar,
+        ReConcat => Kind::RegexpConcat,
+        ReUnion => Kind::RegexpUnion,
+        ReInter => Kind::RegexpInter,
+        ReStar => Kind::RegexpStar,
+        ReComp => Kind::RegexpComplement,
+        ReDiff => Kind::RegexpDiff,
+        ReAdd => Kind::RegexpPlus,
+        ReOpt => Kind::RegexpOpt,
+        ReRange => Kind::RegexpRange,
+        Concat => Kind::BitvectorConcat,
+        BvNot => Kind::BitvectorNot,
+        BvNeg => Kind::BitvectorNeg,
+        BvAnd => Kind::BitvectorAnd,
+        BvOr => Kind::BitvectorOr,
+        BvAdd => Kind::BitvectorAdd,
+        BvMul => Kind::BitvectorMult,
+        BvUdiv => Kind::BitvectorUdiv,
+        BvUrem => Kind::BitvectorUrem,
+        BvShl => Kind::BitvectorShl,
+        BvLshr => Kind::BitvectorLshr,
+        BvUlt => Kind::BitvectorUlt,
+        BvNand => Kind::BitvectorNand,
+        BvNor => Kind::BitvectorNor,
+        BvXor => Kind::BitvectorXor,
+        BvNxor => Kind::BitvectorXnor,
+        BvComp => Kind::BitvectorComp,
+        BvSub => Kind::BitvectorSub,
+        BvSdiv => Kind::BitvectorSdiv,
+        BvSrem => Kind::BitvectorSrem,
+        BvSmod => Kind::BitvectorSmod,
+        BvAShr => Kind::BitvectorAshr,
+        BvUle => Kind::BitvectorUle,
+        BvUgt => Kind::BitvectorUgt,
+        BvUge => Kind::BitvectorUge,
+        BvSlt => Kind::BitvectorSlt,
+        BvSle => Kind::BitvectorSle,
+        BvSgt => Kind::BitvectorSgt,
+        BvSge => Kind::BitvectorSge,
+        BvNego => Kind::BitvectorNego,
+        BvUaddo => Kind::BitvectorUaddo,
+        BvSaddo => Kind::BitvectorSaddo,
+        BvUmulo => Kind::BitvectorUmulo,
+        BvSmulo => Kind::BitvectorSmulo,
+        UbvToInt => Kind::BitvectorUbvToInt,
+        SbvToInt => Kind::BitvectorSbvToInt,
+        Bv2Nat => Kind::BitvectorSbvToInt,
+        Bv2Int => Kind::BitvectorSbvToInt,
+        BvUsubo => Kind::BitvectorUsubo,
+        BvSsubo => Kind::BitvectorSsubo,
+        BvSdivo => Kind::BitvectorSdivo,
         _ => return None,
     })
 }
 
 // ── Term translation ─────────────────────────────────────────
-impl<A: HasArenaAlt> ConvertToCvc5<Cvc5Env, A> for Term {
-    type Output = CTerm;
+impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5Env<'tm>, A> for Term {
+    type Output = CTerm<'tm>;
 
-    fn to_cvc5(&self, env: &mut Cvc5Env, arena: &mut A) -> Res<CTerm> {
+    fn to_cvc5(&self, env: &mut Cvc5Env<'tm>, arena: &mut A) -> Res<CTerm<'tm>> {
         if let Some(ct) = env.term_cache.get(self) {
             return Ok(ct.clone());
         }
@@ -310,11 +309,11 @@ impl<A: HasArenaAlt> ConvertToCvc5<Cvc5Env, A> for Term {
     }
 }
 
-fn translate_term_inner<A: HasArenaAlt>(
+fn translate_term_inner<'tm, A: HasArenaAlt>(
     term: &Term,
-    env: &mut Cvc5Env,
+    env: &mut Cvc5Env<'tm>,
     arena: &mut A,
-) -> Res<CTerm> {
+) -> Res<CTerm<'tm>> {
     use alg::Term as AT;
     match term.repr() {
         AT::Constant(c, _) => env.translate_constant(c),
@@ -330,36 +329,36 @@ fn translate_term_inner<A: HasArenaAlt>(
             .ok_or_else(|| format!("unbound local: {}", loc.symbol)),
         AT::Not(t) => {
             let nt = t.to_cvc5(env, arena)?;
-            Ok(env.tm.mk_term(Kind::CVC5_KIND_NOT, &[nt]))
+            Ok(env.tm.mk_term(Kind::Not, &[nt]))
         }
         AT::Eq(a, b) => {
             let (ca, cb) = (a.to_cvc5(env, arena)?, b.to_cvc5(env, arena)?);
-            Ok(env.tm.mk_term(Kind::CVC5_KIND_EQUAL, &[ca, cb]))
+            Ok(env.tm.mk_term(Kind::Equal, &[ca, cb]))
         }
         AT::Distinct(ts) => {
             let cts = ts.to_cvc5(env, arena)?;
-            Ok(env.tm.mk_term(Kind::CVC5_KIND_DISTINCT, &cts))
+            Ok(env.tm.mk_term(Kind::Distinct, &cts))
         }
         AT::And(ts) => {
             let cts = ts.to_cvc5(env, arena)?;
-            Ok(env.tm.mk_term(Kind::CVC5_KIND_AND, &cts))
+            Ok(env.tm.mk_term(Kind::And, &cts))
         }
         AT::Or(ts) => {
             let cts = ts.to_cvc5(env, arena)?;
-            Ok(env.tm.mk_term(Kind::CVC5_KIND_OR, &cts))
+            Ok(env.tm.mk_term(Kind::Or, &cts))
         }
         AT::Xor(ts) => {
             let cts = ts.to_cvc5(env, arena)?;
             let mut r = cts[0].clone();
             for c in &cts[1..] {
-                r = env.tm.mk_term(Kind::CVC5_KIND_XOR, &[r, CTerm::clone(c)]);
+                r = env.tm.mk_term(Kind::Xor, &[r, CTerm::clone(c)]);
             }
             Ok(r)
         }
         AT::Implies(premises, concl) => {
             let mut all = premises.to_cvc5(env, arena)?;
             all.push(concl.to_cvc5(env, arena)?);
-            Ok(env.tm.mk_term(Kind::CVC5_KIND_IMPLIES, &all))
+            Ok(env.tm.mk_term(Kind::Implies, &all))
         }
         AT::Ite(c, t, e) => {
             let (cc, ct, ce) = (
@@ -367,13 +366,13 @@ fn translate_term_inner<A: HasArenaAlt>(
                 t.to_cvc5(env, arena)?,
                 e.to_cvc5(env, arena)?,
             );
-            Ok(env.tm.mk_term(Kind::CVC5_KIND_ITE, &[cc, ct, ce]))
+            Ok(env.tm.mk_term(Kind::Ite, &[cc, ct, ce]))
         }
         AT::Forall(vars, body) => {
-            env.translate_quantifier(Kind::CVC5_KIND_FORALL, vars, body, arena)
+            env.translate_quantifier(Kind::Forall, vars, body, arena)
         }
         AT::Exists(vars, body) => {
-            env.translate_quantifier(Kind::CVC5_KIND_EXISTS, vars, body, arena)
+            env.translate_quantifier(Kind::Exists, vars, body, arena)
         }
         AT::Let(bindings, body) => env.translate_let(bindings, body, arena),
         AT::App(qid, args, ret) => {
@@ -388,19 +387,19 @@ fn translate_term_inner<A: HasArenaAlt>(
     }
 }
 
-impl<T, A: HasArenaAlt, E> ConvertToCvc5<Cvc5Env, A> for [T]
+impl<'tm, T, A: HasArenaAlt, E> ConvertToCvc5<Cvc5Env<'tm>, A> for [T]
 where
-    T: ConvertToCvc5<Cvc5Env, A, Output = E>,
+    T: ConvertToCvc5<Cvc5Env<'tm>, A, Output = E>,
 {
     type Output = Vec<E>;
 
-    fn to_cvc5(&self, env: &mut Cvc5Env, arena: &mut A) -> Res<Vec<E>> {
+    fn to_cvc5(&self, env: &mut Cvc5Env<'tm>, arena: &mut A) -> Res<Vec<E>> {
         self.iter().map(|t| t.to_cvc5(env, arena)).collect()
     }
 }
 
-impl Cvc5Env {
-    fn translate_constant(&self, c: &Constant) -> Res<CTerm> {
+impl<'tm> Cvc5Env<'tm> {
+    fn translate_constant(&self, c: &Constant) -> Res<CTerm<'tm>> {
         use alg::Constant::*;
         match c {
             Bool(true) => Ok(self.tm.mk_true()),
@@ -427,7 +426,7 @@ impl Cvc5Env {
     }
 
     /// Build `(kind head args...)`.
-    fn mk_applied(&self, kind: Kind, head: CTerm, mut args: Vec<CTerm>) -> CTerm {
+    fn mk_applied(&self, kind: Kind, head: CTerm<'tm>, mut args: Vec<CTerm<'tm>>) -> CTerm<'tm> {
         args.insert(0, head);
         self.tm.mk_term(kind, &args)
     }
@@ -440,7 +439,7 @@ impl Cvc5Env {
         name: &str,
         sort: &Sort,
         arena: &mut A,
-    ) -> Res<Option<CTerm>> {
+    ) -> Res<Option<CTerm<'tm>>> {
         let sort_name = sort.repr().sort_name();
         if let Some(base_sort) = self.sort.get(sort_name).cloned() {
             let dt = base_sort.datatype();
@@ -462,7 +461,7 @@ impl Cvc5Env {
         qid: &QualifiedIdentifier,
         sort: &Sort,
         arena: &mut A,
-    ) -> Res<CTerm> {
+    ) -> Res<CTerm<'tm>> {
         use alg::IdentifierKind::*;
         let name = qid.id_str();
         match qid.get_kind() {
@@ -483,9 +482,9 @@ impl Cvc5Env {
                 let is_ctor = t.sort().is_dt_constructor();
                 if is_ctor {
                     if let Some(ct) = self.resolve_parametric_ctor(name, sort, arena)? {
-                        Ok(self.tm.mk_term(Kind::CVC5_KIND_APPLY_CONSTRUCTOR, &[ct]))
+                        Ok(self.tm.mk_term(Kind::ApplyConstructor, &[ct]))
                     } else {
-                        Ok(self.tm.mk_term(Kind::CVC5_KIND_APPLY_CONSTRUCTOR, &[t]))
+                        Ok(self.tm.mk_term(Kind::ApplyConstructor, &[t]))
                     }
                 } else {
                     Ok(t)
@@ -499,7 +498,7 @@ impl Cvc5Env {
         &mut self,
         vars: &[alg::VarBinding<Str, Sort>],
         arena: &mut A,
-    ) -> Res<Vec<CTerm>> {
+    ) -> Res<Vec<CTerm<'tm>>> {
         let mut bound = Vec::with_capacity(vars.len());
         for v in vars {
             let cs = v.2.to_cvc5(self, arena)?;
@@ -523,7 +522,7 @@ impl Cvc5Env {
         vars: &[alg::VarBinding<Str, Sort>],
         body: &Term,
         arena: &mut A,
-    ) -> Res<CTerm> {
+    ) -> Res<CTerm<'tm>> {
         let bound = self.bind_vars(vars, arena)?;
         let result = self.translate_quantifier_body(kind, body, &bound, arena);
         self.unbind_vars(vars);
@@ -534,10 +533,10 @@ impl Cvc5Env {
         &mut self,
         kind: Kind,
         body: &Term,
-        bound: &[CTerm],
+        bound: &[CTerm<'tm>],
         arena: &mut A,
-    ) -> Res<CTerm> {
-        let bvl = self.tm.mk_term(Kind::CVC5_KIND_VARIABLE_LIST, bound);
+    ) -> Res<CTerm<'tm>> {
+        let bvl = self.tm.mk_term(Kind::VariableList, bound);
 
         // Peel off annotations from the body to extract :pattern triggers
         let (inner_body, attrs) = match body.repr() {
@@ -552,11 +551,11 @@ impl Cvc5Env {
             for attr in attrs {
                 if let Attribute::Pattern(terms) = attr {
                     let cterms = terms.to_cvc5(self, arena)?;
-                    pats.push(self.tm.mk_term(Kind::CVC5_KIND_INST_PATTERN, &cterms));
+                    pats.push(self.tm.mk_term(Kind::InstPattern, &cterms));
                 }
             }
             if !pats.is_empty() {
-                let plist = self.tm.mk_term(Kind::CVC5_KIND_INST_PATTERN_LIST, &pats);
+                let plist = self.tm.mk_term(Kind::InstPatternList, &pats);
                 return Ok(self.tm.mk_term(kind, &[bvl, cbody, plist]));
             }
         }
@@ -569,7 +568,7 @@ impl Cvc5Env {
         bindings: &[alg::VarBinding<Str, Term>],
         body: &Term,
         arena: &mut A,
-    ) -> Res<CTerm> {
+    ) -> Res<CTerm<'tm>> {
         let new_bindings = bindings
             .iter()
             .map(|b| Ok((b.1, b.2.to_cvc5(self, arena)?)))
@@ -589,13 +588,13 @@ impl Cvc5Env {
         scrutinee: &Term,
         arms: &[alg::PatternArm<Str, Term>],
         arena: &mut A,
-    ) -> Res<CTerm> {
+    ) -> Res<CTerm<'tm>> {
         let cscrutinee = scrutinee.to_cvc5(self, arena)?;
         let scr_sort = cscrutinee.sort();
         let dt = scr_sort.datatype();
         // For parametric datatypes, selector codomain sorts are uninstantiated (e.g. X).
         // We need to substitute the sort parameters with the actual instantiated parameters.
-        let subst: Option<(Vec<CSort>, Vec<CSort>)> = if dt.is_parametric() {
+        let subst: Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)> = if dt.is_parametric() {
             let params = dt.parameters();
             let inst_params = scr_sort.instantiated_parameters();
             Some((params, inst_params))
@@ -615,10 +614,10 @@ impl Cvc5Env {
                     };
                     let ctor_app = self
                         .tm
-                        .mk_term(Kind::CVC5_KIND_APPLY_CONSTRUCTOR, &[ctor_term]);
+                        .mk_term(Kind::ApplyConstructor, &[ctor_term]);
                     let cbody = arm.body.to_cvc5(self, arena)?;
                     self.tm
-                        .mk_term(Kind::CVC5_KIND_MATCH_CASE, &[ctor_app, cbody])
+                        .mk_term(Kind::MatchCase, &[ctor_app, cbody])
                 }
                 alg::Pattern::Applied {
                     ctor: name,
@@ -655,15 +654,15 @@ impl Cvc5Env {
                     pat_children.extend(pattern_args);
                     let pattern = self
                         .tm
-                        .mk_term(Kind::CVC5_KIND_APPLY_CONSTRUCTOR, &pat_children);
-                    let vlist = self.tm.mk_term(Kind::CVC5_KIND_VARIABLE_LIST, &vars);
+                        .mk_term(Kind::ApplyConstructor, &pat_children);
+                    let vlist = self.tm.mk_term(Kind::VariableList, &vars);
                     let cbody = arm.body.to_cvc5(self, arena);
                     for (_, id) in arguments.iter().flatten() {
                         self.locals.remove(id);
                     }
                     let cbody = cbody?;
                     self.tm
-                        .mk_term(Kind::CVC5_KIND_MATCH_BIND_CASE, &[vlist, pattern, cbody])
+                        .mk_term(Kind::MatchBindCase, &[vlist, pattern, cbody])
                 }
                 alg::Pattern::Wildcard(binding) => {
                     let fresh = arena.arena_alt().fresh_x().to_string();
@@ -673,14 +672,14 @@ impl Cvc5Env {
                     }
                     let vlist = self
                         .tm
-                        .mk_term(Kind::CVC5_KIND_VARIABLE_LIST, std::slice::from_ref(&bv));
+                        .mk_term(Kind::VariableList, std::slice::from_ref(&bv));
                     let cbody = arm.body.to_cvc5(self, arena);
                     if let Some((_, id)) = binding {
                         self.locals.remove(id);
                     }
                     let cbody = cbody?;
                     self.tm
-                        .mk_term(Kind::CVC5_KIND_MATCH_BIND_CASE, &[vlist, bv, cbody])
+                        .mk_term(Kind::MatchBindCase, &[vlist, bv, cbody])
                 }
             };
             cases.push(case);
@@ -688,7 +687,7 @@ impl Cvc5Env {
 
         let mut match_children = vec![cscrutinee];
         match_children.extend(cases);
-        Ok(self.tm.mk_term(Kind::CVC5_KIND_MATCH, &match_children))
+        Ok(self.tm.mk_term(Kind::Match, &match_children))
     }
 
     fn translate_app<A: HasArenaAlt>(
@@ -697,7 +696,7 @@ impl Cvc5Env {
         args: &[Term],
         rs: &Sort,
         arena: &mut A,
-    ) -> Res<CTerm> {
+    ) -> Res<CTerm<'tm>> {
         let cargs = args.to_cvc5(self, arena)?;
         let id = &qid.0;
         let kind = id.get_kind();
@@ -705,7 +704,7 @@ impl Cvc5Env {
         if let Some(IdentifierKind::Sub) = kind
             && cargs.len() == 1
         {
-            return Ok(self.tm.mk_term(Kind::CVC5_KIND_NEG, &cargs));
+            return Ok(self.tm.mk_term(Kind::Neg, &cargs));
         }
         if let Some(kind) = kind.as_ref().and_then(ident_kind_to_cvc5) {
             return Ok(self.tm.mk_term(kind, &cargs));
@@ -718,23 +717,23 @@ impl Cvc5Env {
             let fs = f.sort();
             if fs.is_dt_constructor() {
                 if let Some(ct) = self.resolve_parametric_ctor(name, rs, arena)? {
-                    Ok(self.mk_applied(Kind::CVC5_KIND_APPLY_CONSTRUCTOR, ct, cargs))
+                    Ok(self.mk_applied(Kind::ApplyConstructor, ct, cargs))
                 } else {
-                    Ok(self.mk_applied(Kind::CVC5_KIND_APPLY_CONSTRUCTOR, f, cargs))
+                    Ok(self.mk_applied(Kind::ApplyConstructor, f, cargs))
                 }
             } else if fs.is_dt_selector() {
-                Ok(self.mk_applied(Kind::CVC5_KIND_APPLY_SELECTOR, f, cargs))
+                Ok(self.mk_applied(Kind::ApplySelector, f, cargs))
             } else if fs.is_dt_tester() {
-                Ok(self.mk_applied(Kind::CVC5_KIND_APPLY_TESTER, f, cargs))
+                Ok(self.mk_applied(Kind::ApplyTester, f, cargs))
             } else {
-                Ok(self.mk_applied(Kind::CVC5_KIND_APPLY_UF, f, cargs))
+                Ok(self.mk_applied(Kind::ApplyUf, f, cargs))
             }
         } else {
             Err(format!("unknown function: {name}"))
         }
     }
 
-    fn translate_indexed_app(&self, ik: &IdentifierKind, cargs: Vec<CTerm>) -> Res<CTerm> {
+    fn translate_indexed_app(&self, ik: &IdentifierKind, cargs: Vec<CTerm<'tm>>) -> Res<CTerm<'tm>> {
         use alg::IdentifierKind::*;
         let mk = |kind, indices: &[u32]| {
             let op = self.tm.mk_op(kind, indices);
@@ -745,19 +744,19 @@ impl Cvc5Env {
         };
         match ik {
             Extract(hi, lo) => mk(
-                Kind::CVC5_KIND_BITVECTOR_EXTRACT,
+                Kind::BitvectorExtract,
                 &[to_u32(hi)?, to_u32(lo)?],
             ),
-            Repeat(n) => mk(Kind::CVC5_KIND_BITVECTOR_REPEAT, &[to_u32(n)?]),
-            ZeroExtend(n) => mk(Kind::CVC5_KIND_BITVECTOR_ZERO_EXTEND, &[to_u32(n)?]),
-            SignExtend(n) => mk(Kind::CVC5_KIND_BITVECTOR_SIGN_EXTEND, &[to_u32(n)?]),
-            RotateLeft(n) => mk(Kind::CVC5_KIND_BITVECTOR_ROTATE_LEFT, &[to_u32(n)?]),
-            RotateRight(n) => mk(Kind::CVC5_KIND_BITVECTOR_ROTATE_RIGHT, &[to_u32(n)?]),
+            Repeat(n) => mk(Kind::BitvectorRepeat, &[to_u32(n)?]),
+            ZeroExtend(n) => mk(Kind::BitvectorZeroExtend, &[to_u32(n)?]),
+            SignExtend(n) => mk(Kind::BitvectorSignExtend, &[to_u32(n)?]),
+            RotateLeft(n) => mk(Kind::BitvectorRotateLeft, &[to_u32(n)?]),
+            RotateRight(n) => mk(Kind::BitvectorRotateRight, &[to_u32(n)?]),
             IntToBv(n) | Int2Bv(n) | Nat2Bv(n) => {
-                mk(Kind::CVC5_KIND_INT_TO_BITVECTOR, &[to_u32(n)?])
+                mk(Kind::IntToBitvector, &[to_u32(n)?])
             }
-            RePower(n) => mk(Kind::CVC5_KIND_REGEXP_REPEAT, &[to_u32(n)?]),
-            ReLoop(lo, hi) => mk(Kind::CVC5_KIND_REGEXP_LOOP, &[to_u32(lo)?, to_u32(hi)?]),
+            RePower(n) => mk(Kind::RegexpRepeat, &[to_u32(n)?]),
+            ReLoop(lo, hi) => mk(Kind::RegexpLoop, &[to_u32(lo)?, to_u32(hi)?]),
             Is(cname) => {
                 // Resolve tester via the argument's sort (works for both mono and parametric)
                 if let Some(arg) = cargs.first() {
@@ -766,7 +765,7 @@ impl Cvc5Env {
                         let ctor = dt.constructor(i);
                         if ctor.name() == cname.inner().as_str() {
                             return Ok(self.mk_applied(
-                                Kind::CVC5_KIND_APPLY_TESTER,
+                                Kind::ApplyTester,
                                 ctor.tester_term(),
                                 cargs,
                             ));
@@ -781,10 +780,10 @@ impl Cvc5Env {
 }
 
 // ── Command translation ──────────────────────────────────────
-impl<A: HasArenaAlt> ConvertToCvc5<Cvc5EnvSolver<'_>, A> for Command {
-    type Output = CommandResult;
+impl<'tm, A: HasArenaAlt> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm>, A> for Command {
+    type Output = CommandResult<'tm>;
 
-    fn to_cvc5(&self, es: &mut Cvc5EnvSolver, arena: &mut A) -> Res<CommandResult> {
+    fn to_cvc5(&self, es: &mut Cvc5EnvSolver<'_, 'tm>, arena: &mut A) -> Res<CommandResult<'tm>> {
         use alg::Command as AC;
         let env = &mut *es.env;
         let solver = &mut *es.solver;
@@ -928,7 +927,7 @@ impl<A: HasArenaAlt> ConvertToCvc5<Cvc5EnvSolver<'_>, A> for Command {
             }
             AC::Echo(_) | AC::Exit | AC::GetAssignment => Ok(CommandResult::None),
             AC::GetProof => {
-                let proofs = solver.get_proof(ProofComponent::CVC5_PROOF_COMPONENT_FULL);
+                let proofs = solver.get_proof(ProofComponent::Full);
                 Ok(CommandResult::GetProof(proofs))
             }
         }
@@ -936,13 +935,13 @@ impl<A: HasArenaAlt> ConvertToCvc5<Cvc5EnvSolver<'_>, A> for Command {
 }
 
 // ── Command helper methods ───────────────────────────────────
-impl Cvc5EnvSolver<'_> {
+impl<'tm> Cvc5EnvSolver<'_, 'tm> {
     fn translate_define_fun<A: HasArenaAlt>(
         &mut self,
         fd: &alg::FunctionDef<Str, Sort, Term>,
         recursive: bool,
         arena: &mut A,
-    ) -> Res<CommandResult> {
+    ) -> Res<CommandResult<'tm>> {
         let env = &mut *self.env;
         let out = fd.out_sort.to_cvc5(env, arena)?;
         let vars = env.bind_vars(&fd.vars, arena)?;
@@ -962,7 +961,7 @@ impl Cvc5EnvSolver<'_> {
         &mut self,
         fds: &[alg::FunctionDef<Str, Sort, Term>],
         arena: &mut A,
-    ) -> Res<CommandResult> {
+    ) -> Res<CommandResult<'tm>> {
         let env = &mut *self.env;
         // First pass: declare all function constants so they can reference each other
         let mut funs = Vec::with_capacity(fds.len());
@@ -993,7 +992,7 @@ impl Cvc5EnvSolver<'_> {
             all_vars.push(vars);
             bodies.push(body?);
         }
-        let var_refs: Vec<&[CTerm]> = all_vars.iter().map(|v| v.as_slice()).collect();
+        let var_refs: Vec<&[CTerm<'tm>]> = all_vars.iter().map(|v| v.as_slice()).collect();
         self.solver.define_funs_rec(&funs, &var_refs, &bodies, true);
         Ok(CommandResult::None)
     }
@@ -1002,7 +1001,7 @@ impl Cvc5EnvSolver<'_> {
         &mut self,
         defs: &[alg::DatatypeDef<Str, Sort>],
         arena: &mut A,
-    ) -> Res<CommandResult> {
+    ) -> Res<CommandResult<'tm>> {
         let env = &mut *self.env;
         // Pre-register unresolved sorts so self/mutual references resolve
         for def in defs {
@@ -1028,14 +1027,14 @@ impl Cvc5EnvSolver<'_> {
     }
 
     fn build_dt_decls<A: HasArenaAlt>(
-        env: &mut Cvc5Env,
+        env: &mut Cvc5Env<'tm>,
         defs: &[alg::DatatypeDef<Str, Sort>],
         arena: &mut A,
-    ) -> Res<Vec<cvc5_rs::DatatypeDecl>> {
+    ) -> Res<Vec<cvc5::DatatypeDecl<'tm>>> {
         let mut decls = Vec::with_capacity(defs.len());
         for def in defs {
             let params = &def.dec.params;
-            let cvc5_params: Vec<CSort> = params.iter().map(|p| env.tm.mk_param_sort(p)).collect();
+            let cvc5_params: Vec<CSort<'tm>> = params.iter().map(|p| env.tm.mk_param_sort(p)).collect();
             for (p, cs) in params.iter().zip(&cvc5_params) {
                 env.dt_sorts.insert(p.clone(), cs.clone());
             }
@@ -1062,8 +1061,8 @@ impl Cvc5EnvSolver<'_> {
     }
 
     fn register_dt_functions<A: HasArenaAlt>(
-        env: &mut Cvc5Env,
-        sort: CSort,
+        env: &mut Cvc5Env<'tm>,
+        sort: CSort<'tm>,
         dec: &DatatypeDec,
         arena: &mut A,
     ) {

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -59,9 +59,13 @@ use std::collections::HashMap;
 use yaspar::ast::Keyword;
 use yaspar::{binary_to_string, hex_to_string};
 
+/// A cvc5 sort, tied to the lifetime of the [`TermManager`] that created it.
 pub type CSort<'tm> = cvc5::Sort<'tm>;
+/// A cvc5 term, tied to the lifetime of the [`TermManager`] that created it.
 pub type CTerm<'tm> = cvc5::Term<'tm>;
+/// A cvc5 satisfiability result, tied to the lifetime of the [`TermManager`].
 pub type CResult<'tm> = cvc5::Result<'tm>;
+/// A cvc5 proof object, tied to the lifetime of the [`TermManager`].
 pub type CProof<'tm> = cvc5::Proof<'tm>;
 type Res<T> = std::result::Result<T, String>;
 
@@ -86,14 +90,31 @@ pub enum CommandResult<'tm> {
 }
 
 /// Convert a yaspar-ir typed AST node to its cvc5 counterpart.
+///
+/// This trait is implemented for [`Sort`], [`Term`], and [`Command`], each with a
+/// different environment type:
+///
+/// | AST node    | Environment          | Output             |
+/// |-------------|----------------------|--------------------|
+/// | [`Sort`]    | [`Cvc5Env`]          | [`CSort`]          |
+/// | [`Term`]    | [`Cvc5Env`]          | [`CTerm`]          |
+/// | [`Command`] | [`Cvc5EnvSolver`]    | [`CommandResult`]  |
+///
+/// Translation may fail if the AST references symbols or sorts not yet registered
+/// in the environment (e.g. an undeclared global variable).
 pub trait ConvertToCvc5<Env> {
+    /// The cvc5 type produced by the translation.
     type Output;
+    /// Translate `self` into a cvc5 object, using `env` for symbol/sort lookup and caching.
     fn to_cvc5(&self, env: &mut Env) -> Res<Self::Output>;
 }
 
+/// A translated cvc5 term together with any `:pattern` annotations collected during traversal.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct WithPattern<'tm> {
+    /// The translated cvc5 term.
     term: CTerm<'tm>,
+    /// Pattern terms collected from `:pattern` annotations (empty when none are present).
     patterns: Vec<CTerm<'tm>>,
 }
 
@@ -112,21 +133,43 @@ impl<'tm> From<CTerm<'tm>> for WithPattern<'tm> {
     }
 }
 
+/// Cached sort-parameter substitution for parametric datatypes.
+///
+/// When translating `match` expressions over parametric datatypes, selector codomain sorts
+/// are uninstantiated (e.g. the sort parameter `X`). This substitution maps sort parameters
+/// to their concrete instantiations so that bound variables receive the correct sorts.
+/// `None` for monomorphic datatypes.
 type SortSubst<'tm> = Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)>;
 
-/// Environment for translating yaspar-ir ASTs to cvc5 objects.
+/// Inner environment for translating yaspar-ir ASTs to cvc5 objects.
+///
+/// This struct holds the [`TermManager`] reference and all translation state: sort/term
+/// caches, global and local symbol tables, and datatype bookkeeping. It implements
+/// [`TermRecursor`] for stack-safe, memoized term translation.
+///
+/// Users should not construct this directly — use [`Cvc5Env::create`] instead, which
+/// wraps this in a [`Memoize`] layer for automatic term-level caching.
 pub struct Cvc5EnvInner<'tm> {
+    /// The cvc5 term manager that owns all created sorts and terms.
     tm: &'tm TermManager,
+    /// Named sorts registered by `declare-sort` or datatype declarations.
     sort: HashMap<String, CSort<'tm>>,
+    /// Global symbols (constants, functions, constructors, selectors, testers).
     globals: HashMap<String, CTerm<'tm>>,
+    /// Local (bound) variables, keyed by their uniquely assigned id.
     locals: HashMap<usize, WithPattern<'tm>>,
+    /// Cache from yaspar-ir [`Sort`] to translated [`CSort`], avoiding redundant work.
     sort_cache: HashMap<Sort, CSort<'tm>>,
+    /// datatype sorts mapping from names to their corresponding potentially polymorphic representations.
     dt_sorts: HashMap<String, CSort<'tm>>,
+    /// Stack of bound-variable lists for scope management in quantifiers and match arms.
     scope_stack: Vec<Vec<CTerm<'tm>>>,
+    /// Cached sort-parameter substitutions for parametric datatype match translation.
     sort_subst_map: HashMap<Term, SortSubst<'tm>>,
 }
 
 impl<'tm> Cvc5EnvInner<'tm> {
+    /// Create a new inner environment backed by the given [`TermManager`].
     pub fn new(tm: &'tm TermManager) -> Self {
         Self {
             tm,
@@ -140,21 +183,58 @@ impl<'tm> Cvc5EnvInner<'tm> {
         }
     }
 }
+/// The main translation environment for sorts and terms.
+///
+/// This is a [`Memoize`]-wrapped [`Cvc5EnvInner`] that automatically caches translated
+/// terms by their hashconsed identity. Because yaspar-ir terms are hashconsed,
+/// structurally identical sub-terms share the same pointer — the memoization layer
+/// ensures each unique sub-term is translated at most once.
+///
+/// # Construction
+///
+/// ```rust
+/// use cvc5::TermManager;
+/// use yaspar_ir::cvc5::Cvc5Env;
+///
+/// let tm = TermManager::new();
+/// let mut env = Cvc5Env::create(&tm);
+/// ```
 pub type Cvc5Env<'tm> = Memoize<Cvc5EnvInner<'tm>, HashMap<Term, WithPattern<'tm>>>;
 
 impl<'tm> Cvc5Env<'tm> {
+    /// Create a new translation environment backed by the given [`TermManager`].
     pub fn create(tm: &'tm TermManager) -> Self {
         Self::new(Cvc5EnvInner::new(tm))
     }
 }
 
-/// Environment combining a [`Cvc5EnvInner`] with a [`Solver`] for translating commands.
+/// Environment combining a [`Cvc5Env`] with a [`Solver`] for translating commands.
+///
+/// Commands like `assert`, `check-sat`, `define-fun`, and `declare-datatypes` need
+/// access to both the translation environment (for sort/term translation) and the
+/// solver (for issuing solver calls). This struct bundles the two together.
+///
+/// # Example
+///
+/// ```rust
+/// use cvc5::{Solver, TermManager};
+/// use yaspar_ir::cvc5::{Cvc5Env, Cvc5EnvSolver};
+///
+/// let tm = TermManager::new();
+/// let mut solver = Solver::new(&tm);
+/// let mut env = Cvc5Env::create(&tm);
+/// let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+/// // now use es.to_cvc5() on Command values
+/// ```
 pub struct Cvc5EnvSolver<'a, 'tm> {
+    /// The translation environment for sorts and terms.
     pub env: &'a mut Cvc5Env<'tm>,
+    /// The cvc5 solver instance.
     pub solver: &'a mut Solver<'tm>,
 }
 
 impl<'a, 'tm> Cvc5EnvSolver<'a, 'tm> {
+    /// Create a new command-translation environment from a [`Cvc5Env`] and a [`Solver`].
     pub fn new(env: &'a mut Cvc5Env<'tm>, solver: &'a mut Solver<'tm>) -> Self {
         Self { env, solver }
     }
@@ -187,7 +267,6 @@ fn translate_sort_inner<'tm>(sort: &Sort, env: &mut Cvc5EnvInner<'tm>) -> Res<CS
     if !s.0.indices.is_empty() {
         return Err(format!("unknown sort with indices: {s}"));
     }
-    // Check temporary datatype sorts (params and unresolved self-references)
     if let Some(cs) = env.dt_sorts.get(name).cloned() {
         if s.1.is_empty() {
             return Ok(cs);

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -8,7 +8,7 @@
 //!
 //! # Overview
 //!
-//! - [`ConvertToCvc5<Env, A>`] — the core trait, implemented for [`Sort`], [`Term`], and [`Command`].
+//! - [`ConvertToCvc5<Env>`] — the core trait, implemented for [`Sort`], [`Term`], and [`Command`].
 //! - [`Cvc5Env`] — holds a [`cvc5::TermManager`] and caches for sort/term/symbol translation.
 //!   Used as the environment for `Sort::to_cvc5` and `Term::to_cvc5`.
 //! - [`Cvc5EnvSolver`] — wraps a [`Cvc5EnvInner`] and a [`Solver`]. Used as the environment
@@ -41,7 +41,7 @@
 //!
 //! # Caching
 //!
-//! `Cvc5Env` caches translated sorts and terms so that repeated translations of the same
+//! [`Cvc5Env`] caches translated sorts and terms so that repeated translations of the same
 //! hashconsed object return the cached cvc5 object directly.
 //!
 //! # Annotations
@@ -112,6 +112,8 @@ impl<'tm> From<CTerm<'tm>> for WithPattern<'tm> {
     }
 }
 
+type SortSubst<'tm> = Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)>;
+
 /// Environment for translating yaspar-ir ASTs to cvc5 objects.
 pub struct Cvc5EnvInner<'tm> {
     tm: &'tm TermManager,
@@ -121,7 +123,7 @@ pub struct Cvc5EnvInner<'tm> {
     sort_cache: HashMap<Sort, CSort<'tm>>,
     dt_sorts: HashMap<String, CSort<'tm>>,
     scope_stack: Vec<Vec<CTerm<'tm>>>,
-    sort_subst_map: HashMap<Term, Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)>>,
+    sort_subst_map: HashMap<Term, SortSubst<'tm>>,
 }
 
 impl<'tm> Cvc5EnvInner<'tm> {
@@ -355,7 +357,7 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
     fn on_constant(
         &mut self,
-        current: &Term,
+        _current: &Term,
         constant: &Constant,
         sort: &Option<Sort>,
     ) -> Res<WithPattern<'tm>> {
@@ -364,7 +366,7 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
     fn on_global(
         &mut self,
-        current: &Term,
+        _current: &Term,
         id: &QualifiedIdentifier,
         sort: &Option<Sort>,
     ) -> Res<WithPattern<'tm>> {
@@ -373,7 +375,7 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
         self.translate_global(id, sort)
     }
 
-    fn on_local(&mut self, current: &Term, id: &Local) -> Res<WithPattern<'tm>> {
+    fn on_local(&mut self, _current: &Term, id: &Local) -> Res<WithPattern<'tm>> {
         self.locals
             .get(&id.id)
             .cloned()
@@ -382,9 +384,9 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
     fn on_app(
         &mut self,
-        current: &Term,
+        _current: &Term,
         id: &QualifiedIdentifier,
-        ts: &[Term],
+        _ts: &[Term],
         s: &Option<Sort>,
         recs: Vec<WithPattern<'tm>>,
     ) -> Res<WithPattern<'tm>> {
@@ -397,9 +399,9 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
     fn on_let_binding(
         &mut self,
-        current: &Term,
+        _current: &Term,
         vs: &[VarBinding<Str, Term>],
-        body: &Term,
+        _body: &Term,
         binding_idx: usize,
         binding_rec: WithPattern<'tm>,
     ) -> Res<Self::Binding> {
@@ -408,9 +410,9 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
     }
     fn setup_let_scope(
         &mut self,
-        current: &Term,
-        vs: &[VarBinding<Str, Term>],
-        body: &Term,
+        _current: &Term,
+        _vs: &[VarBinding<Str, Term>],
+        _body: &Term,
         vs_rec: &[Self::Binding],
     ) -> Res<()> {
         for (idx, t) in vs_rec {
@@ -420,9 +422,9 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
     }
     fn on_let(
         &mut self,
-        current: &Term,
-        vs: &[VarBinding<Str, Term>],
-        body: &Term,
+        _current: &Term,
+        _vs: &[VarBinding<Str, Term>],
+        _body: &Term,
         vs_rec: Vec<Self::Binding>,
         body_rec: WithPattern<'tm>,
     ) -> Res<WithPattern<'tm>> {
@@ -433,18 +435,18 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
     }
     fn setup_quantifier_scope(
         &mut self,
-        current: &Term,
+        _current: &Term,
         vs: &[VarBinding<Str, Sort>],
-        t: &Term,
-        is_forall: bool,
+        _t: &Term,
+        _is_forall: bool,
     ) -> Res<()> {
         self.bind_vars(vs)
     }
     fn on_exists(
         &mut self,
-        current: &Term,
+        _current: &Term,
         vs: &[VarBinding<Str, Sort>],
-        t: &Term,
+        _t: &Term,
         t_rec: WithPattern<'tm>,
     ) -> Res<WithPattern<'tm>> {
         let bound = self.unbind_vars(vs, |v| &v.1)?;
@@ -452,9 +454,9 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
     }
     fn on_forall(
         &mut self,
-        current: &Term,
+        _current: &Term,
         vs: &[VarBinding<Str, Sort>],
-        t: &Term,
+        _t: &Term,
         t_rec: Self::Out,
     ) -> Res<WithPattern<'tm>> {
         let bound = self.unbind_vars(vs, |v| &v.1)?;
@@ -462,7 +464,7 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
     }
     fn setup_match_case_scope(
         &mut self,
-        current: &Term,
+        _current: &Term,
         scrutinee: &Term,
         cases: &[PatternArm],
         scrutinee_rec: &Self::Out,
@@ -473,7 +475,7 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
         if !self.sort_subst_map.contains_key(scrutinee) {
             // For parametric datatypes, selector codomain sorts are uninstantiated (e.g. X).
             // We need to substitute the sort parameters with the actual instantiated parameters.
-            let subst: Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)> = if dt.is_parametric() {
+            let subst: SortSubst<'tm> = if dt.is_parametric() {
                 let params = dt.parameters();
                 let inst_params = scr_sort.instantiated_parameters();
                 Some((params, inst_params))
@@ -488,7 +490,7 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
                 let pv = match v {
                     None => self.tm.mk_anonymous_var(scr_sort.clone()),
                     Some((name, id)) => {
-                        let v = self.tm.mk_var(scr_sort.clone(), &name);
+                        let v = self.tm.mk_var(scr_sort.clone(), name);
                         self.locals.insert(*id, v.clone().into());
                         v
                     }
@@ -524,18 +526,17 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
     }
     fn on_match_arm(
         &mut self,
-        current: &Term,
-        scrutinee: &Term,
+        _current: &Term,
+        _scrutinee: &Term,
         cases: &[PatternArm],
         scrutinee_rec: &Self::Out,
         case_idx: usize,
-        current_pattern: Self::Pattern,
+        _current_pattern: Self::Pattern,
         arm: Self::Out,
     ) -> Res<Self::Arm> {
         let scr_sort = scrutinee_rec.term.sort();
         let dt = scr_sort.datatype();
         let mut args = self.unbind_vars(&cases[case_idx].pattern.variables_and_ids(), |v| &v.1)?;
-        let subst = self.sort_subst_map.get(scrutinee).unwrap();
         match &cases[case_idx].pattern {
             Pattern::Wildcard(_) => {
                 // we know there is only one variable
@@ -571,9 +572,9 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
     }
     fn on_match(
         &mut self,
-        current: &Term,
-        scrutinee: &Term,
-        cases: &[PatternArm],
+        _current: &Term,
+        _scrutinee: &Term,
+        _cases: &[PatternArm],
         scrutinee_rec: Self::Out,
         cases_rec: Vec<Self::Arm>,
     ) -> Res<WithPattern<'tm>> {
@@ -584,9 +585,9 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
     fn on_annotated(
         &mut self,
-        current: &Term,
-        t: &Term,
-        anns: &[Attribute],
+        _current: &Term,
+        _t: &Term,
+        _anns: &[Attribute],
         t_rec: WithPattern<'tm>,
         anns_rec: Vec<Vec<CTerm<'tm>>>,
     ) -> Res<WithPattern<'tm>> {
@@ -598,26 +599,26 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
             patterns: pats,
         })
     }
-    fn on_attribute_keyword(&mut self, keyword: &Keyword) -> Res<Vec<CTerm<'tm>>> {
+    fn on_attribute_keyword(&mut self, _keyword: &Keyword) -> Res<Vec<CTerm<'tm>>> {
         Ok(vec![])
     }
     fn on_attribute_constant(
         &mut self,
-        keyword: &Keyword,
-        constant: &Constant,
+        _keyword: &Keyword,
+        _constant: &Constant,
     ) -> Res<Vec<CTerm<'tm>>> {
         Ok(vec![])
     }
-    fn on_attribute_symbol(&mut self, keyword: &Keyword, symbol: &Str) -> Res<Vec<CTerm<'tm>>> {
+    fn on_attribute_symbol(&mut self, _keyword: &Keyword, _symbol: &Str) -> Res<Vec<CTerm<'tm>>> {
         Ok(vec![])
     }
-    fn on_attribute_named(&mut self, name: &Str) -> Res<Vec<CTerm<'tm>>> {
+    fn on_attribute_named(&mut self, _name: &Str) -> Res<Vec<CTerm<'tm>>> {
         Ok(vec![])
     }
 
     fn on_attribute_pattern(
         &mut self,
-        patterns: &[Term],
+        _patterns: &[Term],
         patterns_rec: Vec<WithPattern<'tm>>,
     ) -> Res<Vec<CTerm<'tm>>> {
         Ok(to_term_vec(patterns_rec))
@@ -625,9 +626,9 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
     fn on_eq(
         &mut self,
-        current: &Term,
-        a: &Term,
-        b: &Term,
+        _current: &Term,
+        _a: &Term,
+        _b: &Term,
         a_rec: WithPattern<'tm>,
         b_rec: WithPattern<'tm>,
     ) -> Res<WithPattern<'tm>> {
@@ -639,8 +640,8 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
     fn on_distinct(
         &mut self,
-        current: &Term,
-        ts: &[Term],
+        _current: &Term,
+        _ts: &[Term],
         ts_rec: Vec<WithPattern<'tm>>,
     ) -> Res<WithPattern<'tm>> {
         Ok(self.tm.mk_term(Kind::Distinct, &to_term_vec(ts_rec)).into())
@@ -648,8 +649,8 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
     fn on_and(
         &mut self,
-        current: &Term,
-        ts: &[Term],
+        _current: &Term,
+        _ts: &[Term],
         ts_rec: Vec<WithPattern<'tm>>,
     ) -> Res<WithPattern<'tm>> {
         Ok(self.tm.mk_term(Kind::And, &to_term_vec(ts_rec)).into())
@@ -657,17 +658,17 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
     fn on_or(
         &mut self,
-        current: &Term,
-        ts: &[Term],
+        _current: &Term,
+        _ts: &[Term],
         ts_rec: Vec<WithPattern<'tm>>,
     ) -> Res<WithPattern<'tm>> {
-        Ok(self.tm.mk_term(Kind::Or, &&to_term_vec(ts_rec)).into())
+        Ok(self.tm.mk_term(Kind::Or, &to_term_vec(ts_rec)).into())
     }
 
     fn on_xor(
         &mut self,
-        current: &Term,
-        ts: &[Term],
+        _current: &Term,
+        _ts: &[Term],
         ts_rec: Vec<WithPattern<'tm>>,
     ) -> Res<WithPattern<'tm>> {
         Ok(self.tm.mk_term(Kind::Xor, &to_term_vec(ts_rec)).into())
@@ -675,8 +676,8 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
     fn on_not(
         &mut self,
-        current: &Term,
-        t: &Term,
+        _current: &Term,
+        _t: &Term,
         t_rec: WithPattern<'tm>,
     ) -> Res<WithPattern<'tm>> {
         Ok(self.tm.mk_term(Kind::Not, &[t_rec.into()]).into())
@@ -684,9 +685,9 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
     fn on_implies(
         &mut self,
-        current: &Term,
-        ts: &[Term],
-        t: &Term,
+        _current: &Term,
+        _ts: &[Term],
+        _t: &Term,
         ts_rec: Vec<WithPattern<'tm>>,
         t_rec: WithPattern<'tm>,
     ) -> Res<WithPattern<'tm>> {
@@ -697,10 +698,10 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
     fn on_ite(
         &mut self,
-        current: &Term,
-        b: &Term,
-        t: &Term,
-        e: &Term,
+        _current: &Term,
+        _b: &Term,
+        _t: &Term,
+        _e: &Term,
         b_rec: WithPattern<'tm>,
         t_rec: WithPattern<'tm>,
         e_rec: WithPattern<'tm>,

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -115,7 +115,9 @@ pub struct WithPattern<'tm> {
     /// The translated cvc5 term.
     term: CTerm<'tm>,
     /// Pattern terms collected from `:pattern` annotations (empty when none are present).
-    patterns: Vec<CTerm<'tm>>,
+    ///
+    /// Multiple `:pattern`s are maintained.
+    patterns: Vec<Vec<CTerm<'tm>>>,
 }
 
 impl<'tm> From<WithPattern<'tm>> for CTerm<'tm> {
@@ -428,7 +430,7 @@ fn to_term_vec(terms: Vec<WithPattern>) -> Vec<CTerm> {
 
 impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
     type Out = WithPattern<'tm>;
-    type Attr = Vec<CTerm<'tm>>;
+    type Attr = Vec<Vec<CTerm<'tm>>>;
     type Binding = (usize, WithPattern<'tm>);
     type Pattern = ();
     type Arm = CTerm<'tm>;
@@ -668,7 +670,7 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
         _t: &Term,
         _anns: &[Attribute],
         t_rec: WithPattern<'tm>,
-        anns_rec: Vec<Vec<CTerm<'tm>>>,
+        anns_rec: Vec<Vec<Vec<CTerm<'tm>>>>,
     ) -> Res<WithPattern<'tm>> {
         // do not handle other annotations
         let mut pats = t_rec.patterns;
@@ -678,20 +680,24 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
             patterns: pats,
         })
     }
-    fn on_attribute_keyword(&mut self, _keyword: &Keyword) -> Res<Vec<CTerm<'tm>>> {
+    fn on_attribute_keyword(&mut self, _keyword: &Keyword) -> Res<Vec<Vec<CTerm<'tm>>>> {
         Ok(vec![])
     }
     fn on_attribute_constant(
         &mut self,
         _keyword: &Keyword,
         _constant: &Constant,
-    ) -> Res<Vec<CTerm<'tm>>> {
+    ) -> Res<Vec<Vec<CTerm<'tm>>>> {
         Ok(vec![])
     }
-    fn on_attribute_symbol(&mut self, _keyword: &Keyword, _symbol: &Str) -> Res<Vec<CTerm<'tm>>> {
+    fn on_attribute_symbol(
+        &mut self,
+        _keyword: &Keyword,
+        _symbol: &Str,
+    ) -> Res<Vec<Vec<CTerm<'tm>>>> {
         Ok(vec![])
     }
-    fn on_attribute_named(&mut self, _name: &Str) -> Res<Vec<CTerm<'tm>>> {
+    fn on_attribute_named(&mut self, _name: &Str) -> Res<Vec<Vec<CTerm<'tm>>>> {
         Ok(vec![])
     }
 
@@ -699,8 +705,8 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
         &mut self,
         _patterns: &[Term],
         patterns_rec: Vec<WithPattern<'tm>>,
-    ) -> Res<Vec<CTerm<'tm>>> {
-        Ok(to_term_vec(patterns_rec))
+    ) -> Res<Vec<Vec<CTerm<'tm>>>> {
+        Ok(vec![to_term_vec(patterns_rec)])
     }
 
     fn on_eq(
@@ -947,10 +953,18 @@ impl<'tm> Cvc5EnvInner<'tm> {
 
         // Build INST_PATTERN_LIST from :pattern annotations
         if !t_rec.patterns.is_empty() {
-            let pats = self.tm.mk_term(Kind::InstPattern, &t_rec.patterns);
-            let plist = self
-                .tm
-                .mk_term(Kind::InstPatternList, std::slice::from_ref(&pats));
+            let pats = t_rec
+                .patterns
+                .iter()
+                .filter_map(|ts| {
+                    if ts.is_empty() {
+                        None
+                    } else {
+                        Some(self.tm.mk_term(Kind::InstPattern, ts))
+                    }
+                })
+                .collect::<Vec<_>>();
+            let plist = self.tm.mk_term(Kind::InstPatternList, &pats);
             return Ok(self.tm.mk_term(kind, &[bvl, cbody, plist]).into());
         }
         Ok(self.tm.mk_term(kind, &[bvl, cbody]).into())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! | [`untyped`] | Untyped ASTs with location information, and the parser entry point [`UntypedAst`](untyped::UntypedAst) |
 //! | [`traits`] | Core abstraction traits ([`Contains`](traits::Contains), [`Repr`](traits::Repr), [`AllocatableString`](traits::AllocatableString)) |
 //! | [`statics`] | Static constants (sort name strings, regex patterns) |
-//! | [`cvc5`] | Translation to cvc5-rs objects (`Sort`, `Term`, `Command`). Requires the `cvc5` feature. |
+//! | [`cvc5`] | Translation to cvc5 objects (`Sort`, `Term`, `Command`). Requires the `cvc5` feature. |
 
 mod allocator;
 pub mod ast;

--- a/src/raw/alg/rec.rs
+++ b/src/raw/alg/rec.rs
@@ -220,6 +220,7 @@ pub trait TermRecursor<Str, So, T> {
         current: &T,
         scrutinee: &T,
         cases: &[PatternArm<Str, T>],
+        scrutinee_rec: &Self::Out,
         case_idx: usize,
         current_pattern: Self::Pattern,
         arm: Self::Out,
@@ -621,6 +622,7 @@ where
                     current,
                     scrutinee,
                     cases,
+                    &scrutinee_rec,
                     case_rec.len(),
                     current_pattern.unwrap(),
                     result,
@@ -939,7 +941,7 @@ where
                     id,
                     args,
                     sort,
-                    rec: vec![],
+                    rec: Vec::with_capacity(args.len()),
                 });
                 Ok(Either::Left(&args[0]))
             }
@@ -960,7 +962,7 @@ where
                     current,
                     vs,
                     body,
-                    vs_rec: vec![],
+                    vs_rec: Vec::with_capacity(vs.len()),
                 });
                 Ok(Either::Left(&vs[0].2))
             }
@@ -1013,7 +1015,7 @@ where
                     current,
                     kind: NaryKind::Distinct,
                     ts,
-                    rec: vec![],
+                    rec: Vec::with_capacity(ts.len()),
                 });
                 Ok(Either::Left(&ts[0]))
             }
@@ -1026,7 +1028,7 @@ where
                     current,
                     kind: NaryKind::And,
                     ts,
-                    rec: vec![],
+                    rec: Vec::with_capacity(ts.len()),
                 });
                 Ok(Either::Left(&ts[0]))
             }
@@ -1039,7 +1041,7 @@ where
                     current,
                     kind: NaryKind::Or,
                     ts,
-                    rec: vec![],
+                    rec: Vec::with_capacity(ts.len()),
                 });
                 Ok(Either::Left(&ts[0]))
             }
@@ -1052,7 +1054,7 @@ where
                     current,
                     kind: NaryKind::Xor,
                     ts,
-                    rec: vec![],
+                    rec: Vec::with_capacity(ts.len()),
                 });
                 Ok(Either::Left(&ts[0]))
             }
@@ -1071,7 +1073,7 @@ where
                     current,
                     ts,
                     t: concl,
-                    rec: vec![],
+                    rec: Vec::with_capacity(ts.len()),
                 });
                 Ok(Either::Left(&ts[0]))
             }

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -29,6 +29,7 @@ use crate::ast::alg::{
 };
 use crate::containers::InsertableMapping;
 use crate::traits::{Contains, Repr};
+use delegate::delegate;
 use either::Either;
 use std::collections::HashMap;
 use yaspar::ast::Keyword;
@@ -99,6 +100,20 @@ where
         memo_term_recursion(self, t)
     }
 
+    delegate! {
+        to self.inner {
+            fn on_attribute_keyword(&mut self, keyword: &Keyword) -> Result<Self::Attr, Self::Err>;
+            fn on_attribute_constant(&mut self, keyword: &Keyword, constant: &Constant<Str>) -> Result<Self::Attr, Self::Err>;
+            fn on_attribute_symbol(&mut self, keyword: &Keyword, symbol: &Str) -> Result<Self::Attr, Self::Err>;
+            fn on_attribute_named(&mut self, name: &Str) -> Result<Self::Attr, Self::Err>;
+            fn on_attribute_pattern(&mut self, patterns: &[T], patterns_rec: Vec<Self::Out>) -> Result<Self::Attr, Self::Err>;
+            fn on_let_binding(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, binding_idx: usize, binding_rec: Self::Out) -> Result<Self::Binding, Self::Err>;
+            fn setup_let_scope(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: &[Self::Binding]) -> Result<(), Self::Err>;
+            fn setup_quantifier_scope(&mut self, current: &T, vs: &[VarBinding<Str, So>], t: &T, is_forall: bool) -> Result<(), Self::Err>;
+            fn setup_match_case_scope(&mut self, current: &T, scrutinee: &T, cases: &[PatternArm<Str, T>], scrutinee_rec: &Self::Out, case_idx: usize) -> Result<Self::Pattern, Self::Err>;
+        }
+    }
+
     fn on_constant(
         &mut self,
         current: &T,
@@ -140,28 +155,6 @@ where
         Ok(r)
     }
 
-    fn on_let_binding(
-        &mut self,
-        current: &T,
-        vs: &[VarBinding<Str, T>],
-        body: &T,
-        binding_idx: usize,
-        binding_rec: Self::Out,
-    ) -> Result<Self::Binding, Self::Err> {
-        self.inner
-            .on_let_binding(current, vs, body, binding_idx, binding_rec)
-    }
-
-    fn setup_let_scope(
-        &mut self,
-        current: &T,
-        vs: &[VarBinding<Str, T>],
-        body: &T,
-        vs_rec: &[Self::Binding],
-    ) -> Result<(), Self::Err> {
-        self.inner.setup_let_scope(current, vs, body, vs_rec)
-    }
-
     fn on_let(
         &mut self,
         current: &T,
@@ -173,16 +166,6 @@ where
         let r = self.inner.on_let(current, vs, body, vs_rec, body_rec)?;
         self.cache.insert(current.clone(), r.clone());
         Ok(r)
-    }
-
-    fn setup_quantifier_scope(
-        &mut self,
-        current: &T,
-        vs: &[VarBinding<Str, So>],
-        t: &T,
-        is_forall: bool,
-    ) -> Result<(), Self::Err> {
-        self.inner.setup_quantifier_scope(current, vs, t, is_forall)
     }
 
     fn on_exists(
@@ -209,29 +192,25 @@ where
         Ok(r)
     }
 
-    fn setup_match_case_scope(
+    fn on_match_arm(
         &mut self,
         current: &T,
         scrutinee: &T,
         cases: &[PatternArm<Str, T>],
         scrutinee_rec: &Self::Out,
         case_idx: usize,
-    ) -> Result<Self::Pattern, Self::Err> {
-        self.inner
-            .setup_match_case_scope(current, scrutinee, cases, scrutinee_rec, case_idx)
-    }
-
-    fn on_match_arm(
-        &mut self,
-        current: &T,
-        scrutinee: &T,
-        cases: &[PatternArm<Str, T>],
-        case_idx: usize,
         current_pattern: Self::Pattern,
         arm: Self::Out,
     ) -> Result<Self::Arm, Self::Err> {
-        self.inner
-            .on_match_arm(current, scrutinee, cases, case_idx, current_pattern, arm)
+        self.inner.on_match_arm(
+            current,
+            scrutinee,
+            cases,
+            scrutinee_rec,
+            case_idx,
+            current_pattern,
+            arm,
+        )
     }
 
     fn on_match(
@@ -260,38 +239,6 @@ where
         let r = self.inner.on_annotated(current, t, anns, t_rec, anns_rec)?;
         self.cache.insert(current.clone(), r.clone());
         Ok(r)
-    }
-
-    fn on_attribute_keyword(&mut self, keyword: &Keyword) -> Result<Self::Attr, Self::Err> {
-        self.inner.on_attribute_keyword(keyword)
-    }
-
-    fn on_attribute_constant(
-        &mut self,
-        keyword: &Keyword,
-        constant: &Constant<Str>,
-    ) -> Result<Self::Attr, Self::Err> {
-        self.inner.on_attribute_constant(keyword, constant)
-    }
-
-    fn on_attribute_symbol(
-        &mut self,
-        keyword: &Keyword,
-        symbol: &Str,
-    ) -> Result<Self::Attr, Self::Err> {
-        self.inner.on_attribute_symbol(keyword, symbol)
-    }
-
-    fn on_attribute_named(&mut self, name: &Str) -> Result<Self::Attr, Self::Err> {
-        self.inner.on_attribute_named(name)
-    }
-
-    fn on_attribute_pattern(
-        &mut self,
-        patterns: &[T],
-        patterns_rec: Vec<Self::Out>,
-    ) -> Result<Self::Attr, Self::Err> {
-        self.inner.on_attribute_pattern(patterns, patterns_rec)
     }
 
     fn on_eq(

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -32,6 +32,7 @@ use crate::traits::{Contains, Repr};
 use delegate::delegate;
 use either::Either;
 use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
 use yaspar::ast::Keyword;
 
 /// A caching wrapper that memoizes the `Out` results of a [`TermRecursor`].
@@ -50,6 +51,20 @@ pub struct Memoize<R, M> {
     /// The term-to-result cache. Publicly accessible so callers can inspect, reuse,
     /// or pre-populate it across traversals.
     pub cache: M,
+}
+
+impl<R, M> Deref for Memoize<R, M> {
+    type Target = R;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<R, M> DerefMut for Memoize<R, M> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
 }
 
 impl<R, T, Out> Memoize<R, HashMap<T, Out>> {

--- a/src/raw/tc.rs
+++ b/src/raw/tc.rs
@@ -905,6 +905,7 @@ where
         current: &T,
         _scrutinee: &T,
         _cases: &[alg::PatternArm<St, T>],
+        _scrutinee_rec: &Self::Out,
         _case_idx: usize,
         current_pattern: Self::Pattern,
         arm: Self::Out,

--- a/src/untyped/instance.rs
+++ b/src/untyped/instance.rs
@@ -362,12 +362,10 @@ impl ActionOnTerm for UntypedAst {
                 }
                 IdentifierKind::Implies => {
                     match args.pop() {
-                        None => {}
-                        Some(rt) => {
-                            if !args.is_empty() {
-                                return Ok(wrap(ATerm::Implies(args, rt).into(), range));
-                            }
+                        Some(rt) if !args.is_empty() => {
+                            return Ok(wrap(ATerm::Implies(args, rt).into(), range));
                         }
+                        _ => {}
                     }
                     Err(ParseError::User {
                         error: GrammarError::Other {

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -21,7 +21,7 @@ fn run_script(script: &str) {
     let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     for cmd in &cmds {
-        cmd.to_cvc5(&mut es, &mut ctx).unwrap();
+        cmd.to_cvc5(&mut es).unwrap();
     }
 }
 
@@ -39,7 +39,7 @@ fn check_sat(script: &str) -> bool {
     let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     for cmd in &cmds {
-        cmd.to_cvc5(&mut es, &mut ctx).unwrap();
+        cmd.to_cvc5(&mut es).unwrap();
     }
     es.solver.check_sat().is_sat()
 }
@@ -279,7 +279,7 @@ fn translate_term_standalone() {
     let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     for cmd in &cmds {
-        cmd.to_cvc5(&mut es, &mut ctx).unwrap();
+        cmd.to_cvc5(&mut es).unwrap();
     }
     // All commands translated without error
 }
@@ -295,7 +295,7 @@ fn error_unknown_global() {
     let x = ctx.simple_sorted_symbol("x", int_sort);
     let tm = TermManager::new();
     let mut env = Cvc5Env::create(&tm);
-    assert!(x.to_cvc5(&mut env, &mut ctx).is_err());
+    assert!(x.to_cvc5(&mut env).is_err());
 }
 
 #[test]
@@ -306,7 +306,7 @@ fn error_unsupported_sort() {
     let custom = ctx.simple_sort("MyCustomSort");
     let tm = TermManager::new();
     let mut env = Cvc5Env::create(&tm);
-    assert!(custom.to_cvc5(&mut env, &mut ctx).is_err());
+    assert!(custom.to_cvc5(&mut env).is_err());
 }
 
 // ── Locals cleanup tests ─────────────────────────────────────
@@ -332,7 +332,7 @@ fn locals_cleaned_up_after_quantifier_error() {
 
     // Translate set-logic only — skip declare-const y
     cmds[0]
-        .to_cvc5(&mut Cvc5EnvSolver::new(&mut env, &mut solver), &mut ctx)
+        .to_cvc5(&mut Cvc5EnvSolver::new(&mut env, &mut solver))
         .unwrap();
 
     // Extract the forall term from the assert command and translate it directly
@@ -343,13 +343,13 @@ fn locals_cleaned_up_after_quantifier_error() {
     };
 
     // Should fail because y is not registered
-    assert!(forall.to_cvc5(&mut env, &mut ctx).is_err());
+    assert!(forall.to_cvc5(&mut env).is_err());
 
     // Now register y and retry — env should be clean (no stale locals from x)
     cmds[1]
-        .to_cvc5(&mut Cvc5EnvSolver::new(&mut env, &mut solver), &mut ctx)
+        .to_cvc5(&mut Cvc5EnvSolver::new(&mut env, &mut solver))
         .unwrap();
-    assert!(forall.to_cvc5(&mut env, &mut ctx).is_ok());
+    assert!(forall.to_cvc5(&mut env).is_ok());
 }
 
 /// After a failed translation inside a let body, the env should recover.
@@ -370,15 +370,15 @@ fn locals_cleaned_up_after_let_error() {
     let mut solver = Solver::new(&tm);
     let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
-    cmds[0].to_cvc5(&mut es, &mut ctx).unwrap();
+    cmds[0].to_cvc5(&mut es).unwrap();
     // Skip declare-const y
 
     // assert with let should fail because y is not registered
-    assert!(cmds[2].to_cvc5(&mut es, &mut ctx).is_err());
+    assert!(cmds[2].to_cvc5(&mut es).is_err());
 
     // Register y and retry
-    cmds[1].to_cvc5(&mut es, &mut ctx).unwrap();
-    assert!(cmds[2].to_cvc5(&mut es, &mut ctx).is_ok());
+    cmds[1].to_cvc5(&mut es).unwrap();
+    assert!(cmds[2].to_cvc5(&mut es).is_ok());
 }
 
 /// After a failed define-fun translation, the env should recover.
@@ -399,15 +399,15 @@ fn locals_cleaned_up_after_define_fun_error() {
     let mut solver = Solver::new(&tm);
     let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
-    cmds[0].to_cvc5(&mut es, &mut ctx).unwrap();
+    cmds[0].to_cvc5(&mut es).unwrap();
     // Skip declare-const y
 
     // define-fun should fail because y is not registered
-    assert!(cmds[2].to_cvc5(&mut es, &mut ctx).is_err());
+    assert!(cmds[2].to_cvc5(&mut es).is_err());
 
     // Register y and retry
-    cmds[1].to_cvc5(&mut es, &mut ctx).unwrap();
-    assert!(cmds[2].to_cvc5(&mut es, &mut ctx).is_ok());
+    cmds[1].to_cvc5(&mut es).unwrap();
+    assert!(cmds[2].to_cvc5(&mut es).is_ok());
 }
 
 /// :named annotations in assert should register the term as a global,
@@ -432,7 +432,7 @@ fn named_annotation_registers_global() {
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     // All commands should succeed — "pos" from :named must be usable in the second assert
     for cmd in &cmds {
-        cmd.to_cvc5(&mut es, &mut ctx).unwrap();
+        cmd.to_cvc5(&mut es).unwrap();
     }
 }
 
@@ -638,7 +638,7 @@ fn with_script_results(script: &str, options: &[(&str, &str)], f: impl FnOnce(&[
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     let results: Vec<_> = cmds
         .iter()
-        .map(|cmd| cmd.to_cvc5(&mut es, &mut ctx).unwrap())
+        .map(|cmd| cmd.to_cvc5(&mut es).unwrap())
         .collect();
     f(&results);
 }

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -3,7 +3,7 @@
 
 #![cfg(feature = "cvc5")]
 
-use cvc5_rs::{Solver, TermManager};
+use cvc5::{Solver, TermManager};
 use yaspar_ir::ast::{Context, ObjectAllocatorExt, Typecheck};
 use yaspar_ir::cvc5::{ConvertToCvc5, Cvc5Env, Cvc5EnvSolver};
 use yaspar_ir::untyped::UntypedAst;

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -18,7 +18,7 @@ fn run_script(script: &str) {
         .unwrap();
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     for cmd in &cmds {
         cmd.to_cvc5(&mut es, &mut ctx).unwrap();
@@ -36,7 +36,7 @@ fn check_sat(script: &str) -> bool {
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
     solver.set_option("produce-models", "true");
-    let mut env = Cvc5Env::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     for cmd in &cmds {
         cmd.to_cvc5(&mut es, &mut ctx).unwrap();
@@ -276,7 +276,7 @@ fn translate_term_standalone() {
         .unwrap();
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     for cmd in &cmds {
         cmd.to_cvc5(&mut es, &mut ctx).unwrap();
@@ -294,7 +294,7 @@ fn error_unknown_global() {
     let int_sort = ctx.int_sort();
     let x = ctx.simple_sorted_symbol("x", int_sort);
     let tm = TermManager::new();
-    let mut env = Cvc5Env::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
     assert!(x.to_cvc5(&mut env, &mut ctx).is_err());
 }
 
@@ -305,7 +305,7 @@ fn error_unsupported_sort() {
     // A custom sort that cvc5 doesn't know about
     let custom = ctx.simple_sort("MyCustomSort");
     let tm = TermManager::new();
-    let mut env = Cvc5Env::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
     assert!(custom.to_cvc5(&mut env, &mut ctx).is_err());
 }
 
@@ -328,7 +328,7 @@ fn locals_cleaned_up_after_quantifier_error() {
 
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
 
     // Translate set-logic only — skip declare-const y
     cmds[0]
@@ -368,7 +368,7 @@ fn locals_cleaned_up_after_let_error() {
 
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     cmds[0].to_cvc5(&mut es, &mut ctx).unwrap();
     // Skip declare-const y
@@ -397,7 +397,7 @@ fn locals_cleaned_up_after_define_fun_error() {
 
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     cmds[0].to_cvc5(&mut es, &mut ctx).unwrap();
     // Skip declare-const y
@@ -428,7 +428,7 @@ fn named_annotation_registers_global() {
 
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     // All commands should succeed — "pos" from :named must be usable in the second assert
     for cmd in &cmds {
@@ -634,7 +634,7 @@ fn with_script_results(script: &str, options: &[(&str, &str)], f: impl FnOnce(&[
     for (k, v) in options {
         solver.set_option(k, v);
     }
-    let mut env = Cvc5Env::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     let results: Vec<_> = cmds
         .iter()

--- a/tests/rec.rs
+++ b/tests/rec.rs
@@ -134,12 +134,12 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
 
     fn on_match_arm(
         &mut self,
-        current: &T,
-        scrutinee: &T,
-        cases: &[PatternArm<Str, T>],
-        scrutinee_rec: &Self::Out,
-        case_idx: usize,
-        current_pattern: Self::Pattern,
+        _current: &Term,
+        _scrutinee: &Term,
+        _cases: &[PatternArm<Str, Term>],
+        _scrutinee_rec: &Self::Out,
+        _case_idx: usize,
+        _current_pattern: Self::Pattern,
         arm: Self::Out,
     ) -> Result<Self::Arm, Self::Err> {
         Ok(arm)

--- a/tests/rec.rs
+++ b/tests/rec.rs
@@ -134,11 +134,12 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
 
     fn on_match_arm(
         &mut self,
-        _current: &Term,
-        _scrutinee: &Term,
-        _cases: &[PatternArm<Str, Term>],
-        _case_idx: usize,
-        _current_pattern: Self::Pattern,
+        current: &T,
+        scrutinee: &T,
+        cases: &[PatternArm<Str, T>],
+        scrutinee_rec: &Self::Out,
+        case_idx: usize,
+        current_pattern: Self::Pattern,
         arm: Self::Out,
     ) -> Result<Self::Arm, Self::Err> {
         Ok(arm)

--- a/tests/rec_memo.rs
+++ b/tests/rec_memo.rs
@@ -141,11 +141,12 @@ impl TermRecursor<Str, Sort, Term> for TouchedTermSize {
 
     fn on_match_arm(
         &mut self,
-        _current: &Term,
-        _scrutinee: &Term,
-        _cases: &[PatternArm<Str, Term>],
-        _case_idx: usize,
-        _current_pattern: Self::Pattern,
+        current: &T,
+        scrutinee: &T,
+        cases: &[PatternArm<Str, T>],
+        scrutinee_rec: &Self::Out,
+        case_idx: usize,
+        current_pattern: Self::Pattern,
         arm: Self::Out,
     ) -> Result<Self::Arm, Self::Err> {
         Ok(arm)

--- a/tests/rec_memo.rs
+++ b/tests/rec_memo.rs
@@ -141,12 +141,12 @@ impl TermRecursor<Str, Sort, Term> for TouchedTermSize {
 
     fn on_match_arm(
         &mut self,
-        current: &T,
-        scrutinee: &T,
-        cases: &[PatternArm<Str, T>],
-        scrutinee_rec: &Self::Out,
-        case_idx: usize,
-        current_pattern: Self::Pattern,
+        _current: &Term,
+        _scrutinee: &Term,
+        _cases: &[PatternArm<Str, Term>],
+        _scrutinee_rec: &Self::Out,
+        _case_idx: usize,
+        _current_pattern: Self::Pattern,
         arm: Self::Out,
     ) -> Result<Self::Arm, Self::Err> {
         Ok(arm)


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*

This PR ported to the latest cvc5 0.4 crate. It also uses TermRecursor to recurse on terms when converting yaspar terms to cvc5 terms. It also added a missing argument to `on_match_arm`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
