### PR TITLE
add cleanup functions to TermRecursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ impl TermRecursor<Str, Sort, Term> for TermDepth {
     fn on_forall(&mut self, _: &Term, _: &[VarBinding<Str, Sort>], _: &Term, r: usize) -> Result<usize, Bottom> { Ok(1 + r) }
     fn on_exists(&mut self, _: &Term, _: &[VarBinding<Str, Sort>], _: &Term, r: usize) -> Result<usize, Bottom> { Ok(1 + r) }
     fn setup_match_case_scope(&mut self, _: &Term, _: &Term, _: &[PatternArm<Str, Term>], _: &usize, _: usize) -> Result<(), Bottom> { Ok(()) }
-    fn on_match_arm(&mut self, _: &Term, _: &Term, _: &[PatternArm<Str, Term>], _: usize, r: usize) -> Result<usize, Bottom> { Ok(r) }
+    fn on_match_arm(&mut self, _: &Term, _: &Term, _: &[PatternArm<Str, Term>], _: usize, _: (), r: usize) -> Result<usize, Bottom> { Ok(r) }
     fn on_match(&mut self, _: &Term, _: &Term, _: &[PatternArm<Str, Term>], s: usize, arms: Vec<usize>) -> Result<usize, Bottom> {
         Ok(1 + arms.into_iter().chain([s]).max().unwrap())
     }
@@ -516,6 +516,104 @@ It returns the output directly without wrapping in `Result`.
 
 The convenience trait `TypedTermRecursor` is a marker for recursors specialized to the typed AST
 (`Str`, `Sort`, `Term`). An analogous `UntypedTermRecursor` exists for untyped ASTs.
+
+### Error handling and cleanup hooks
+
+When a `TermRecursor` callback returns `Err`, the traversal aborts immediately. However,
+scoped constructs (`let`, `forall`/`exists`, `match`) may have already called their
+`setup_*` hooks to extend the recursor's environment. If the error occurs inside such a
+scope, the environment modifications from those hooks would be left behind — potentially
+corrupting the recursor's state for future use.
+
+To address this, the traversal engine automatically **rewinds the stack** on error, calling
+a corresponding `cleanup_*_on_error` hook for each scoped frame that was entered but not
+yet completed:
+
+| Setup hook                   | Cleanup hook                          | Frame type  |
+|------------------------------|---------------------------------------|-------------|
+| `setup_let_scope`            | `cleanup_let_scope_on_error`          | `let`       |
+| `setup_quantifier_scope`     | `cleanup_quantifier_scope_on_error`   | `forall` / `exists` |
+| `setup_match_case_scope`     | `cleanup_match_case_scope_on_error`   | `match` arm |
+
+All three cleanup hooks have **default no-op implementations**, so existing recursors that
+set `Err = Bottom` (infallible) are unaffected. Recursors that can fail and maintain mutable
+state across scopes should override the relevant hooks to undo their `setup_*` side effects.
+
+For example, a recursor that pushes a scope frame in `setup_quantifier_scope` should pop it
+in `cleanup_quantifier_scope_on_error`:
+
+```rust
+fn setup_quantifier_scope(
+    &mut self, _: &Term, vs: &[VarBinding<Str, Sort>], _: &Term, _: bool,
+) -> Result<(), MyError> {
+    self.env.push(/* new scope from vs */);
+    Ok(())
+}
+
+fn cleanup_quantifier_scope_on_error(
+    &mut self, _: &Term, _: &[VarBinding<Str, Sort>], _: &Term, _: bool,
+) {
+    self.env.pop();
+}
+```
+
+The cleanup hooks are called in stack order (innermost scope first) during the rewind,
+mirroring the reverse of the `setup_*` call sequence.
+
+### Reducing boilerplate with `TypedBuilder`
+
+Implementing `TermRecursor` requires defining callbacks for every term variant, even when
+most of them simply rebuild the term unchanged. The `TypedBuilder` struct provides a
+complete set of identity-rebuild callbacks for the typed AST (`Str`, `Sort`, `Term`),
+so custom recursors only need to override the callbacks with actual logic.
+
+`TypedBuilder` is designed to be embedded as a field and combined with the
+[`delegate`](https://crates.io/crates/delegate) crate to forward boilerplate callbacks:
+
+```rust
+use delegate::delegate;
+use yaspar_ir::ast::*;
+use yaspar_ir::ast::alg::*;
+use yaspar_ir::ast::boilerplates::TypedBuilder;
+
+pub struct MyRecursor<'a> {
+    inner: TypedBuilder<'a, Context>,
+    // ... custom state ...
+}
+
+impl TermRecursor<Str, Sort, Term> for MyRecursor<'_> {
+    type Out = Term;
+    type Attr = Attribute;
+    type Binding = VarBinding<Str, Term>;
+    type Pattern = ();
+    type Arm = PatternArm;
+    type Err = Bottom;
+
+    // Forward all rebuild-only callbacks to TypedBuilder
+    delegate! {
+        to self.inner {
+            fn on_constant(&mut self, current: &Term, c: &Constant, s: &Option<Sort>) -> Result<Term, Bottom>;
+            fn on_global(&mut self, current: &Term, id: &QualifiedIdentifier, s: &Option<Sort>) -> Result<Term, Bottom>;
+            fn on_app(&mut self, current: &Term, id: &QualifiedIdentifier, ts: &[Term], s: &Option<Sort>, recs: Vec<Term>) -> Result<Term, Bottom>;
+            fn on_eq(&mut self, current: &Term, a: &Term, b: &Term, a_rec: Term, b_rec: Term) -> Result<Term, Bottom>;
+            fn on_and(&mut self, current: &Term, ts: &[Term], recs: Vec<Term>) -> Result<Term, Bottom>;
+            fn on_or(&mut self, current: &Term, ts: &[Term], recs: Vec<Term>) -> Result<Term, Bottom>;
+            // ... other callbacks that don't need custom logic ...
+        }
+    }
+
+    // Override only the callbacks with custom logic
+    fn on_local(&mut self, current: &Term, id: &Local) -> Result<Term, Bottom> {
+        // custom substitution, transformation, etc.
+        Ok(current.clone())
+    }
+
+    // ...
+}
+```
+
+See `LetEliminatorInner` in `ast::letelim` and `MonomorphizerInner` in `ast::mono` for
+complete real-world examples of this pattern.
 
 ### Memoized term recursion with `Memoize`
 

--- a/src/raw/alg/rec.rs
+++ b/src/raw/alg/rec.rs
@@ -77,6 +77,17 @@ impl IsBottom for Bottom {
 ///   entering the body of a `Forall` or `Exists`.
 /// - [`setup_match_case_scope`](TermRecursor::setup_match_case_scope) – called before
 ///   entering each match arm body.
+///
+/// Each `setup_*` hook has a corresponding `cleanup_*_on_error` hook that is called
+/// during stack unwinding when a callback returns `Err`. These allow the implementor
+/// to undo any environment modifications made by the `setup_*` hook:
+///
+/// - [`cleanup_let_scope_on_error`](TermRecursor::cleanup_let_scope_on_error)
+/// - [`cleanup_quantifier_scope_on_error`](TermRecursor::cleanup_quantifier_scope_on_error)
+/// - [`cleanup_match_case_scope_on_error`](TermRecursor::cleanup_match_case_scope_on_error)
+///
+/// All cleanup hooks have default no-op implementations, so infallible recursors
+/// (`Err = Bottom`) need not provide them.
 #[allow(clippy::too_many_arguments)]
 pub trait TermRecursor<Str, So, T> {
     /// The type produced by each recursive step.
@@ -170,6 +181,10 @@ pub trait TermRecursor<Str, So, T> {
         vs_rec: &[Self::Binding],
     ) -> Result<(), Self::Err>;
 
+    /// Called during error rewind for each `let` scope that was entered (via
+    /// [`setup_let_scope`](Self::setup_let_scope)) but not yet completed. Override this
+    /// to undo any environment modifications made in `setup_let_scope`. The default
+    /// implementation is a no-op.
     fn cleanup_let_scope_on_error(
         &mut self,
         _current: &T,
@@ -198,6 +213,10 @@ pub trait TermRecursor<Str, So, T> {
         is_forall: bool,
     ) -> Result<(), Self::Err>;
 
+    /// Called during error rewind for each quantifier scope that was entered (via
+    /// [`setup_quantifier_scope`](Self::setup_quantifier_scope)) but not yet completed.
+    /// Override this to undo any environment modifications made in
+    /// `setup_quantifier_scope`. The default implementation is a no-op.
     fn cleanup_quantifier_scope_on_error(
         &mut self,
         _current: &T,
@@ -234,6 +253,10 @@ pub trait TermRecursor<Str, So, T> {
         case_idx: usize,
     ) -> Result<Self::Pattern, Self::Err>;
 
+    /// Called during error rewind for each match arm scope that was entered (via
+    /// [`setup_match_case_scope`](Self::setup_match_case_scope)) but not yet completed.
+    /// Override this to undo any environment modifications made in
+    /// `setup_match_case_scope`. The default implementation is a no-op.
     fn cleanup_match_case_scope_on_error(
         &mut self,
         _current: &T,
@@ -508,6 +531,21 @@ type PushResult<'a, R, Str, So, T> = Result<
     <R as TermRecursor<Str, So, T>>::Err,
 >;
 
+/// The traversal engine that drives a [`TermRecursor`] over a term tree.
+///
+/// This trait encapsulates the stack-based traversal algorithm: expanding nodes,
+/// propagating results upward, and handling error cleanup. It is parameterized over
+/// the recursor `R` so that different schemes can customize the traversal — for
+/// example, [`MemoizedScheme`](super::rec_memo::MemoizedScheme) overrides
+/// [`expand_and_resolve`](Self::expand_and_resolve) to check a cache before descending.
+///
+/// The default implementations of all methods form a complete traversal. Implementors
+/// typically only need to override [`expand_and_resolve`](Self::expand_and_resolve) to
+/// inject custom behavior (e.g. caching) at the point where a term is first visited.
+///
+/// End users do not interact with this trait directly; instead they implement
+/// [`TermRecursor`] and call [`recurse_on_term`](TermRecursor::recurse_on_term), which
+/// delegates to [`BasicScheme`].
 pub(crate) trait TermRecursionScheme<R, Str, So, T>
 where
     R: TermRecursor<Str, So, T>,
@@ -1137,8 +1175,10 @@ where
         }
     }
 
-    /// Only when the recursion fails, this function is called to rewind the recursion stack
-    /// and `cleanup_*` callbacks are invoked to clean up the recursor state, if necessary.
+    /// Unwind the traversal stack after an error, calling `cleanup_*_on_error` hooks
+    /// for each scoped frame (`LetBody`, `Quantifier`, `MatchCases`) that was entered
+    /// but not yet completed. Frames are popped innermost-first, mirroring the reverse
+    /// of the `setup_*` call sequence. Non-scoped frames are silently discarded.
     fn rewind_stack_for_error(recursor: &mut R, stack: &mut RStack<'_, R, Str, So, T>) {
         while let Some(frame) = stack.pop() {
             match frame {
@@ -1179,6 +1219,11 @@ where
         }
     }
 
+    /// Core traversal loop operating on a caller-provided stack.
+    ///
+    /// Alternates between expanding the next child and pushing results upward until
+    /// the stack is empty. Separated from [`term_recursion`](Self::term_recursion) so
+    /// that the caller can perform cleanup on the stack if an error occurs.
     fn term_recursion_inner<'a>(
         recursor: &mut R,
         term: &'a T,
@@ -1200,6 +1245,11 @@ where
         }
     }
 
+    /// Top-level entry point for the traversal.
+    ///
+    /// Creates the stack, runs [`term_recursion_inner`](Self::term_recursion_inner),
+    /// and calls [`rewind_stack_for_error`](Self::rewind_stack_for_error) if the
+    /// traversal fails, ensuring that all `setup_*` side effects are cleaned up.
     fn term_recursion(recursor: &mut R, term: &T) -> Result<R::Out, R::Err>
     where
         T: Contains<T: Repr<T = Term<Str, So, T>>>,
@@ -1213,6 +1263,11 @@ where
     }
 }
 
+/// The default (non-memoized) traversal scheme.
+///
+/// Uses all default method implementations from [`TermRecursionScheme`], performing a
+/// straightforward depth-first walk without caching. This is the scheme used by
+/// [`TermRecursor::recurse_on_term`].
 pub(crate) struct BasicScheme;
 
 impl<R, Str, So, T> TermRecursionScheme<R, Str, So, T> for BasicScheme where

--- a/src/raw/alg/rec.rs
+++ b/src/raw/alg/rec.rs
@@ -86,8 +86,9 @@ impl IsBottom for Bottom {
 /// - [`cleanup_quantifier_scope_on_error`](TermRecursor::cleanup_quantifier_scope_on_error)
 /// - [`cleanup_match_case_scope_on_error`](TermRecursor::cleanup_match_case_scope_on_error)
 ///
+/// These cleanup functions take as arguments owned recursive values and must succeed as the last resorts.
 /// All cleanup hooks have default no-op implementations, so infallible recursors
-/// (`Err = Bottom`) need not provide them.
+/// (e.g. `Err = Bottom`) need not provide them.
 #[allow(clippy::too_many_arguments)]
 pub trait TermRecursor<Str, So, T> {
     /// The type produced by each recursive step.
@@ -677,7 +678,7 @@ where
                             scrutinee,
                             cases,
                             scrutinee_rec: result,
-                            case_rec: vec![],
+                            case_rec: Vec::with_capacity(cases.len()),
                             current_pattern: None,
                         }));
                     }
@@ -740,7 +741,7 @@ where
                     body,
                     anns,
                 } => {
-                    let mut anns_rec: Vec<R::Attr> = vec![];
+                    let mut anns_rec: Vec<R::Attr> = Vec::with_capacity(anns.len());
                     Self::advance_attributes_until_pattern(recursor, anns, &mut anns_rec)?;
                     if anns_rec.len() >= anns.len() {
                         result = recursor.on_annotated(current, body, anns, result, anns_rec)?;
@@ -1022,7 +1023,7 @@ where
                         id,
                         args,
                         sort,
-                        rec: vec![],
+                        rec: Vec::with_capacity(args.len()),
                     });
                     Ok(Either::Left(&args[0]))
                 }
@@ -1043,7 +1044,7 @@ where
                         current,
                         vs,
                         body,
-                        vs_rec: vec![],
+                        vs_rec: Vec::with_capacity(vs.len()),
                     });
                     Ok(Either::Left(&vs[0].2))
                 }
@@ -1096,7 +1097,7 @@ where
                         current,
                         kind: NaryKind::Distinct,
                         ts,
-                        rec: vec![],
+                        rec: Vec::with_capacity(ts.len()),
                     });
                     Ok(Either::Left(&ts[0]))
                 }
@@ -1109,7 +1110,7 @@ where
                         current,
                         kind: NaryKind::And,
                         ts,
-                        rec: vec![],
+                        rec: Vec::with_capacity(ts.len()),
                     });
                     Ok(Either::Left(&ts[0]))
                 }
@@ -1122,7 +1123,7 @@ where
                         current,
                         kind: NaryKind::Or,
                         ts,
-                        rec: vec![],
+                        rec: Vec::with_capacity(ts.len()),
                     });
                     Ok(Either::Left(&ts[0]))
                 }
@@ -1135,7 +1136,7 @@ where
                         current,
                         kind: NaryKind::Xor,
                         ts,
-                        rec: vec![],
+                        rec: Vec::with_capacity(ts.len()),
                     });
                     Ok(Either::Left(&ts[0]))
                 }
@@ -1154,7 +1155,7 @@ where
                         current,
                         ts,
                         t: concl,
-                        rec: vec![],
+                        rec: Vec::with_capacity(ts.len()),
                     });
                     Ok(Either::Left(&ts[0]))
                 }

--- a/src/raw/alg/rec.rs
+++ b/src/raw/alg/rec.rs
@@ -170,6 +170,15 @@ pub trait TermRecursor<Str, So, T> {
         vs_rec: &[Self::Binding],
     ) -> Result<(), Self::Err>;
 
+    fn cleanup_let_scope_on_error(
+        &mut self,
+        _current: &T,
+        _vs: &[VarBinding<Str, T>],
+        _body: &T,
+        _vs_rec: Vec<Self::Binding>,
+    ) {
+    }
+
     /// Called after all let-binding RHS and the body have been recursed.
     fn on_let(
         &mut self,
@@ -188,6 +197,16 @@ pub trait TermRecursor<Str, So, T> {
         t: &T,
         is_forall: bool,
     ) -> Result<(), Self::Err>;
+
+    fn cleanup_quantifier_scope_on_error(
+        &mut self,
+        _current: &T,
+        _vs: &[VarBinding<Str, So>],
+        _t: &T,
+        _is_forall: bool,
+    ) {
+    }
+
     /// Called for `exists` after the body has been recursed.
     fn on_exists(
         &mut self,
@@ -214,6 +233,17 @@ pub trait TermRecursor<Str, So, T> {
         scrutinee_rec: &Self::Out,
         case_idx: usize,
     ) -> Result<Self::Pattern, Self::Err>;
+
+    fn cleanup_match_case_scope_on_error(
+        &mut self,
+        _current: &T,
+        _scrutinee: &T,
+        _cases: &[PatternArm<Str, T>],
+        _scrutinee_rec: Self::Out,
+        _case_idx: usize,
+    ) {
+    }
+
     /// Called after each match arm body has been recursed.
     fn on_match_arm(
         &mut self,
@@ -1094,21 +1124,82 @@ where
     }
 }
 
+pub(crate) fn rewind_stack_for_error<R, Str, So, T>(
+    recursor: &mut R,
+    stack: &mut RStack<'_, R, Str, So, T>,
+) where
+    R: TermRecursor<Str, So, T>,
+{
+    while let Some(frame) = stack.pop() {
+        match frame {
+            Frame::LetBody {
+                current,
+                vs,
+                body,
+                vs_rec,
+            } => {
+                recursor.cleanup_let_scope_on_error(current, vs, body, vs_rec);
+            }
+            Frame::Quantifier {
+                current,
+                vs,
+                body,
+                is_forall,
+            } => {
+                recursor.cleanup_quantifier_scope_on_error(current, vs, body, is_forall);
+            }
+            Frame::MatchCases {
+                current,
+                scrutinee,
+                cases,
+                scrutinee_rec,
+                case_rec,
+                current_pattern: _,
+            } => {
+                recursor.cleanup_match_case_scope_on_error(
+                    current,
+                    scrutinee,
+                    scrutinee_rec,
+                    cases,
+                    case_rec.len(),
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+pub(crate) fn term_recursion_inner<R, Str, So, T>(
+    recursor: &mut R,
+    term: &T,
+    stack: &mut RStack<'_, R, Str, So, T>,
+) -> Result<R::Out, R::Err>
+where
+    R: TermRecursor<Str, So, T>,
+    T: Contains<T: Repr<T = Term<Str, So, T>>>,
+{
+    let mut result = expand_and_resolve(recursor, stack, term)?;
+    loop {
+        match push_result(recursor, stack, result)? {
+            Either::Left(final_result) => return Ok(final_result),
+            Either::Right(mut frame) => {
+                let child = next_child(recursor, &mut frame)?;
+                stack.push(frame);
+                result = expand_and_resolve(recursor, stack, child)?;
+            }
+        }
+    }
+}
+
 pub(crate) fn term_recursion<R, Str, So, T>(recursor: &mut R, term: &T) -> Result<R::Out, R::Err>
 where
     R: TermRecursor<Str, So, T>,
     T: Contains<T: Repr<T = Term<Str, So, T>>>,
 {
     let mut stack: RStack<'_, R, Str, So, T> = Vec::new();
-    let mut result = expand_and_resolve(recursor, &mut stack, term)?;
-    loop {
-        match push_result(recursor, &mut stack, result)? {
-            Either::Left(final_result) => return Ok(final_result),
-            Either::Right(mut frame) => {
-                let child = next_child(recursor, &mut frame)?;
-                stack.push(frame);
-                result = expand_and_resolve(recursor, &mut stack, child)?;
-            }
-        }
+    let result = term_recursion_inner(recursor, term, &mut stack);
+    if result.is_err() {
+        rewind_stack_for_error(recursor, &mut stack);
     }
+    result
 }

--- a/src/raw/alg/rec.rs
+++ b/src/raw/alg/rec.rs
@@ -100,7 +100,7 @@ pub trait TermRecursor<Str, So, T> {
         Self: Sized,
         T: Contains<T: Repr<T = Term<Str, So, T>>>,
     {
-        term_recursion(self, t)
+        BasicScheme::term_recursion(self, t)
     }
 
     /// Convenience entry point for infallible recursors (where `Err = Bottom`).
@@ -502,231 +502,250 @@ pub(crate) enum NaryKind {
 /// The traversal stack: a `Vec` of frames.
 pub(crate) type RStack<'a, R, Str, So, T> = Vec<Frame<'a, Str, So, T, R>>;
 
-/// Advance `anns_rec` past consecutive non-`Pattern` attributes starting at
-/// `anns[anns_rec.len()]`. Stops when a `Pattern` is encountered or all attributes
-/// are consumed. Non-`Pattern` attributes are processed via the recursor's
-/// `on_attribute_*` callbacks.
-fn advance_attributes_until_pattern<R, Str, So, T>(
-    recursor: &mut R,
-    anns: &[Attribute<Str, T>],
-    anns_rec: &mut Vec<R::Attr>,
-) -> Result<(), R::Err>
-where
-    R: TermRecursor<Str, So, T>,
-{
-    while anns_rec.len() < anns.len() {
-        match &anns[anns_rec.len()] {
-            Attribute::Pattern(ts) => {
-                if ts.is_empty() {
-                    anns_rec.push(recursor.on_attribute_pattern(ts, vec![])?);
-                } else {
-                    break;
-                }
-            }
-            Attribute::Keyword(k) => anns_rec.push(recursor.on_attribute_keyword(k)?),
-            Attribute::Constant(k, c) => anns_rec.push(recursor.on_attribute_constant(k, c)?),
-            Attribute::Symbol(k, s) => anns_rec.push(recursor.on_attribute_symbol(k, s)?),
-            Attribute::Named(s) => anns_rec.push(recursor.on_attribute_named(s)?),
-        }
-    }
-    Ok(())
-}
-
 /// Result of [`push_result`]: either the final value or a frame needing more children.
 type PushResult<'a, R, Str, So, T> = Result<
     Either<<R as TermRecursor<Str, So, T>>::Out, Frame<'a, Str, So, T, R>>,
     <R as TermRecursor<Str, So, T>>::Err,
 >;
 
-/// Propagate a freshly computed `result` upward through the stack.
-///
-/// Pops frames and invokes callbacks as children complete. When a frame still has
-/// unprocessed children, it returns `Either::Right(frame)`, where `frame` is the top of the stack,
-/// so the main loop can push the frame back and expand the next child. Returns `Either::Left(result)`
-/// when the stack is empty (traversal complete).
-pub(crate) fn push_result<'a, R, Str, So, T>(
-    recursor: &mut R,
-    stack: &mut RStack<'a, R, Str, So, T>,
-    mut result: R::Out,
-) -> PushResult<'a, R, Str, So, T>
+pub(crate) trait TermRecursionScheme<R, Str, So, T>
 where
     R: TermRecursor<Str, So, T>,
 {
-    loop {
-        let frame = match stack.pop() {
-            Some(f) => f,
-            None => return Ok(Either::Left(result)),
-        };
-        match frame {
-            Frame::App {
-                current,
-                id,
-                args,
-                sort,
-                mut rec,
-            } => {
-                rec.push(result);
-                if rec.len() >= args.len() {
-                    result = recursor.on_app(current, id, args, sort, rec)?;
-                } else {
-                    return Ok(Either::Right(Frame::App {
-                        current,
-                        id,
-                        args,
-                        sort,
-                        rec,
-                    }));
+    /// Advance `anns_rec` past consecutive non-`Pattern` attributes starting at
+    /// `anns[anns_rec.len()]`. Stops when a `Pattern` is encountered or all attributes
+    /// are consumed. Non-`Pattern` attributes are processed via the recursor's
+    /// `on_attribute_*` callbacks.
+    fn advance_attributes_until_pattern(
+        recursor: &mut R,
+        anns: &[Attribute<Str, T>],
+        anns_rec: &mut Vec<R::Attr>,
+    ) -> Result<(), R::Err> {
+        while anns_rec.len() < anns.len() {
+            match &anns[anns_rec.len()] {
+                Attribute::Pattern(ts) => {
+                    if ts.is_empty() {
+                        anns_rec.push(recursor.on_attribute_pattern(ts, vec![])?);
+                    } else {
+                        break;
+                    }
                 }
+                Attribute::Keyword(k) => anns_rec.push(recursor.on_attribute_keyword(k)?),
+                Attribute::Constant(k, c) => anns_rec.push(recursor.on_attribute_constant(k, c)?),
+                Attribute::Symbol(k, s) => anns_rec.push(recursor.on_attribute_symbol(k, s)?),
+                Attribute::Named(s) => anns_rec.push(recursor.on_attribute_named(s)?),
             }
-            Frame::LetBindings {
-                current,
-                vs,
-                body,
-                mut vs_rec,
-            } => {
-                vs_rec.push(recursor.on_let_binding(current, vs, body, vs_rec.len(), result)?);
-                let frame = if vs_rec.len() >= vs.len() {
-                    Frame::LetBody {
+        }
+        Ok(())
+    }
+
+    /// Propagate a freshly computed `result` upward through the stack.
+    ///
+    /// Pops frames and invokes callbacks as children complete. When a frame still has
+    /// unprocessed children, it returns `Either::Right(frame)`, where `frame` is the top of the stack,
+    /// so the main loop can push the frame back and expand the next child. Returns `Either::Left(result)`
+    /// when the stack is empty (traversal complete).
+    fn push_result<'a>(
+        recursor: &mut R,
+        stack: &mut RStack<'a, R, Str, So, T>,
+        mut result: R::Out,
+    ) -> PushResult<'a, R, Str, So, T> {
+        loop {
+            let frame = match stack.pop() {
+                Some(f) => f,
+                None => return Ok(Either::Left(result)),
+            };
+            match frame {
+                Frame::App {
+                    current,
+                    id,
+                    args,
+                    sort,
+                    mut rec,
+                } => {
+                    rec.push(result);
+                    if rec.len() >= args.len() {
+                        result = recursor.on_app(current, id, args, sort, rec)?;
+                    } else {
+                        return Ok(Either::Right(Frame::App {
+                            current,
+                            id,
+                            args,
+                            sort,
+                            rec,
+                        }));
+                    }
+                }
+                Frame::LetBindings {
+                    current,
+                    vs,
+                    body,
+                    mut vs_rec,
+                } => {
+                    vs_rec.push(recursor.on_let_binding(
                         current,
                         vs,
-                        vs_rec,
                         body,
-                    }
-                } else {
-                    Frame::LetBindings {
-                        current,
-                        vs,
-                        body,
-                        vs_rec,
-                    }
-                };
-                return Ok(Either::Right(frame));
-            }
-            Frame::LetBody {
-                current,
-                vs,
-                vs_rec,
-                body,
-            } => {
-                result = recursor.on_let(current, vs, body, vs_rec, result)?;
-            }
-            Frame::Quantifier {
-                current,
-                vs,
-                body,
-                is_forall,
-            } => {
-                result = if is_forall {
-                    recursor.on_forall(current, vs, body, result)
-                } else {
-                    recursor.on_exists(current, vs, body, result)
-                }?;
-            }
-            Frame::MatchScrutinee {
-                current,
-                scrutinee,
-                cases,
-            } => {
-                if cases.is_empty() {
-                    result = recursor.on_match(current, scrutinee, cases, result, vec![])?;
-                } else {
-                    return Ok(Either::Right(Frame::MatchCases {
-                        current,
-                        scrutinee,
-                        cases,
-                        scrutinee_rec: result,
-                        case_rec: vec![],
-                        current_pattern: None,
-                    }));
+                        vs_rec.len(),
+                        result,
+                    )?);
+                    let frame = if vs_rec.len() >= vs.len() {
+                        Frame::LetBody {
+                            current,
+                            vs,
+                            vs_rec,
+                            body,
+                        }
+                    } else {
+                        Frame::LetBindings {
+                            current,
+                            vs,
+                            body,
+                            vs_rec,
+                        }
+                    };
+                    return Ok(Either::Right(frame));
                 }
-            }
-            Frame::MatchCases {
-                current,
-                scrutinee,
-                cases,
-                scrutinee_rec,
-                mut case_rec,
-                current_pattern,
-            } => {
-                let arm = recursor.on_match_arm(
+                Frame::LetBody {
+                    current,
+                    vs,
+                    vs_rec,
+                    body,
+                } => {
+                    result = recursor.on_let(current, vs, body, vs_rec, result)?;
+                }
+                Frame::Quantifier {
+                    current,
+                    vs,
+                    body,
+                    is_forall,
+                } => {
+                    result = if is_forall {
+                        recursor.on_forall(current, vs, body, result)
+                    } else {
+                        recursor.on_exists(current, vs, body, result)
+                    }?;
+                }
+                Frame::MatchScrutinee {
                     current,
                     scrutinee,
                     cases,
-                    &scrutinee_rec,
-                    case_rec.len(),
-                    current_pattern.unwrap(),
-                    result,
-                )?;
-                case_rec.push(arm);
-                if case_rec.len() >= cases.len() {
-                    result =
-                        recursor.on_match(current, scrutinee, cases, scrutinee_rec, case_rec)?;
-                } else {
-                    return Ok(Either::Right(Frame::MatchCases {
+                } => {
+                    if cases.is_empty() {
+                        result = recursor.on_match(current, scrutinee, cases, result, vec![])?;
+                    } else {
+                        return Ok(Either::Right(Frame::MatchCases {
+                            current,
+                            scrutinee,
+                            cases,
+                            scrutinee_rec: result,
+                            case_rec: vec![],
+                            current_pattern: None,
+                        }));
+                    }
+                }
+                Frame::MatchCases {
+                    current,
+                    scrutinee,
+                    cases,
+                    scrutinee_rec,
+                    mut case_rec,
+                    current_pattern,
+                } => {
+                    let arm = recursor.on_match_arm(
                         current,
                         scrutinee,
                         cases,
-                        scrutinee_rec,
-                        case_rec,
-                        current_pattern: None,
+                        &scrutinee_rec,
+                        case_rec.len(),
+                        current_pattern.unwrap(),
+                        result,
+                    )?;
+                    case_rec.push(arm);
+                    if case_rec.len() >= cases.len() {
+                        result = recursor.on_match(
+                            current,
+                            scrutinee,
+                            cases,
+                            scrutinee_rec,
+                            case_rec,
+                        )?;
+                    } else {
+                        return Ok(Either::Right(Frame::MatchCases {
+                            current,
+                            scrutinee,
+                            cases,
+                            scrutinee_rec,
+                            case_rec,
+                            current_pattern: None,
+                        }));
+                    }
+                }
+                Frame::EqL { current, l, r } => {
+                    return Ok(Either::Right(Frame::EqR {
+                        current,
+                        l,
+                        r,
+                        l_rec: result,
                     }));
                 }
-            }
-            Frame::EqL { current, l, r } => {
-                return Ok(Either::Right(Frame::EqR {
+                Frame::EqR {
                     current,
                     l,
                     r,
-                    l_rec: result,
-                }));
-            }
-            Frame::EqR {
-                current,
-                l,
-                r,
-                l_rec,
-            } => {
-                result = recursor.on_eq(current, l, r, l_rec, result)?;
-            }
-            Frame::AnnotatedBody {
-                current,
-                body,
-                anns,
-            } => {
-                let mut anns_rec: Vec<R::Attr> = vec![];
-                advance_attributes_until_pattern(recursor, anns, &mut anns_rec)?;
-                if anns_rec.len() >= anns.len() {
-                    result = recursor.on_annotated(current, body, anns, result, anns_rec)?;
-                } else {
-                    return Ok(Either::Right(Frame::AnnotatedAttrs {
-                        current,
-                        body,
-                        anns,
-                        t_rec: result,
-                        anns_rec,
-                        cur_pattern_rec: vec![],
-                    }));
+                    l_rec,
+                } => {
+                    result = recursor.on_eq(current, l, r, l_rec, result)?;
                 }
-            }
-            Frame::AnnotatedAttrs {
-                current,
-                body,
-                anns,
-                t_rec,
-                mut anns_rec,
-                mut cur_pattern_rec,
-            } => {
-                cur_pattern_rec.push(result);
-                let pat_ts = match &anns[anns_rec.len()] {
-                    Attribute::Pattern(ts) => ts,
-                    _ => unreachable!(),
-                };
-                if cur_pattern_rec.len() >= pat_ts.len() {
-                    anns_rec.push(recursor.on_attribute_pattern(pat_ts, cur_pattern_rec)?);
-                    cur_pattern_rec = vec![];
-                    advance_attributes_until_pattern(recursor, anns, &mut anns_rec)?;
+                Frame::AnnotatedBody {
+                    current,
+                    body,
+                    anns,
+                } => {
+                    let mut anns_rec: Vec<R::Attr> = vec![];
+                    Self::advance_attributes_until_pattern(recursor, anns, &mut anns_rec)?;
                     if anns_rec.len() >= anns.len() {
-                        result = recursor.on_annotated(current, body, anns, t_rec, anns_rec)?;
+                        result = recursor.on_annotated(current, body, anns, result, anns_rec)?;
+                    } else {
+                        return Ok(Either::Right(Frame::AnnotatedAttrs {
+                            current,
+                            body,
+                            anns,
+                            t_rec: result,
+                            anns_rec,
+                            cur_pattern_rec: vec![],
+                        }));
+                    }
+                }
+                Frame::AnnotatedAttrs {
+                    current,
+                    body,
+                    anns,
+                    t_rec,
+                    mut anns_rec,
+                    mut cur_pattern_rec,
+                } => {
+                    cur_pattern_rec.push(result);
+                    let pat_ts = match &anns[anns_rec.len()] {
+                        Attribute::Pattern(ts) => ts,
+                        _ => unreachable!(),
+                    };
+                    if cur_pattern_rec.len() >= pat_ts.len() {
+                        anns_rec.push(recursor.on_attribute_pattern(pat_ts, cur_pattern_rec)?);
+                        cur_pattern_rec = vec![];
+                        Self::advance_attributes_until_pattern(recursor, anns, &mut anns_rec)?;
+                        if anns_rec.len() >= anns.len() {
+                            result = recursor.on_annotated(current, body, anns, t_rec, anns_rec)?;
+                        } else {
+                            return Ok(Either::Right(Frame::AnnotatedAttrs {
+                                current,
+                                body,
+                                anns,
+                                t_rec,
+                                anns_rec,
+                                cur_pattern_rec,
+                            }));
+                        }
                     } else {
                         return Ok(Either::Right(Frame::AnnotatedAttrs {
                             current,
@@ -737,469 +756,466 @@ where
                             cur_pattern_rec,
                         }));
                     }
-                } else {
-                    return Ok(Either::Right(Frame::AnnotatedAttrs {
-                        current,
-                        body,
-                        anns,
-                        t_rec,
-                        anns_rec,
-                        cur_pattern_rec,
-                    }));
                 }
-            }
-            Frame::Nary {
-                current,
-                kind,
-                ts,
-                mut rec,
-            } => {
-                rec.push(result);
-                if rec.len() >= ts.len() {
-                    result = match kind {
-                        NaryKind::Distinct => recursor.on_distinct(current, ts, rec)?,
-                        NaryKind::And => recursor.on_and(current, ts, rec)?,
-                        NaryKind::Or => recursor.on_or(current, ts, rec)?,
-                        NaryKind::Xor => recursor.on_xor(current, ts, rec)?,
-                    };
-                } else {
-                    return Ok(Either::Right(Frame::Nary {
-                        current,
-                        kind,
-                        ts,
-                        rec,
-                    }));
-                }
-            }
-            Frame::Not { current, t } => {
-                result = recursor.on_not(current, t, result)?;
-            }
-            Frame::ImpliesPremises {
-                current,
-                ts,
-                t,
-                mut rec,
-            } => {
-                rec.push(result);
-                let frame = if rec.len() >= ts.len() {
-                    Frame::ImpliesConclusion {
-                        current,
-                        ts,
-                        t,
-                        ts_rec: rec,
-                    }
-                } else {
-                    Frame::ImpliesPremises {
-                        current,
-                        ts,
-                        t,
-                        rec,
-                    }
-                };
-                return Ok(Either::Right(frame));
-            }
-            Frame::ImpliesConclusion {
-                current,
-                ts,
-                t,
-                ts_rec,
-            } => {
-                result = recursor.on_implies(current, ts, t, ts_rec, result)?;
-            }
-            Frame::IteB { current, b, t, e } => {
-                return Ok(Either::Right(Frame::IteT {
+                Frame::Nary {
                     current,
-                    b,
+                    kind,
+                    ts,
+                    mut rec,
+                } => {
+                    rec.push(result);
+                    if rec.len() >= ts.len() {
+                        result = match kind {
+                            NaryKind::Distinct => recursor.on_distinct(current, ts, rec)?,
+                            NaryKind::And => recursor.on_and(current, ts, rec)?,
+                            NaryKind::Or => recursor.on_or(current, ts, rec)?,
+                            NaryKind::Xor => recursor.on_xor(current, ts, rec)?,
+                        };
+                    } else {
+                        return Ok(Either::Right(Frame::Nary {
+                            current,
+                            kind,
+                            ts,
+                            rec,
+                        }));
+                    }
+                }
+                Frame::Not { current, t } => {
+                    result = recursor.on_not(current, t, result)?;
+                }
+                Frame::ImpliesPremises {
+                    current,
+                    ts,
                     t,
-                    e,
-                    b_rec: result,
-                }));
-            }
-            Frame::IteT {
-                current,
-                b,
-                t,
-                e,
-                b_rec,
-            } => {
-                return Ok(Either::Right(Frame::IteE {
+                    mut rec,
+                } => {
+                    rec.push(result);
+                    let frame = if rec.len() >= ts.len() {
+                        Frame::ImpliesConclusion {
+                            current,
+                            ts,
+                            t,
+                            ts_rec: rec,
+                        }
+                    } else {
+                        Frame::ImpliesPremises {
+                            current,
+                            ts,
+                            t,
+                            rec,
+                        }
+                    };
+                    return Ok(Either::Right(frame));
+                }
+                Frame::ImpliesConclusion {
+                    current,
+                    ts,
+                    t,
+                    ts_rec,
+                } => {
+                    result = recursor.on_implies(current, ts, t, ts_rec, result)?;
+                }
+                Frame::IteB { current, b, t, e } => {
+                    return Ok(Either::Right(Frame::IteT {
+                        current,
+                        b,
+                        t,
+                        e,
+                        b_rec: result,
+                    }));
+                }
+                Frame::IteT {
                     current,
                     b,
                     t,
                     e,
                     b_rec,
-                    t_rec: result,
-                }));
-            }
-            Frame::IteE {
-                current,
-                b,
-                t,
-                e,
-                b_rec,
-                t_rec,
-            } => {
-                result = recursor.on_ite(current, b, t, e, b_rec, t_rec, result)?;
+                } => {
+                    return Ok(Either::Right(Frame::IteE {
+                        current,
+                        b,
+                        t,
+                        e,
+                        b_rec,
+                        t_rec: result,
+                    }));
+                }
+                Frame::IteE {
+                    current,
+                    b,
+                    t,
+                    e,
+                    b_rec,
+                    t_rec,
+                } => {
+                    result = recursor.on_ite(current, b, t, e, b_rec, t_rec, result)?;
+                }
             }
         }
     }
-}
 
-pub(crate) fn next_child<'a, R, Str, So, T>(
-    recursor: &mut R,
-    frame: &mut Frame<'a, Str, So, T, R>,
-) -> Result<&'a T, R::Err>
-where
-    R: TermRecursor<Str, So, T>,
-{
-    match frame {
-        Frame::App { args, rec, .. } => Ok(&args[rec.len()]),
-        Frame::LetBindings { vs, vs_rec, .. } => Ok(&vs[vs_rec.len()].2),
-        Frame::LetBody {
-            current,
-            vs,
-            vs_rec,
-            body,
-            ..
-        } => {
-            recursor.setup_let_scope(current, vs, body, vs_rec)?;
-            Ok(body)
-        }
-        Frame::Quantifier {
-            current,
-            vs,
-            body,
-            is_forall,
-            ..
-        } => {
-            recursor.setup_quantifier_scope(current, vs, body, *is_forall)?;
-            Ok(body)
-        }
-        Frame::MatchScrutinee { scrutinee, .. } => Ok(scrutinee),
-        Frame::MatchCases {
-            current,
-            scrutinee,
-            cases,
-            scrutinee_rec,
-            case_rec,
-            current_pattern,
-        } => {
-            let pat = recursor.setup_match_case_scope(
-                current,
-                scrutinee,
-                cases,
-                scrutinee_rec,
-                case_rec.len(),
-            )?;
-            *current_pattern = Some(pat);
-            Ok(&cases[case_rec.len()].body)
-        }
-        Frame::EqL { l, .. } => Ok(l),
-        Frame::EqR { r, .. } => Ok(r),
-        Frame::AnnotatedBody { body, .. } => Ok(body),
-        Frame::AnnotatedAttrs {
-            anns,
-            anns_rec,
-            cur_pattern_rec,
-            ..
-        } => match &anns[anns_rec.len()] {
-            Attribute::Pattern(ts) => Ok(&ts[cur_pattern_rec.len()]),
-            _ => unreachable!(),
-        },
-        Frame::Nary { ts, rec, .. } => Ok(&ts[rec.len()]),
-        Frame::Not { t, .. } => Ok(t),
-        Frame::ImpliesPremises { ts, rec, .. } => Ok(&ts[rec.len()]),
-        Frame::ImpliesConclusion { t, .. } => Ok(t),
-        Frame::IteB { b, .. } => Ok(b),
-        Frame::IteT { t, .. } => Ok(t),
-        Frame::IteE { e, .. } => Ok(e),
-    }
-}
-
-/// Descend from `current` into its leftmost leaf, pushing [`Frame`]s for
-/// intermediate nodes, then resolve the leaf via the appropriate callback.
-///
-/// Loops over [`expand_and_resolve_once`] until a leaf is reached.
-pub(crate) fn expand_and_resolve<'a, R, Str: 'a, So: 'a, T>(
-    recursor: &mut R,
-    stack: &mut RStack<'a, R, Str, So, T>,
-    mut current: &'a T,
-) -> Result<R::Out, R::Err>
-where
-    R: TermRecursor<Str, So, T>,
-    T: Contains<T: Repr<T = Term<Str, So, T>>>,
-{
-    loop {
-        match expand_and_resolve_once(recursor, stack, current)? {
-            Either::Left(r) => {
-                current = r;
-            }
-            Either::Right(result) => {
-                return Ok(result);
-            }
-        }
-    }
-}
-
-/// Process a single term node: either push a [`Frame`] and return the next
-/// child to descend into (`Either::Left`), or resolve a leaf directly via
-/// its callback (`Either::Right`).
-#[inline]
-pub(crate) fn expand_and_resolve_once<'a, R, Str: 'a, So: 'a, T>(
-    recursor: &mut R,
-    stack: &mut RStack<'a, R, Str, So, T>,
-    current: &'a T,
-) -> Result<Either<&'a T, R::Out>, R::Err>
-where
-    R: TermRecursor<Str, So, T>,
-    T: Contains<T: Repr<T = Term<Str, So, T>>>,
-{
-    match current.inner().repr() {
-        Term::Constant(constant, sort) => recursor
-            .on_constant(current, constant, sort)
-            .map(Either::Right),
-        Term::Global(id, sort) => recursor.on_global(current, id, sort).map(Either::Right),
-        Term::Local(id) => recursor.on_local(current, id).map(Either::Right),
-        Term::App(id, args, sort) => {
-            if args.is_empty() {
-                recursor
-                    .on_app(current, id, args, sort, vec![])
-                    .map(Either::Right)
-            } else {
-                stack.push(Frame::App {
-                    current,
-                    id,
-                    args,
-                    sort,
-                    rec: Vec::with_capacity(args.len()),
-                });
-                Ok(Either::Left(&args[0]))
-            }
-        }
-        Term::Let(vs, body) => {
-            if vs.is_empty() {
-                let vc = vec![];
-                recursor.setup_let_scope(current, vs, body, &vc)?;
-                stack.push(Frame::LetBody {
-                    current,
-                    vs,
-                    body,
-                    vs_rec: vc,
-                });
-                Ok(Either::Left(body))
-            } else {
-                stack.push(Frame::LetBindings {
-                    current,
-                    vs,
-                    body,
-                    vs_rec: Vec::with_capacity(vs.len()),
-                });
-                Ok(Either::Left(&vs[0].2))
-            }
-        }
-        Term::Exists(vs, body) => {
-            recursor.setup_quantifier_scope(current, vs, body, false)?;
-            stack.push(Frame::Quantifier {
-                current,
-                vs,
-                body,
-                is_forall: false,
-            });
-            Ok(Either::Left(body))
-        }
-        Term::Forall(vs, body) => {
-            recursor.setup_quantifier_scope(current, vs, body, true)?;
-            stack.push(Frame::Quantifier {
-                current,
-                vs,
-                body,
-                is_forall: true,
-            });
-            Ok(Either::Left(body))
-        }
-        Term::Matching(scrutinee, cases) => {
-            stack.push(Frame::MatchScrutinee {
-                current,
-                scrutinee,
-                cases,
-            });
-            Ok(Either::Left(scrutinee))
-        }
-        Term::Annotated(body, anns) => {
-            stack.push(Frame::AnnotatedBody {
-                current,
-                body,
-                anns,
-            });
-            Ok(Either::Left(body))
-        }
-        Term::Eq(l, r) => {
-            stack.push(Frame::EqL { current, l, r });
-            Ok(Either::Left(l))
-        }
-        Term::Distinct(ts) => {
-            if ts.is_empty() {
-                recursor.on_distinct(current, ts, vec![]).map(Either::Right)
-            } else {
-                stack.push(Frame::Nary {
-                    current,
-                    kind: NaryKind::Distinct,
-                    ts,
-                    rec: Vec::with_capacity(ts.len()),
-                });
-                Ok(Either::Left(&ts[0]))
-            }
-        }
-        Term::And(ts) => {
-            if ts.is_empty() {
-                recursor.on_and(current, ts, vec![]).map(Either::Right)
-            } else {
-                stack.push(Frame::Nary {
-                    current,
-                    kind: NaryKind::And,
-                    ts,
-                    rec: Vec::with_capacity(ts.len()),
-                });
-                Ok(Either::Left(&ts[0]))
-            }
-        }
-        Term::Or(ts) => {
-            if ts.is_empty() {
-                recursor.on_or(current, ts, vec![]).map(Either::Right)
-            } else {
-                stack.push(Frame::Nary {
-                    current,
-                    kind: NaryKind::Or,
-                    ts,
-                    rec: Vec::with_capacity(ts.len()),
-                });
-                Ok(Either::Left(&ts[0]))
-            }
-        }
-        Term::Xor(ts) => {
-            if ts.is_empty() {
-                recursor.on_xor(current, ts, vec![]).map(Either::Right)
-            } else {
-                stack.push(Frame::Nary {
-                    current,
-                    kind: NaryKind::Xor,
-                    ts,
-                    rec: Vec::with_capacity(ts.len()),
-                });
-                Ok(Either::Left(&ts[0]))
-            }
-        }
-        Term::Implies(ts, concl) => {
-            if ts.is_empty() {
-                stack.push(Frame::ImpliesConclusion {
-                    current,
-                    ts,
-                    t: concl,
-                    ts_rec: vec![],
-                });
-                Ok(Either::Left(concl))
-            } else {
-                stack.push(Frame::ImpliesPremises {
-                    current,
-                    ts,
-                    t: concl,
-                    rec: Vec::with_capacity(ts.len()),
-                });
-                Ok(Either::Left(&ts[0]))
-            }
-        }
-        Term::Not(inner) => {
-            stack.push(Frame::Not { current, t: inner });
-            Ok(Either::Left(inner))
-        }
-        Term::Ite(b, th, e) => {
-            stack.push(Frame::IteB {
-                current,
-                b,
-                t: th,
-                e,
-            });
-            Ok(Either::Left(b))
-        }
-    }
-}
-
-pub(crate) fn rewind_stack_for_error<R, Str, So, T>(
-    recursor: &mut R,
-    stack: &mut RStack<'_, R, Str, So, T>,
-) where
-    R: TermRecursor<Str, So, T>,
-{
-    while let Some(frame) = stack.pop() {
+    /// Peek at the top frame to determine the next child term to expand.
+    ///
+    /// For scoped constructs (`LetBody`, `Quantifier`, `MatchCases`), this also
+    /// invokes the appropriate `setup_*` callback on the recursor before returning
+    /// the child.
+    fn next_child<'a>(
+        recursor: &mut R,
+        frame: &mut Frame<'a, Str, So, T, R>,
+    ) -> Result<&'a T, R::Err> {
         match frame {
+            Frame::App { args, rec, .. } => Ok(&args[rec.len()]),
+            Frame::LetBindings { vs, vs_rec, .. } => Ok(&vs[vs_rec.len()].2),
             Frame::LetBody {
                 current,
                 vs,
-                body,
                 vs_rec,
+                body,
+                ..
             } => {
-                recursor.cleanup_let_scope_on_error(current, vs, body, vs_rec);
+                recursor.setup_let_scope(current, vs, body, vs_rec)?;
+                Ok(body)
             }
             Frame::Quantifier {
                 current,
                 vs,
                 body,
                 is_forall,
+                ..
             } => {
-                recursor.cleanup_quantifier_scope_on_error(current, vs, body, is_forall);
+                recursor.setup_quantifier_scope(current, vs, body, *is_forall)?;
+                Ok(body)
             }
+            Frame::MatchScrutinee { scrutinee, .. } => Ok(scrutinee),
             Frame::MatchCases {
                 current,
                 scrutinee,
                 cases,
                 scrutinee_rec,
                 case_rec,
-                current_pattern: _,
+                current_pattern,
             } => {
-                recursor.cleanup_match_case_scope_on_error(
+                let pat = recursor.setup_match_case_scope(
                     current,
                     scrutinee,
-                    scrutinee_rec,
                     cases,
+                    scrutinee_rec,
                     case_rec.len(),
-                );
+                )?;
+                *current_pattern = Some(pat);
+                Ok(&cases[case_rec.len()].body)
             }
-            _ => {}
+            Frame::EqL { l, .. } => Ok(l),
+            Frame::EqR { r, .. } => Ok(r),
+            Frame::AnnotatedBody { body, .. } => Ok(body),
+            Frame::AnnotatedAttrs {
+                anns,
+                anns_rec,
+                cur_pattern_rec,
+                ..
+            } => match &anns[anns_rec.len()] {
+                Attribute::Pattern(ts) => Ok(&ts[cur_pattern_rec.len()]),
+                _ => unreachable!(),
+            },
+            Frame::Nary { ts, rec, .. } => Ok(&ts[rec.len()]),
+            Frame::Not { t, .. } => Ok(t),
+            Frame::ImpliesPremises { ts, rec, .. } => Ok(&ts[rec.len()]),
+            Frame::ImpliesConclusion { t, .. } => Ok(t),
+            Frame::IteB { b, .. } => Ok(b),
+            Frame::IteT { t, .. } => Ok(t),
+            Frame::IteE { e, .. } => Ok(e),
         }
+    }
+
+    /// Descend from `current` into its leftmost leaf, pushing [`Frame`]s for
+    /// intermediate nodes, then resolve the leaf via the appropriate callback.
+    ///
+    /// Loops over [`expand_and_resolve_once`] until a leaf is reached.
+    fn expand_and_resolve<'a>(
+        recursor: &mut R,
+        stack: &mut RStack<'a, R, Str, So, T>,
+        mut current: &'a T,
+    ) -> Result<R::Out, R::Err>
+    where
+        Str: 'a,
+        So: 'a,
+        T: Contains<T: Repr<T = Term<Str, So, T>>>,
+    {
+        loop {
+            match Self::expand_and_resolve_once(recursor, stack, current)? {
+                Either::Left(r) => {
+                    current = r;
+                }
+                Either::Right(result) => {
+                    return Ok(result);
+                }
+            }
+        }
+    }
+
+    /// Process a single term node: either push a [`Frame`] and return the next
+    /// child to descend into (`Either::Left`), or resolve a leaf directly via
+    /// its callback (`Either::Right`).
+    #[inline]
+    fn expand_and_resolve_once<'a>(
+        recursor: &mut R,
+        stack: &mut RStack<'a, R, Str, So, T>,
+        current: &'a T,
+    ) -> Result<Either<&'a T, R::Out>, R::Err>
+    where
+        Str: 'a,
+        So: 'a,
+        T: Contains<T: Repr<T = Term<Str, So, T>>>,
+    {
+        match current.inner().repr() {
+            Term::Constant(constant, sort) => recursor
+                .on_constant(current, constant, sort)
+                .map(Either::Right),
+            Term::Global(id, sort) => recursor.on_global(current, id, sort).map(Either::Right),
+            Term::Local(id) => recursor.on_local(current, id).map(Either::Right),
+            Term::App(id, args, sort) => {
+                if args.is_empty() {
+                    recursor
+                        .on_app(current, id, args, sort, vec![])
+                        .map(Either::Right)
+                } else {
+                    stack.push(Frame::App {
+                        current,
+                        id,
+                        args,
+                        sort,
+                        rec: vec![],
+                    });
+                    Ok(Either::Left(&args[0]))
+                }
+            }
+            Term::Let(vs, body) => {
+                if vs.is_empty() {
+                    let vc = vec![];
+                    recursor.setup_let_scope(current, vs, body, &vc)?;
+                    stack.push(Frame::LetBody {
+                        current,
+                        vs,
+                        body,
+                        vs_rec: vc,
+                    });
+                    Ok(Either::Left(body))
+                } else {
+                    stack.push(Frame::LetBindings {
+                        current,
+                        vs,
+                        body,
+                        vs_rec: vec![],
+                    });
+                    Ok(Either::Left(&vs[0].2))
+                }
+            }
+            Term::Exists(vs, body) => {
+                recursor.setup_quantifier_scope(current, vs, body, false)?;
+                stack.push(Frame::Quantifier {
+                    current,
+                    vs,
+                    body,
+                    is_forall: false,
+                });
+                Ok(Either::Left(body))
+            }
+            Term::Forall(vs, body) => {
+                recursor.setup_quantifier_scope(current, vs, body, true)?;
+                stack.push(Frame::Quantifier {
+                    current,
+                    vs,
+                    body,
+                    is_forall: true,
+                });
+                Ok(Either::Left(body))
+            }
+            Term::Matching(scrutinee, cases) => {
+                stack.push(Frame::MatchScrutinee {
+                    current,
+                    scrutinee,
+                    cases,
+                });
+                Ok(Either::Left(scrutinee))
+            }
+            Term::Annotated(body, anns) => {
+                stack.push(Frame::AnnotatedBody {
+                    current,
+                    body,
+                    anns,
+                });
+                Ok(Either::Left(body))
+            }
+            Term::Eq(l, r) => {
+                stack.push(Frame::EqL { current, l, r });
+                Ok(Either::Left(l))
+            }
+            Term::Distinct(ts) => {
+                if ts.is_empty() {
+                    recursor.on_distinct(current, ts, vec![]).map(Either::Right)
+                } else {
+                    stack.push(Frame::Nary {
+                        current,
+                        kind: NaryKind::Distinct,
+                        ts,
+                        rec: vec![],
+                    });
+                    Ok(Either::Left(&ts[0]))
+                }
+            }
+            Term::And(ts) => {
+                if ts.is_empty() {
+                    recursor.on_and(current, ts, vec![]).map(Either::Right)
+                } else {
+                    stack.push(Frame::Nary {
+                        current,
+                        kind: NaryKind::And,
+                        ts,
+                        rec: vec![],
+                    });
+                    Ok(Either::Left(&ts[0]))
+                }
+            }
+            Term::Or(ts) => {
+                if ts.is_empty() {
+                    recursor.on_or(current, ts, vec![]).map(Either::Right)
+                } else {
+                    stack.push(Frame::Nary {
+                        current,
+                        kind: NaryKind::Or,
+                        ts,
+                        rec: vec![],
+                    });
+                    Ok(Either::Left(&ts[0]))
+                }
+            }
+            Term::Xor(ts) => {
+                if ts.is_empty() {
+                    recursor.on_xor(current, ts, vec![]).map(Either::Right)
+                } else {
+                    stack.push(Frame::Nary {
+                        current,
+                        kind: NaryKind::Xor,
+                        ts,
+                        rec: vec![],
+                    });
+                    Ok(Either::Left(&ts[0]))
+                }
+            }
+            Term::Implies(ts, concl) => {
+                if ts.is_empty() {
+                    stack.push(Frame::ImpliesConclusion {
+                        current,
+                        ts,
+                        t: concl,
+                        ts_rec: vec![],
+                    });
+                    Ok(Either::Left(concl))
+                } else {
+                    stack.push(Frame::ImpliesPremises {
+                        current,
+                        ts,
+                        t: concl,
+                        rec: vec![],
+                    });
+                    Ok(Either::Left(&ts[0]))
+                }
+            }
+            Term::Not(inner) => {
+                stack.push(Frame::Not { current, t: inner });
+                Ok(Either::Left(inner))
+            }
+            Term::Ite(b, th, e) => {
+                stack.push(Frame::IteB {
+                    current,
+                    b,
+                    t: th,
+                    e,
+                });
+                Ok(Either::Left(b))
+            }
+        }
+    }
+
+    /// Only when the recursion fails, this function is called to rewind the recursion stack
+    /// and `cleanup_*` callbacks are invoked to clean up the recursor state, if necessary.
+    fn rewind_stack_for_error(recursor: &mut R, stack: &mut RStack<'_, R, Str, So, T>) {
+        while let Some(frame) = stack.pop() {
+            match frame {
+                Frame::LetBody {
+                    current,
+                    vs,
+                    body,
+                    vs_rec,
+                } => {
+                    recursor.cleanup_let_scope_on_error(current, vs, body, vs_rec);
+                }
+                Frame::Quantifier {
+                    current,
+                    vs,
+                    body,
+                    is_forall,
+                } => {
+                    recursor.cleanup_quantifier_scope_on_error(current, vs, body, is_forall);
+                }
+                Frame::MatchCases {
+                    current,
+                    scrutinee,
+                    cases,
+                    scrutinee_rec,
+                    case_rec,
+                    current_pattern: _,
+                } => {
+                    recursor.cleanup_match_case_scope_on_error(
+                        current,
+                        scrutinee,
+                        cases,
+                        scrutinee_rec,
+                        case_rec.len(),
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn term_recursion_inner<'a>(
+        recursor: &mut R,
+        term: &'a T,
+        stack: &mut RStack<'a, R, Str, So, T>,
+    ) -> Result<R::Out, R::Err>
+    where
+        T: Contains<T: Repr<T = Term<Str, So, T>>>,
+    {
+        let mut result = Self::expand_and_resolve(recursor, stack, term)?;
+        loop {
+            match Self::push_result(recursor, stack, result)? {
+                Either::Left(final_result) => return Ok(final_result),
+                Either::Right(mut frame) => {
+                    let child = Self::next_child(recursor, &mut frame)?;
+                    stack.push(frame);
+                    result = Self::expand_and_resolve(recursor, stack, child)?;
+                }
+            }
+        }
+    }
+
+    fn term_recursion(recursor: &mut R, term: &T) -> Result<R::Out, R::Err>
+    where
+        T: Contains<T: Repr<T = Term<Str, So, T>>>,
+    {
+        let mut stack = Vec::new();
+        let result = Self::term_recursion_inner(recursor, term, &mut stack);
+        if result.is_err() {
+            Self::rewind_stack_for_error(recursor, &mut stack);
+        }
+        result
     }
 }
 
-pub(crate) fn term_recursion_inner<R, Str, So, T>(
-    recursor: &mut R,
-    term: &T,
-    stack: &mut RStack<'_, R, Str, So, T>,
-) -> Result<R::Out, R::Err>
-where
-    R: TermRecursor<Str, So, T>,
-    T: Contains<T: Repr<T = Term<Str, So, T>>>,
-{
-    let mut result = expand_and_resolve(recursor, stack, term)?;
-    loop {
-        match push_result(recursor, stack, result)? {
-            Either::Left(final_result) => return Ok(final_result),
-            Either::Right(mut frame) => {
-                let child = next_child(recursor, &mut frame)?;
-                stack.push(frame);
-                result = expand_and_resolve(recursor, stack, child)?;
-            }
-        }
-    }
-}
+pub(crate) struct BasicScheme;
 
-pub(crate) fn term_recursion<R, Str, So, T>(recursor: &mut R, term: &T) -> Result<R::Out, R::Err>
-where
-    R: TermRecursor<Str, So, T>,
-    T: Contains<T: Repr<T = Term<Str, So, T>>>,
+impl<R, Str, So, T> TermRecursionScheme<R, Str, So, T> for BasicScheme where
+    R: TermRecursor<Str, So, T>
 {
-    let mut stack: RStack<'_, R, Str, So, T> = Vec::new();
-    let result = term_recursion_inner(recursor, term, &mut stack);
-    if result.is_err() {
-        rewind_stack_for_error(recursor, &mut stack);
-    }
-    result
 }

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -124,8 +124,12 @@ where
             fn on_attribute_pattern(&mut self, patterns: &[T], patterns_rec: Vec<Self::Out>) -> Result<Self::Attr, Self::Err>;
             fn on_let_binding(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, binding_idx: usize, binding_rec: Self::Out) -> Result<Self::Binding, Self::Err>;
             fn setup_let_scope(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: &[Self::Binding]) -> Result<(), Self::Err>;
+            fn cleanup_let_scope_on_error(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: Vec<Self::Binding>);
             fn setup_quantifier_scope(&mut self, current: &T, vs: &[VarBinding<Str, So>], t: &T, is_forall: bool) -> Result<(), Self::Err>;
+            fn cleanup_quantifier_scope_on_error(&mut self, current: &T, vs: &[VarBinding<Str, So>], t: &T, is_forall: bool);
             fn setup_match_case_scope(&mut self, current: &T, scrutinee: &T, cases: &[PatternArm<Str, T>], scrutinee_rec: &Self::Out, case_idx: usize) -> Result<Self::Pattern, Self::Err>;
+            fn cleanup_match_case_scope_on_error(&mut self, current: &T, scrutinee: &T, cases: &[PatternArm<Str, T>], scrutinee_rec: Self::Out, case_idx: usize);
+            fn on_match_arm(&mut self, current: &T, scrutinee: &T, cases: &[PatternArm<Str, T>], scrutinee_rec: &Self::Out, case_idx: usize, current_pattern: Self::Pattern, arm: Self::Out) -> Result<Self::Arm, Self::Err>;
         }
     }
 
@@ -205,27 +209,6 @@ where
         let r = self.inner.on_forall(current, vs, t, t_rec)?;
         self.cache.insert(current.clone(), r.clone());
         Ok(r)
-    }
-
-    fn on_match_arm(
-        &mut self,
-        current: &T,
-        scrutinee: &T,
-        cases: &[PatternArm<Str, T>],
-        scrutinee_rec: &Self::Out,
-        case_idx: usize,
-        current_pattern: Self::Pattern,
-        arm: Self::Out,
-    ) -> Result<Self::Arm, Self::Err> {
-        self.inner.on_match_arm(
-            current,
-            scrutinee,
-            cases,
-            scrutinee_rec,
-            case_idx,
-            current_pattern,
-            arm,
-        )
     }
 
     fn on_match(

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -348,6 +348,11 @@ where
     }
 }
 
+/// A caching traversal scheme for [`Memoize`]-wrapped recursors.
+///
+/// Overrides [`expand_and_resolve`](TermRecursionScheme::expand_and_resolve) to check
+/// the cache before descending into a term. On a cache hit, the entire sub-tree is
+/// skipped and the cached result is returned immediately.
 pub(crate) struct MemoizedScheme;
 
 impl<R, M, Str, So, T> TermRecursionScheme<Memoize<R, M>, Str, So, T> for MemoizedScheme

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -112,7 +112,7 @@ where
     where
         T: Contains<T: Repr<T = Term<Str, So, T>>>,
     {
-        memo_term_recursion(self, t)
+        MemoizedScheme::term_recursion(self, t)
     }
 
     delegate! {
@@ -348,56 +348,40 @@ where
     }
 }
 
-/// Like [`expand_and_resolve`], but checks the cache before descending.
-///
-/// If `current` is already in the cache, the cached result is returned immediately
-/// without pushing any frames or invoking any callbacks.
-fn memo_expand_and_resolve<'a, R, M, Str: 'a, So: 'a, T>(
-    recursor: &mut Memoize<R, M>,
-    stack: &mut RStack<'a, Memoize<R, M>, Str, So, T>,
-    mut current: &'a T,
-) -> Result<R::Out, R::Err>
+pub(crate) struct MemoizedScheme;
+
+impl<R, M, Str, So, T> TermRecursionScheme<Memoize<R, M>, Str, So, T> for MemoizedScheme
 where
     R: TermRecursor<Str, So, T, Out: Clone>,
     M: InsertableMapping<Key = T, Value = R::Out>,
-    T: Contains<T: Repr<T = Term<Str, So, T>>> + Clone,
+    T: Clone,
 {
-    loop {
-        if let Some(r) = recursor.cache.lookup(current) {
-            return Ok(r);
-        }
-
-        match expand_and_resolve_once(recursor, stack, current)? {
-            Either::Left(l) => {
-                current = l;
-            }
-            Either::Right(r) => {
+    /// Like [`expand_and_resolve`], but checks the cache before descending.
+    ///
+    /// If `current` is already in the cache, the cached result is returned immediately
+    /// without pushing any frames or invoking any callbacks.
+    fn expand_and_resolve<'a>(
+        recursor: &mut Memoize<R, M>,
+        stack: &mut RStack<'a, Memoize<R, M>, Str, So, T>,
+        mut current: &'a T,
+    ) -> Result<R::Out, R::Err>
+    where
+        Str: 'a,
+        So: 'a,
+        T: Contains<T: Repr<T = Term<Str, So, T>>>,
+    {
+        loop {
+            if let Some(r) = recursor.cache.lookup(current) {
                 return Ok(r);
             }
-        }
-    }
-}
 
-/// Entry point for memoized traversal. Same structure as [`term_recursion`] but uses
-/// [`memo_expand_and_resolve`] to short-circuit cached sub-trees.
-fn memo_term_recursion<R, M, Str, So, T>(
-    recursor: &mut Memoize<R, M>,
-    term: &T,
-) -> Result<R::Out, R::Err>
-where
-    R: TermRecursor<Str, So, T, Out: Clone>,
-    M: InsertableMapping<Key = T, Value = R::Out>,
-    T: Contains<T: Repr<T = Term<Str, So, T>>> + Clone,
-{
-    let mut stack = vec![];
-    let mut result = memo_expand_and_resolve(recursor, &mut stack, term)?;
-    loop {
-        match push_result(recursor, &mut stack, result)? {
-            Either::Left(final_result) => return Ok(final_result),
-            Either::Right(mut frame) => {
-                let child = next_child(recursor, &mut frame)?;
-                stack.push(frame);
-                result = memo_expand_and_resolve(recursor, &mut stack, child)?;
+            match Self::expand_and_resolve_once(recursor, stack, current)? {
+                Either::Left(l) => {
+                    current = l;
+                }
+                Either::Right(r) => {
+                    return Ok(r);
+                }
             }
         }
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I noticed that with the current recursion scheme, it is no longer possible to clean up mutations due to entering scopes. cleanup calls are added to rewind the stack and invoked from the top of the stack. Recursion scheme is also refactored to maximize code reuse, in case of other recursion schemes need to be implemented. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
