### PR TITLE
Term backward translation from cvc5

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,20 +716,29 @@ Currently, the crate provides the following functionalities:
 13. Translation to cvc5: see the `cvc5` module and the `ConvertToCvc5` trait. This functionality requires the feature
     `cvc5`. It translates typed `Sort`s, `Term`s, and `Command`s to their cvc5 counterparts, with memoized caching
     and support for quantifier `:pattern` annotations.
+14. Translation from cvc5: see the `cvc5` module and the `ConvertFromCvc5` trait. This functionality requires the
+    feature `cvc5`. It translates cvc5 `Sort`s and `Term`s back to yaspar-ir typed ASTs, with sort caching and
+    scoped variable tracking for quantifiers and match expressions.
 
-### Translation to cvc5
+### Translation to and from cvc5
 
-The `cvc5` module exposes the `ConvertToCvc5<Env>` trait, which provides a uniform `.to_cvc5(env)` method for
-translating sorts, terms, and commands. Two environment types are used:
+The `cvc5` module provides bidirectional translation between yaspar-ir and cvc5. It exposes two
+traits and three environment types:
 
-- `Cvc5Env` — a memoized wrapper around `Cvc5EnvInner` that caches term translations. Used for
-  translating `Sort`s and `Term`s.
-- `Cvc5EnvSolver` — wraps a `Cvc5Env` and a `Solver`. Used for translating `Command`s.
+**Forward** (`ConvertToCvc5<Env>`): translates yaspar-ir `Sort`s, `Term`s, and `Command`s to cvc5.
+
+- `Cvc5Env` — a memoized environment that caches sort and term translations. Used for `Sort`s and `Term`s.
+- `Cvc5EnvSolver` — wraps a `Cvc5Env` and a `Solver`. Used for `Command`s.
+
+**Backward** (`ConvertFromCvc5<Env>`): translates cvc5 sorts and terms back to yaspar-ir.
+
+- `FromCvc5Env` — manages sort/term caching, scoped variable bindings for quantifiers and match
+  expressions, and tracking of uninterpreted sort values from models.
 
 ```rust
 use cvc5::{Solver, TermManager};
 use yaspar_ir::ast::{Context, Typecheck};
-use yaspar_ir::cvc5::{ConvertToCvc5, Cvc5Env, Cvc5EnvSolver};
+use yaspar_ir::cvc5::{ConvertFromCvc5, ConvertToCvc5, Cvc5Env, Cvc5EnvSolver, FromCvc5Env};
 use yaspar_ir::untyped::UntypedAst;
 
 fn main() {
@@ -749,18 +758,19 @@ fn main() {
     let mut solver = Solver::new(&tm);
     let mut env = Cvc5Env::create(&tm);
 
-    // translate commands (which internally translate sorts and terms)
+    // translate commands to cvc5 (which internally translate sorts and terms)
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     for cmd in &cmds {
         cmd.to_cvc5(&mut es).unwrap();
     }
 
-    // sorts and terms can also be translated individually
-    let int = ctx.int_sort();
-    let cvc5_int = int.to_cvc5(&mut env).unwrap();
-
+    // translate a term to cvc5 and back
     let term = UntypedAst.parse_term_str("(+ x 1)").unwrap().type_check(&mut ctx).unwrap();
-    let cvc5_term = term.to_cvc5(&mut env).unwrap();
+    let cvc5_term = term.to_cvc5(&mut *es.env).unwrap();
+
+    let mut from_env = FromCvc5Env::new(&mut ctx);
+    let back = cvc5_term.conv_from_cvc5(&mut from_env).unwrap();
+    assert_eq!(term.to_string(), back.to_string());
 }
 ```
 

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -522,38 +522,42 @@ fn translate_term_from_cvc5<'tm, 'env>(
             .iter()
             .map(|&c| char::from_u32(c).unwrap_or('\u{FFFD}'))
             .collect();
-        
+
         let str_val = fenv.env.allocate_str(&s);
-        return Ok(fenv.env.allocate_term(ATerm::Constant(Constant::String(str_val), Some(sort))));
+        return Ok(fenv
+            .env
+            .allocate_term(ATerm::Constant(Constant::String(str_val), Some(sort))));
     }
     if ct.is_bv_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
         let bits = ct.bv_value(2);
         let (bytes, len) = parse_binary_str_to_bytes(&bits);
-        
-        return Ok(fenv.env.allocate_term(ATerm::Constant(Constant::Binary(bytes, len), Some(sort))));
+
+        return Ok(fenv
+            .env
+            .allocate_term(ATerm::Constant(Constant::Binary(bytes, len), Some(sort))));
     }
 
     // ── Logical connectives ─────────────────────────────────
     match kind {
         Kind::And => {
             let children = translate_children(ct, fenv)?;
-            
+
             return Ok(fenv.env.and(children));
         }
         Kind::Or => {
             let children = translate_children(ct, fenv)?;
-            
+
             return Ok(fenv.env.or(children));
         }
         Kind::Xor => {
             let children = translate_children(ct, fenv)?;
-            
+
             return Ok(fenv.env.xor(children));
         }
         Kind::Not => {
             let child = translate_term_from_cvc5(&ct.child(0), fenv)?;
-            
+
             return Ok(fenv.env.not(child));
         }
         Kind::Implies => {
@@ -563,12 +567,12 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 premises.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
             }
             let concl = translate_term_from_cvc5(&ct.child(n - 1), fenv)?;
-            
+
             return Ok(fenv.env.implies(premises, concl));
         }
         Kind::Equal => {
             let children = translate_children(ct, fenv)?;
-            
+
             if children.len() == 2 {
                 return Ok(fenv.env.eq(children[0].clone(), children[1].clone()));
             }
@@ -581,14 +585,14 @@ fn translate_term_from_cvc5<'tm, 'env>(
         }
         Kind::Distinct => {
             let children = translate_children(ct, fenv)?;
-            
+
             return Ok(fenv.env.distinct(children));
         }
         Kind::Ite => {
             let b = translate_term_from_cvc5(&ct.child(0), fenv)?;
             let t = translate_term_from_cvc5(&ct.child(1), fenv)?;
             let e = translate_term_from_cvc5(&ct.child(2), fenv)?;
-            
+
             return Ok(fenv.env.ite(b, t, e));
         }
         // ── Quantifiers ─────────────────────────────────────────
@@ -601,7 +605,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 let cvc5_id = v.id();
                 let name = v.symbol().to_string();
                 let vs = v.sort().conv_from_cvc5(fenv)?;
-                
+
                 let id = fenv.env.new_local();
                 let sym = fenv.env.allocate_symbol(&name);
                 fenv.locals.insert(cvc5_id, VarBinding(sym, id, vs));
@@ -626,7 +630,6 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 if attrs.is_empty() {
                     body
                 } else {
-                    
                     fenv.env.annotated(body, attrs)
                 }
             } else {
@@ -637,7 +640,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 .iter()
                 .map(|id| fenv.locals.remove(id).unwrap())
                 .collect();
-            
+
             return if kind == Kind::Forall {
                 Ok(fenv.env.forall(bindings, body))
             } else {
@@ -648,7 +651,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
         Kind::Neg => {
             let child = translate_term_from_cvc5(&ct.child(0), fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            
+
             let sym = fenv.env.allocate_symbol(SUB);
             let qid = QualifiedIdentifier::simple(sym);
             return Ok(fenv.env.app(qid, vec![child], Some(sort)));
@@ -659,7 +662,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
             // Uninterpreted constant (declared symbol)
             let name = ct.symbol().to_string();
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            
+
             let sym = fenv.env.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
             return Ok(fenv.env.global(qid, Some(sort)));
@@ -672,7 +675,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 args.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
             }
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            
+
             let sym = fenv.env.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
             return Ok(fenv.env.app(qid, args, Some(sort)));
@@ -698,7 +701,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
             if n == 1 {
                 // Nullary constructor → global
                 let sort = ct.sort().conv_from_cvc5(fenv)?;
-                
+
                 let sym = fenv.env.allocate_symbol(&name);
                 let qid = if ct.sort().is_dt() && ct.sort().datatype().is_parametric() {
                     QualifiedIdentifier::simple_sorted(sym, sort.clone())
@@ -712,7 +715,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 args.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
             }
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            
+
             let sym = fenv.env.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
             return Ok(fenv.env.app(qid, args, Some(sort)));
@@ -726,7 +729,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
             };
             let arg = translate_term_from_cvc5(&ct.child(1), fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            
+
             let sym = fenv.env.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
             return Ok(fenv.env.app(qid, vec![arg], Some(sort)));
@@ -742,7 +745,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let ctor_name = tester_name.strip_prefix("is_").unwrap_or(&tester_name);
             let arg = translate_term_from_cvc5(&ct.child(1), fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            
+
             let is_sym = fenv.env.allocate_symbol(IS);
             let ctor_sym = fenv.env.allocate_symbol(ctor_name);
             let id = alg::Identifier {
@@ -757,7 +760,6 @@ fn translate_term_from_cvc5<'tm, 'env>(
         Kind::Variable => {
             let cvc5_id = ct.id();
             if let Some(vb) = fenv.locals.get(&cvc5_id) {
-                
                 return Ok(fenv.env.local(alg::Local {
                     id: vb.1,
                     symbol: vb.0.clone(),
@@ -767,7 +769,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
             // Fallback: unregistered variable (shouldn't happen in well-formed terms)
             let name = ct.symbol().to_string();
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            
+
             let id = fenv.env.new_local();
             let sym = fenv.env.allocate_symbol(&name);
             return Ok(fenv.env.local(alg::Local {
@@ -780,7 +782,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
         Kind::RegexpNone | Kind::RegexpAll | Kind::RegexpAllchar => {
             let ik = cvc5_kind_to_ident_kind(kind).unwrap();
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            
+
             let sym = fenv.env.allocate_symbol(ik.name());
             let qid = QualifiedIdentifier::simple(sym);
             return Ok(fenv.env.global(qid, Some(sort)));
@@ -790,7 +792,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
         Kind::BitvectorToNat => {
             let child = translate_term_from_cvc5(&ct.child(0), fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            
+
             let sym = fenv.env.allocate_symbol(BV2NAT);
             let qid = QualifiedIdentifier::simple(sym);
             return Ok(fenv.env.app(qid, vec![child], Some(sort)));
@@ -806,7 +808,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 let arm = translate_match_case_from_cvc5(&case, fenv)?;
                 arms.push(arm);
             }
-            
+
             return Ok(fenv.env.matching(scrutinee, arms));
         }
         // todo: Const and UninterpretedSortValue
@@ -817,7 +819,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
     if let Some(ik) = cvc5_kind_to_ident_kind(kind) {
         let children = translate_children(ct, fenv)?;
         let sort = ct.sort().conv_from_cvc5(fenv)?;
-        
+
         let name = ik.name();
         let sym = fenv.env.allocate_symbol(name);
         let qid = QualifiedIdentifier::simple(sym);
@@ -883,7 +885,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
             let ctor_term = pattern_ct.child(0);
             let ctor_name = ctor_term.symbol().to_string();
             let body = translate_term_from_cvc5(&case.child(1), fenv)?;
-            
+
             let sym = fenv.env.allocate_symbol(&ctor_name);
             Ok(alg::PatternArm {
                 pattern: alg::Pattern::Ctor(sym),
@@ -904,7 +906,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
                 let cvc5_id = v.id();
                 let name = v.symbol().to_string();
                 let vs = v.sort().conv_from_cvc5(fenv)?;
-                
+
                 let id = fenv.env.new_local();
                 let sym = fenv.env.allocate_symbol(&name);
                 let vb = VarBinding(sym.clone(), id, vs);
@@ -938,7 +940,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
                     let cvc5_id = v.id();
                     let name = v.symbol().to_string();
                     let vs = v.sort().conv_from_cvc5(fenv)?;
-                    
+
                     let id = fenv.env.new_local();
                     let sym = fenv.env.allocate_symbol(&name);
                     fenv.locals.insert(cvc5_id, VarBinding(sym, id, vs));
@@ -969,7 +971,6 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
                     fenv.locals.remove(sid);
                 }
 
-                
                 let ctor_sym = fenv.env.allocate_symbol(&ctor_name);
                 Ok(alg::PatternArm {
                     pattern: alg::Pattern::Applied {
@@ -999,9 +1000,10 @@ fn translate_indexed_from_cvc5<'tm, 'env>(
     };
 
     let (name, indices) = match op_kind {
-        Kind::BitvectorExtract => {
-            (BV_EXTRACT, vec![Index::Numeral(idx_u32(0)?), Index::Numeral(idx_u32(1)?)])
-        }
+        Kind::BitvectorExtract => (
+            BV_EXTRACT,
+            vec![Index::Numeral(idx_u32(0)?), Index::Numeral(idx_u32(1)?)],
+        ),
         Kind::BitvectorRepeat => (BV_REPEAT, vec![Index::Numeral(idx_u32(0)?)]),
         Kind::BitvectorZeroExtend => (BV_ZERO_EXTEND, vec![Index::Numeral(idx_u32(0)?)]),
         Kind::BitvectorSignExtend => (BV_SIGN_EXTEND, vec![Index::Numeral(idx_u32(0)?)]),
@@ -1009,20 +1011,24 @@ fn translate_indexed_from_cvc5<'tm, 'env>(
         Kind::BitvectorRotateRight => (BV_ROTATE_RIGHT, vec![Index::Numeral(idx_u32(0)?)]),
         Kind::IntToBitvector => (INT2BV, vec![Index::Numeral(idx_u32(0)?)]),
         Kind::RegexpRepeat => (RE_POWER, vec![Index::Numeral(idx_u32(0)?)]),
-        Kind::RegexpLoop => {
-            (RE_LOOP, vec![Index::Numeral(idx_u32(0)?), Index::Numeral(idx_u32(1)?)])
-        }
+        Kind::RegexpLoop => (
+            RE_LOOP,
+            vec![Index::Numeral(idx_u32(0)?), Index::Numeral(idx_u32(1)?)],
+        ),
         _ => return Ok(None),
     };
 
     let sym = fenv.env.allocate_symbol(name);
-    let id = alg::Identifier { symbol: sym, indices };
+    let id = alg::Identifier {
+        symbol: sym,
+        indices,
+    };
     let qid = QualifiedIdentifier::from(id);
     Ok(Some(fenv.env.app(qid, children, Some(sort))))
 }
 
 /// Reverse mapping from cvc5 Kind to yaspar-ir IdentifierKind.
-fn cvc5_kind_to_ident_kind(kind: Kind) -> Option<alg::IdentifierKind<Str>> {
+fn cvc5_kind_to_ident_kind(kind: Kind) -> Option<IdentifierKind> {
     use alg::IdentifierKind::*;
     Some(match kind {
         Kind::Add => Add,
@@ -1118,7 +1124,7 @@ fn cvc5_kind_to_ident_kind(kind: Kind) -> Option<alg::IdentifierKind<Str>> {
 }
 
 // ── Identifier kind → cvc5 Kind mapping ─────────────────────
-fn ident_kind_to_cvc5(k: &alg::IdentifierKind<Str>) -> Option<Kind> {
+fn ident_kind_to_cvc5(k: &IdentifierKind) -> Option<Kind> {
     use alg::IdentifierKind::*;
     Some(match k {
         Add => Kind::Add,
@@ -1745,8 +1751,8 @@ impl<'tm> Cvc5EnvInner<'tm> {
                     false,
                 )
                 .into()),
-            Some(ref ik) if ident_kind_to_cvc5(ik).is_some() => {
-                Ok(self.tm.mk_term(ident_kind_to_cvc5(ik).unwrap(), &[]).into())
+            Some(ref ik) if let Some(k) = ident_kind_to_cvc5(ik) => {
+                Ok(self.tm.mk_term(k, &[]).into())
             }
             _ => {
                 // For sort-ascribed parametric constructors like (as nil (List Int)),

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -500,15 +500,7 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
     if ct.is_bv_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
         let bits = ct.bv_value(2);
-        let input = format!("#b{bits}");
-        let mut tokenizer = yaspar::tokenize_str(&input, false);
-        let (bytes, len) = match tokenizer.next_token() {
-            Some(Ok(rt)) => match rt.tok {
-                yaspar::tokens::Token::Binary(v) => v,
-                _ => return Err(format!("failed to parse bitvector literal: {input}")),
-            },
-            _ => return Err(format!("failed to parse bitvector literal: {input}")),
-        };
+        let (bytes, len) = parse_binary_str_to_bytes(&bits);
         let arena = fenv.env.arena();
         return Ok(arena.allocate_term(ATerm::Constant(Constant::Binary(bytes, len), Some(sort))));
     }
@@ -704,8 +696,42 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
                 sort,
             }));
         }
+        // ── Nullary regexp constants ───────────────────────────────
+        Kind::RegexpNone | Kind::RegexpAll | Kind::RegexpAllchar => {
+            let ik = cvc5_kind_to_ident_kind(kind).unwrap();
+            let sort = ct.sort().conv_from_cvc5(fenv)?;
+            let arena = fenv.env.arena();
+            let sym = arena.allocate_symbol(ik.name());
+            let qid = QualifiedIdentifier::simple(sym);
+            return Ok(arena.global(qid, Some(sort)));
+        }
+
+        // ── BitvectorToNat ──────────────────────────────────────
+        Kind::BitvectorToNat => {
+            let child = translate_term_from_cvc5(&ct.child(0), fenv)?;
+            let sort = ct.sort().conv_from_cvc5(fenv)?;
+            let arena = fenv.env.arena();
+            let sym = arena.allocate_symbol("bv2nat");
+            let qid = QualifiedIdentifier::simple(sym);
+            return Ok(arena.app(qid, vec![child], Some(sort)));
+        }
+
+        // ── Match expressions ───────────────────────────────────
+        Kind::Match => {
+            let scrutinee = translate_term_from_cvc5(&ct.child(0), fenv)?;
+            let n = ct.num_children();
+            let mut arms = Vec::with_capacity(n - 1);
+            for i in 1..n {
+                let case = ct.child(i);
+                let arm = translate_match_case_from_cvc5(&case, fenv)?;
+                arms.push(arm);
+            }
+            let arena = fenv.env.arena();
+            return Ok(arena.matching(scrutinee, arms));
+        }
         _ => {}
     }
+
     // ── Known operator kinds ────────────────────────────────
     if let Some(ik) = cvc5_kind_to_ident_kind(kind) {
         let children = translate_children(ct, fenv)?;
@@ -728,6 +754,29 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
     Err(format!("unsupported cvc5 term kind: {:?}", kind))
 }
 
+/// Parse a binary string (e.g. "10110") into packed bytes and length.
+/// Mirrors the logic of `yaspar::parse_binary_str`.
+fn parse_binary_str_to_bytes(s: &str) -> (Vec<u8>, usize) {
+    let mut ret = Vec::new();
+    let mut r: u8 = 0;
+    let mut i: usize = 1;
+    for c in s.chars().rev() {
+        if c == '1' {
+            r |= i as u8;
+        }
+        i *= 2;
+        if i == 256 {
+            i = 1;
+            ret.push(r);
+            r = 0;
+        }
+    }
+    if i > 1 {
+        ret.push(r);
+    }
+    (ret, s.len())
+}
+
 fn translate_children<'tm, 'env, Env: HasArena>(
     ct: &CTerm<'tm>,
     fenv: &mut FromCvc5Env<'tm, 'env, Env>,
@@ -740,6 +789,120 @@ fn translate_children<'tm, 'env, Env: HasArena>(
     Ok(children)
 }
 
+fn translate_match_case_from_cvc5<'tm, 'env, Env: HasArena>(
+    case: &CTerm<'tm>,
+    fenv: &mut FromCvc5Env<'tm, 'env, Env>,
+) -> Res<alg::PatternArm<Str, Term>> {
+    let case_kind = case.kind();
+    match case_kind {
+        Kind::MatchCase => {
+            // Children: [pattern (ApplyConstructor), body]
+            let pattern_ct = case.child(0);
+            // Nullary constructor: ApplyConstructor with just the ctor term
+            let ctor_term = pattern_ct.child(0);
+            let ctor_name = ctor_term.symbol().to_string();
+            let body = translate_term_from_cvc5(&case.child(1), fenv)?;
+            let arena = fenv.env.arena();
+            let sym = arena.allocate_symbol(&ctor_name);
+            Ok(alg::PatternArm {
+                pattern: alg::Pattern::Ctor(sym),
+                body,
+            })
+        }
+        Kind::MatchBindCase => {
+            // Children: [variable_list, pattern, body]
+            let vlist = case.child(0);
+            let pattern_ct = case.child(1);
+            let body_ct = case.child(2);
+
+            // Determine if this is a wildcard or an applied constructor pattern
+            let pat_kind = pattern_ct.kind();
+            if pat_kind == Kind::Variable {
+                // Wildcard pattern: pattern is the same variable as in vlist
+                let v = vlist.child(0);
+                let cvc5_id = v.id();
+                let name = v.symbol().to_string();
+                let vs = v.sort().conv_from_cvc5(fenv)?;
+                let arena = fenv.env.arena();
+                let id = arena.new_local();
+                let sym = arena.allocate_symbol(&name);
+                let vb = VarBinding(sym.clone(), id, vs);
+                fenv.locals.insert(cvc5_id, vb);
+                fenv.scope_stack.push(vec![cvc5_id]);
+
+                let body = translate_term_from_cvc5(&body_ct, fenv)?;
+
+                let scope_ids = fenv.scope_stack.pop().unwrap();
+                for sid in &scope_ids {
+                    fenv.locals.remove(sid);
+                }
+                Ok(alg::PatternArm {
+                    pattern: alg::Pattern::Wildcard(Some((sym, id))),
+                    body,
+                })
+            } else {
+                // Applied constructor pattern: pattern is ApplyConstructor
+                let ctor_term = pattern_ct.child(0);
+                let ctor_name = ctor_term.symbol().to_string();
+                let num_args = pattern_ct.num_children() - 1;
+
+                // Bind variables from the variable list
+                let mut scope_ids = Vec::new();
+                let mut arguments = Vec::with_capacity(num_args);
+
+                // Build a set of variable ids from the vlist for lookup
+                let mut vlist_vars: HashMap<u64, usize> = HashMap::new();
+                for i in 0..vlist.num_children() {
+                    let v = vlist.child(i);
+                    let cvc5_id = v.id();
+                    let name = v.symbol().to_string();
+                    let vs = v.sort().conv_from_cvc5(fenv)?;
+                    let arena = fenv.env.arena();
+                    let id = arena.new_local();
+                    let sym = arena.allocate_symbol(&name);
+                    fenv.locals.insert(cvc5_id, VarBinding(sym, id, vs));
+                    scope_ids.push(cvc5_id);
+                    vlist_vars.insert(cvc5_id, i);
+                }
+                fenv.scope_stack.push(scope_ids.clone());
+
+                // Map pattern arguments to Option<(Str, usize)>
+                for i in 0..num_args {
+                    let arg = pattern_ct.child(i + 1);
+                    let arg_id = arg.id();
+                    if let Some(vb) = fenv.locals.get(&arg_id) {
+                        if arg.has_symbol() {
+                            arguments.push(Some((vb.0.clone(), vb.1)));
+                        } else {
+                            arguments.push(None);
+                        }
+                    } else {
+                        arguments.push(None);
+                    }
+                }
+
+                let body = translate_term_from_cvc5(&body_ct, fenv)?;
+
+                let scope_ids = fenv.scope_stack.pop().unwrap();
+                for sid in &scope_ids {
+                    fenv.locals.remove(sid);
+                }
+
+                let arena = fenv.env.arena();
+                let ctor_sym = arena.allocate_symbol(&ctor_name);
+                Ok(alg::PatternArm {
+                    pattern: alg::Pattern::Applied {
+                        ctor: ctor_sym,
+                        arguments,
+                    },
+                    body,
+                })
+            }
+        }
+        _ => Err(format!("unsupported match case kind: {:?}", case_kind)),
+    }
+}
+
 fn translate_indexed_from_cvc5<'tm, 'env, Env: HasArena>(
     ct: &CTerm<'tm>,
     op: &cvc5::Op<'tm>,
@@ -750,7 +913,7 @@ fn translate_indexed_from_cvc5<'tm, 'env, Env: HasArena>(
     let sort = ct.sort().conv_from_cvc5(fenv)?;
     let arena = fenv.env.arena();
 
-    let mk_indexed = |arena: &mut Arena, name: &str, indices: Vec<Index<Str>>| -> Term {
+    let mk_indexed = |arena: &mut Arena, name: &str, indices: Vec<Index>| -> Term {
         let sym = arena.allocate_symbol(name);
         let id = alg::Identifier {
             symbol: sym,
@@ -1542,6 +1705,9 @@ impl<'tm> Cvc5EnvInner<'tm> {
                     false,
                 )
                 .into()),
+            Some(ref ik) if ident_kind_to_cvc5(ik).is_some() => {
+                Ok(self.tm.mk_term(ident_kind_to_cvc5(ik).unwrap(), &[]).into())
+            }
             _ => {
                 // For sort-ascribed parametric constructors like (as nil (List Int)),
                 // resolve via the instantiated sort using instantiated_term

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -55,6 +55,7 @@ use crate::raw::alg;
 use crate::raw::alg::CheckIdentifier;
 use crate::statics::*;
 use crate::traits::{Contains, Repr};
+use crate::untyped::UntypedAst;
 pub use cvc5::{Kind, ProofComponent, Solver, TermManager};
 use dashu::integer::UBig;
 use std::collections::HashMap;
@@ -531,7 +532,14 @@ fn translate_term_from_cvc5<'tm, 'env>(
     if ct.is_bv_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
         let bits = ct.bv_value(2);
-        let (bytes, len) = parse_binary_str_to_bytes(&bits);
+        let (bytes, len) = match UntypedAst
+            .parse_term_str(&format!("#b{bits}"))
+            .map_err(|e| format!("{e}"))?
+            .repr()
+        {
+            ATerm::Constant(alg::Constant::Binary(bytes, len), _) => (bytes.clone(), *len),
+            _ => return Err(format!("bit vector literal {bits} cannot be parsed!")),
+        };
 
         return Ok(fenv
             .env
@@ -811,7 +819,42 @@ fn translate_term_from_cvc5<'tm, 'env>(
 
             return Ok(fenv.env.matching(scrutinee, arms));
         }
-        // todo: Const and UninterpretedSortValue
+        // ── Const array ──────────────────────────────────────────
+        Kind::ConstArray => {
+            todo!("ConstArray reverse translation")
+        }
+
+        // ── Uninterpreted sort value (from models) ──────────────
+        Kind::UninterpretedSortValue => {
+            todo!("UninterpretedSortValue reverse translation")
+        }
+
+        // ── Lambda ──────────────────────────────────────────────
+        Kind::Lambda => return Err("higher order functions are not supported!".into()),
+
+        // ── Sequences ───────────────────────────────────────────
+        Kind::ConstSequence => return Err("sequence operations are not supported!".into()),
+
+        // ── Sets ────────────────────────────────────────────────
+        Kind::SetEmpty
+        | Kind::SetUniverse
+        | Kind::SetSingleton
+        | Kind::SetUnion
+        | Kind::SetInter
+        | Kind::SetMinus
+        | Kind::SetMember
+        | Kind::SetSubset
+        | Kind::SetComplement
+        | Kind::SetInsert
+        | Kind::SetCard => {
+            return Err("set operations are not supported!".into());
+        }
+
+        // ── Floating point ──────────────────────────────────────
+        Kind::ConstFloatingpoint | Kind::ConstRoundingmode | Kind::FloatingpointFp => {
+            return Err("floating point operations are not supported!".into());
+        }
+
         _ => {}
     }
 
@@ -835,29 +878,6 @@ fn translate_term_from_cvc5<'tm, 'env>(
     }
 
     Err(format!("unsupported cvc5 term kind: {:?}", kind))
-}
-
-/// Parse a binary string (e.g. "10110") into packed bytes and length.
-/// Mirrors the logic of `yaspar::parse_binary_str`.
-fn parse_binary_str_to_bytes(s: &str) -> (Vec<u8>, usize) {
-    let mut ret = Vec::new();
-    let mut r: u8 = 0;
-    let mut i: usize = 1;
-    for c in s.chars().rev() {
-        if c == '1' {
-            r |= i as u8;
-        }
-        i *= 2;
-        if i == 256 {
-            i = 1;
-            ret.push(r);
-            r = 0;
-        }
-    }
-    if i > 1 {
-        ret.push(r);
-    }
-    (ret, s.len())
 }
 
 fn translate_children<'tm, 'env>(
@@ -1015,6 +1035,21 @@ fn translate_indexed_from_cvc5<'tm, 'env>(
             RE_LOOP,
             vec![Index::Numeral(idx_u32(0)?), Index::Numeral(idx_u32(1)?)],
         ),
+        Kind::Divisible => {
+            todo!("Divisible indexed operator reverse translation")
+        }
+        Kind::FloatingpointToFpFromIeeeBv
+        | Kind::FloatingpointToFpFromFp
+        | Kind::FloatingpointToFpFromReal
+        | Kind::FloatingpointToFpFromSbv
+        | Kind::FloatingpointToFpFromUbv
+        | Kind::FloatingpointToUbv
+        | Kind::FloatingpointToSbv => {
+            todo!("Floating point indexed operator reverse translation")
+        }
+        Kind::TupleProject => {
+            todo!("TupleProject indexed operator reverse translation")
+        }
         _ => return Ok(None),
     };
 

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -58,7 +58,7 @@ use crate::traits::{Contains, Repr};
 use crate::untyped::UntypedAst;
 pub use cvc5::{Kind, ProofComponent, Solver, TermManager};
 use dashu::integer::UBig;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use yaspar::ast::Keyword;
 use yaspar::{binary_to_string, hex_to_string};
 
@@ -250,6 +250,61 @@ impl<'a, 'tm> Cvc5EnvSolver<'a, 'tm> {
     }
 }
 
+/// Environment for translating cvc5 objects back to yaspar-ir typed ASTs.
+///
+/// This is independent of [`Cvc5Env`] / [`Cvc5EnvInner`] — the forward and reverse
+/// translations have no shared mutable state.
+///
+/// The type parameter `Env` must implement [`HasArena`], providing the [`Arena`] used
+/// to allocate yaspar-ir objects. This lets callers reuse an existing [`Context`] (or
+/// any other `HasArena` implementor) instead of creating a throwaway fenv.env.
+///
+/// # Example
+///
+/// ```rust
+/// use yaspar_ir::ast::Context;
+/// use yaspar_ir::cvc5::FromCvc5Env;
+///
+/// let mut ctx = Context::new();
+/// let mut from_env = FromCvc5Env::new(&mut ctx);
+/// // use from_env with ConvertFromCvc5::conv_from_cvc5
+/// ```
+pub struct FromCvc5Env<'tm, 'env> {
+    /// Cache from [`CSort`] to yaspar-ir [`Sort`], avoiding redundant work.
+    sort_cache: HashMap<CSort<'tm>, Sort>,
+    /// Bound variable map: cvc5 term id → VarBinding.
+    locals: HashMap<u64, VarBinding<Str, Sort>>,
+    /// Stack of bound variable ids for scope cleanup.
+    scope_stack: Vec<Vec<u64>>,
+    /// Allocated symbols for uninterpreted sort values encountered during translation.
+    uninterpreted_values: HashSet<String>,
+    /// The backing context.
+    pub env: &'env mut Context,
+}
+
+impl<'tm, 'env> FromCvc5Env<'tm, 'env> {
+    /// Create a new reverse-translation environment backed by `env`.
+    pub fn new(env: &'env mut Context) -> Self {
+        Self {
+            sort_cache: HashMap::new(),
+            locals: HashMap::new(),
+            scope_stack: Vec::new(),
+            uninterpreted_values: HashSet::new(),
+            env,
+        }
+    }
+
+    /// Returns whether the given symbol is an uninterpreted sort value.
+    pub fn is_uninterpreted_value(&self, name: &str) -> bool {
+        self.uninterpreted_values.contains(name)
+    }
+
+    /// Returns the set of uninterpreted sort value names encountered.
+    pub fn uninterpreted_values(&self) -> &HashSet<String> {
+        &self.uninterpreted_values
+    }
+}
+
 // ── Sort translation ─────────────────────────────────────────
 impl<'tm> ConvertToCvc5<Cvc5EnvInner<'tm>> for Sort {
     type Output = CSort<'tm>;
@@ -326,48 +381,6 @@ impl<'tm> ConvertToCvc5<Cvc5Env<'tm>> for Sort {
 }
 
 // ── Reverse sort translation (CSort → Sort) ─────────────────
-
-/// Environment for translating cvc5 objects back to yaspar-ir typed ASTs.
-///
-/// This is independent of [`Cvc5Env`] / [`Cvc5EnvInner`] — the forward and reverse
-/// translations have no shared mutable state.
-///
-/// The type parameter `Env` must implement [`HasArena`], providing the [`Arena`] used
-/// to allocate yaspar-ir objects. This lets callers reuse an existing [`Context`] (or
-/// any other `HasArena` implementor) instead of creating a throwaway fenv.env.
-///
-/// # Example
-///
-/// ```rust
-/// use yaspar_ir::ast::Context;
-/// use yaspar_ir::cvc5::FromCvc5Env;
-///
-/// let mut ctx = Context::new();
-/// let mut from_env = FromCvc5Env::new(&mut ctx);
-/// // use from_env with ConvertFromCvc5::conv_from_cvc5
-/// ```
-pub struct FromCvc5Env<'tm, 'env> {
-    /// Cache from [`CSort`] to yaspar-ir [`Sort`], avoiding redundant work.
-    sort_cache: HashMap<CSort<'tm>, Sort>,
-    /// Bound variable map: cvc5 term id → VarBinding.
-    locals: HashMap<u64, VarBinding<Str, Sort>>,
-    /// Stack of bound variable ids for scope cleanup.
-    scope_stack: Vec<Vec<u64>>,
-    /// The backing context.
-    pub env: &'env mut Context,
-}
-
-impl<'tm, 'env> FromCvc5Env<'tm, 'env> {
-    /// Create a new reverse-translation environment backed by `env`.
-    pub fn new(env: &'env mut Context) -> Self {
-        Self {
-            sort_cache: HashMap::new(),
-            locals: HashMap::new(),
-            scope_stack: Vec::new(),
-            env,
-        }
-    }
-}
 
 impl<'tm, 'env> ConvertFromCvc5<FromCvc5Env<'tm, 'env>> for CSort<'tm> {
     type Output = Sort;
@@ -826,7 +839,12 @@ fn translate_term_from_cvc5<'tm, 'env>(
 
         // ── Uninterpreted sort value (from models) ──────────────
         Kind::UninterpretedSortValue => {
-            todo!("UninterpretedSortValue reverse translation")
+            let name = ct.uninterpreted_sort_value();
+            let sort = ct.sort().conv_from_cvc5(fenv)?;
+            fenv.uninterpreted_values.insert(name.clone());
+            let sym = fenv.env.allocate_symbol(&name);
+            let qid = QualifiedIdentifier::simple(sym);
+            return Ok(fenv.env.global(qid, Some(sort)));
         }
 
         // ── Lambda ──────────────────────────────────────────────
@@ -908,7 +926,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
 
             let sym = fenv.env.allocate_symbol(&ctor_name);
             Ok(alg::PatternArm {
-                pattern: alg::Pattern::Ctor(sym),
+                pattern: Pattern::Ctor(sym),
                 body,
             })
         }
@@ -940,7 +958,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
                     fenv.locals.remove(sid);
                 }
                 Ok(alg::PatternArm {
-                    pattern: alg::Pattern::Wildcard(Some((sym, id))),
+                    pattern: Pattern::Wildcard(Some((sym, id))),
                     body,
                 })
             } else {
@@ -993,7 +1011,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
 
                 let ctor_sym = fenv.env.allocate_symbol(&ctor_name);
                 Ok(alg::PatternArm {
-                    pattern: alg::Pattern::Applied {
+                    pattern: Pattern::Applied {
                         ctor: ctor_sym,
                         arguments,
                     },
@@ -1035,21 +1053,6 @@ fn translate_indexed_from_cvc5<'tm, 'env>(
             RE_LOOP,
             vec![Index::Numeral(idx_u32(0)?), Index::Numeral(idx_u32(1)?)],
         ),
-        Kind::Divisible => {
-            todo!("Divisible indexed operator reverse translation")
-        }
-        Kind::FloatingpointToFpFromIeeeBv
-        | Kind::FloatingpointToFpFromFp
-        | Kind::FloatingpointToFpFromReal
-        | Kind::FloatingpointToFpFromSbv
-        | Kind::FloatingpointToFpFromUbv
-        | Kind::FloatingpointToUbv
-        | Kind::FloatingpointToSbv => {
-            todo!("Floating point indexed operator reverse translation")
-        }
-        Kind::TupleProject => {
-            todo!("TupleProject indexed operator reverse translation")
-        }
         _ => return Ok(None),
     };
 

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -303,6 +303,20 @@ impl<'tm, 'env> FromCvc5Env<'tm, 'env> {
     pub fn uninterpreted_values(&self) -> &HashSet<String> {
         &self.uninterpreted_values
     }
+
+    /// Push a new scope with the given cvc5 variable IDs.
+    fn push_scope(&mut self, ids: Vec<u64>) {
+        self.scope_stack.push(ids);
+    }
+
+    /// Pop the current scope and remove all its bindings from locals.
+    fn pop_scope(&mut self) -> Vec<VarBinding<Str, Sort>> {
+        let scope_ids = self.scope_stack.pop().unwrap();
+        scope_ids
+            .iter()
+            .filter_map(|id| self.locals.remove(id))
+            .collect()
+    }
 }
 
 // ── Sort translation ─────────────────────────────────────────
@@ -632,35 +646,33 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 fenv.locals.insert(cvc5_id, VarBinding(sym, id, vs));
                 scope_ids.push(cvc5_id);
             }
-            fenv.scope_stack.push(scope_ids);
-            let body = translate_term_from_cvc5(&body_ct, fenv)?;
-            // Translate :pattern annotations if present (child 2 is INST_PATTERN_LIST)
-            let body = if ct.num_children() > 2 {
-                let plist = ct.child(2);
-                let mut attrs = Vec::new();
-                for i in 0..plist.num_children() {
-                    let pat = plist.child(i);
-                    if pat.kind() == Kind::InstPattern {
-                        let mut pat_terms = Vec::new();
-                        for j in 0..pat.num_children() {
-                            pat_terms.push(translate_term_from_cvc5(&pat.child(j), fenv)?);
+            fenv.push_scope(scope_ids);
+            let result = translate_term_from_cvc5(&body_ct, fenv).and_then(|body| {
+                // Translate :pattern annotations if present (child 2 is INST_PATTERN_LIST)
+                if ct.num_children() > 2 {
+                    let plist = ct.child(2);
+                    let mut attrs = Vec::new();
+                    for i in 0..plist.num_children() {
+                        let pat = plist.child(i);
+                        if pat.kind() == Kind::InstPattern {
+                            let mut pat_terms = Vec::new();
+                            for j in 0..pat.num_children() {
+                                pat_terms.push(translate_term_from_cvc5(&pat.child(j), fenv)?);
+                            }
+                            attrs.push(Attribute::Pattern(pat_terms));
                         }
-                        attrs.push(alg::Attribute::Pattern(pat_terms));
                     }
-                }
-                if attrs.is_empty() {
-                    body
+                    if attrs.is_empty() {
+                        Ok(body)
+                    } else {
+                        Ok(fenv.env.annotated(body, attrs))
+                    }
                 } else {
-                    fenv.env.annotated(body, attrs)
+                    Ok(body)
                 }
-            } else {
-                body
-            };
-            let scope_ids = fenv.scope_stack.pop().unwrap();
-            let bindings: Vec<_> = scope_ids
-                .iter()
-                .map(|id| fenv.locals.remove(id).unwrap())
-                .collect();
+            });
+            let bindings = fenv.pop_scope();
+            let body = result?;
 
             return if kind == Kind::Forall {
                 Ok(fenv.env.forall(bindings, body))
@@ -921,7 +933,20 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
             let pattern_ct = case.child(0);
             // Nullary constructor: ApplyConstructor with just the ctor term
             let ctor_term = pattern_ct.child(0);
-            let ctor_name = ctor_term.symbol().to_string();
+            let ctor_name = if ctor_term.has_symbol() {
+                ctor_term.symbol().to_string()
+            } else {
+                let dt = pattern_ct.sort().datatype();
+                let mut name = String::new();
+                for i in 0..dt.num_constructors() {
+                    let c = dt.constructor(i);
+                    if c.num_selectors() == 0 {
+                        name = c.name().to_string();
+                        break;
+                    }
+                }
+                name
+            };
             let body = translate_term_from_cvc5(&case.child(1), fenv)?;
 
             let sym = fenv.env.allocate_symbol(&ctor_name);
@@ -942,72 +967,64 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
                 // Wildcard pattern: pattern is the same variable as in vlist
                 let v = vlist.child(0);
                 let cvc5_id = v.id();
-                let name = v.symbol().to_string();
                 let vs = v.sort().conv_from_cvc5(fenv)?;
 
-                let id = fenv.env.new_local();
-                let sym = fenv.env.allocate_symbol(&name);
-                let vb = VarBinding(sym.clone(), id, vs);
-                fenv.locals.insert(cvc5_id, vb);
-                fenv.scope_stack.push(vec![cvc5_id]);
+                if v.has_symbol() {
+                    let name = v.symbol().to_string();
+                    let id = fenv.env.new_local();
+                    let sym = fenv.env.allocate_symbol(&name);
+                    let vb = VarBinding(sym.clone(), id, vs);
+                    fenv.locals.insert(cvc5_id, vb);
+                    fenv.push_scope(vec![cvc5_id]);
 
-                let body = translate_term_from_cvc5(&body_ct, fenv)?;
-
-                let scope_ids = fenv.scope_stack.pop().unwrap();
-                for sid in &scope_ids {
-                    fenv.locals.remove(sid);
+                    let result = translate_term_from_cvc5(&body_ct, fenv);
+                    fenv.pop_scope();
+                    let body = result?;
+                    Ok(alg::PatternArm {
+                        pattern: Pattern::Wildcard(Some((sym, id))),
+                        body,
+                    })
+                } else {
+                    // Anonymous wildcard — no variable binding
+                    let body = translate_term_from_cvc5(&body_ct, fenv)?;
+                    Ok(alg::PatternArm {
+                        pattern: Pattern::Wildcard(None),
+                        body,
+                    })
                 }
-                Ok(alg::PatternArm {
-                    pattern: Pattern::Wildcard(Some((sym, id))),
-                    body,
-                })
             } else {
                 // Applied constructor pattern: pattern is ApplyConstructor
                 let ctor_term = pattern_ct.child(0);
-                let ctor_name = ctor_term.symbol().to_string();
+                let ctor_name = if ctor_term.has_symbol() {
+                    ctor_term.symbol().to_string()
+                } else {
+                    format!("{ctor_term}")
+                };
                 let num_args = pattern_ct.num_children() - 1;
 
-                // Bind variables from the variable list
                 let mut scope_ids = Vec::new();
                 let mut arguments = Vec::with_capacity(num_args);
 
-                // Build a set of variable ids from the vlist for lookup
-                let mut vlist_vars: HashMap<u64, usize> = HashMap::new();
-                for i in 0..vlist.num_children() {
-                    let v = vlist.child(i);
-                    let cvc5_id = v.id();
-                    let name = v.symbol().to_string();
-                    let vs = v.sort().conv_from_cvc5(fenv)?;
-
-                    let id = fenv.env.new_local();
-                    let sym = fenv.env.allocate_symbol(&name);
-                    fenv.locals.insert(cvc5_id, VarBinding(sym, id, vs));
-                    scope_ids.push(cvc5_id);
-                    vlist_vars.insert(cvc5_id, i);
-                }
-                fenv.scope_stack.push(scope_ids.clone());
-
-                // Map pattern arguments to Option<(Str, usize)>
                 for i in 0..num_args {
                     let arg = pattern_ct.child(i + 1);
-                    let arg_id = arg.id();
-                    if let Some(vb) = fenv.locals.get(&arg_id) {
-                        if arg.has_symbol() {
-                            arguments.push(Some((vb.0.clone(), vb.1)));
-                        } else {
-                            arguments.push(None);
-                        }
+                    let cvc5_id = arg.id();
+                    scope_ids.push(cvc5_id);
+                    if arg.has_symbol() {
+                        let name = arg.symbol().to_string();
+                        let vs = arg.sort().conv_from_cvc5(fenv)?;
+                        let id = fenv.env.new_local();
+                        let sym = fenv.env.allocate_symbol(&name);
+                        fenv.locals.insert(cvc5_id, VarBinding(sym.clone(), id, vs));
+                        arguments.push(Some((sym, id)));
                     } else {
                         arguments.push(None);
                     }
                 }
+                fenv.push_scope(scope_ids);
 
-                let body = translate_term_from_cvc5(&body_ct, fenv)?;
-
-                let scope_ids = fenv.scope_stack.pop().unwrap();
-                for sid in &scope_ids {
-                    fenv.locals.remove(sid);
-                }
+                let result = translate_term_from_cvc5(&body_ct, fenv);
+                fenv.pop_scope();
+                let body = result?;
 
                 let ctor_sym = fenv.env.allocate_symbol(&ctor_name);
                 Ok(alg::PatternArm {

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -350,7 +350,10 @@ impl<'tm, 'env> FromCvc5Env<'tm, 'env> {
 
     /// Pop the current scope and remove all its bindings from locals.
     fn pop_scope(&mut self) -> Vec<VarBinding<Str, Sort>> {
-        let scope_ids = self.scope_stack.pop().unwrap();
+        let scope_ids = self
+            .scope_stack
+            .pop()
+            .expect("fatal error: unbalanced scope stack!");
         scope_ids
             .iter()
             .filter_map(|id| self.locals.remove(id))
@@ -775,15 +778,22 @@ fn translate_term_from_cvc5<'tm, 'env>(
             } else {
                 // Parametric constructor: get name from the sort's datatype
                 let dt = ct.sort().datatype();
-                let mut found = String::new();
+                let mut found = false;
+                let mut name = String::new();
                 for i in 0..dt.num_constructors() {
                     let ctor = dt.constructor(i);
                     if ctor.term() == head || ctor.num_selectors() == ct.num_children() - 1 {
-                        found = ctor.name().to_string();
+                        name = ctor.name().to_string();
+                        found = true;
                         break;
                     }
                 }
-                found
+                if !found {
+                    return Err(format!(
+                        "fatal error: term {head} cannot find a case for its datatype {dt}!"
+                    ));
+                }
+                name
             };
             let n = ct.num_children();
             if n == 1 {
@@ -987,14 +997,24 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
             let ctor_name = if ctor_term.has_symbol() {
                 ctor_term.symbol().to_string()
             } else {
+                // Parametric constructor: the ctor_term is sort-qualified (e.g. `(as nil (List Int))`).
+                // Compare against instantiated constructor terms from the datatype.
                 let dt = pattern_ct.sort().datatype();
+                let sort = pattern_ct.sort();
+                let mut found = false;
                 let mut name = String::new();
                 for i in 0..dt.num_constructors() {
                     let c = dt.constructor(i);
-                    if c.num_selectors() == 0 {
+                    if c.instantiated_term(sort.clone()) == ctor_term {
                         name = c.name().to_string();
+                        found = true;
                         break;
                     }
+                }
+                if !found {
+                    return Err(format!(
+                        "fatal error: term {ctor_term} cannot find a case for its datatype {dt}!"
+                    ));
                 }
                 name
             };

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -679,14 +679,32 @@ fn translate_term_from_cvc5<'tm, 'env>(
         }
         Kind::ApplyConstructor => {
             let head = ct.child(0);
-            let name = head.symbol().to_string();
+            let name = if head.has_symbol() {
+                head.symbol().to_string()
+            } else {
+                // Parametric constructor: get name from the sort's datatype
+                let dt = ct.sort().datatype();
+                let mut found = String::new();
+                for i in 0..dt.num_constructors() {
+                    let ctor = dt.constructor(i);
+                    if ctor.term() == head || ctor.num_selectors() == ct.num_children() - 1 {
+                        found = ctor.name().to_string();
+                        break;
+                    }
+                }
+                found
+            };
             let n = ct.num_children();
             if n == 1 {
                 // Nullary constructor → global
                 let sort = ct.sort().conv_from_cvc5(fenv)?;
                 
                 let sym = fenv.env.allocate_symbol(&name);
-                let qid = QualifiedIdentifier::simple(sym);
+                let qid = if ct.sort().is_dt() && ct.sort().datatype().is_parametric() {
+                    QualifiedIdentifier::simple_sorted(sym, sort.clone())
+                } else {
+                    QualifiedIdentifier::simple(sym)
+                };
                 return Ok(fenv.env.global(qid, Some(sort)));
             }
             let mut args = Vec::with_capacity(n - 1);
@@ -701,7 +719,11 @@ fn translate_term_from_cvc5<'tm, 'env>(
         }
         Kind::ApplySelector => {
             let head = ct.child(0);
-            let name = head.symbol().to_string();
+            let name = if head.has_symbol() {
+                head.symbol().to_string()
+            } else {
+                format!("{head}")
+            };
             let arg = translate_term_from_cvc5(&ct.child(1), fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
             
@@ -711,7 +733,11 @@ fn translate_term_from_cvc5<'tm, 'env>(
         }
         Kind::ApplyTester => {
             let head = ct.child(0);
-            let tester_name = head.symbol().to_string();
+            let tester_name = if head.has_symbol() {
+                head.symbol().to_string()
+            } else {
+                format!("{head}")
+            };
             // cvc5 tester names are "is_<ctor>"; extract the constructor name
             let ctor_name = tester_name.strip_prefix("is_").unwrap_or(&tester_name);
             let arg = translate_term_from_cvc5(&ct.child(1), fenv)?;

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -1,12 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Translation from yaspar-ir typed ASTs to cvc5 objects.
+//! Translation between yaspar-ir typed ASTs and cvc5 objects.
 //!
-//! This module provides the [`ConvertToCvc5`] trait and two environment types for translating
-//! yaspar-ir typed ASTs into their cvc5 counterparts. It requires the `cvc5` feature.
+//! This module provides bidirectional translation between yaspar-ir and cvc5:
 //!
-//! # Overview
+//! - **Forward** ([`ConvertToCvc5`]): translates yaspar-ir [`Sort`], [`Term`], and [`Command`]
+//!   into their cvc5 counterparts.
+//! - **Backward** ([`ConvertFromCvc5`]): translates cvc5 sorts and terms back into yaspar-ir
+//!   typed ASTs.
+//!
+//! # Forward translation
 //!
 //! - [`ConvertToCvc5<Env>`] — the core trait, implemented for [`Sort`], [`Term`], and [`Command`].
 //! - [`Cvc5Env`] — holds a [`cvc5::TermManager`] and caches for sort/term/symbol translation.
@@ -14,6 +18,17 @@
 //! - [`Cvc5EnvSolver`] — wraps a [`Cvc5EnvInner`] and a [`Solver`]. Used as the environment
 //!   for `Command::to_cvc5`, since commands may interact with the solver (e.g. `assert`,
 //!   `check-sat`, `define-fun`).
+//!
+//! # Backward translation
+//!
+//! - [`ConvertFromCvc5<Env>`] — the core trait, implemented for [`CSort`] and [`CTerm`].
+//! - [`FromCvc5Env`] — holds a mutable reference to a [`Context`] and manages scoped variable
+//!   bindings, sort caching, and tracking of uninterpreted sort values. Used as the environment
+//!   for `CSort::conv_from_cvc5` and `CTerm::conv_from_cvc5`.
+//!
+//! The backward translation handles constants, logical connectives, quantifiers (including
+//! `:pattern` annotations), arithmetic/bitvector/string operators, indexed operators,
+//! datatype constructors/selectors/testers, match expressions, and uninterpreted sort values.
 //!
 //! # Example
 //!
@@ -42,12 +57,14 @@
 //! # Caching
 //!
 //! [`Cvc5Env`] caches translated sorts and terms so that repeated translations of the same
-//! hashconsed object return the cached cvc5 object directly.
+//! hash-consed object return the cached cvc5 object directly. [`FromCvc5Env`] similarly caches
+//! both sort and term translations from cvc5 back to yaspar-ir.
 //!
 //! # Annotations
 //!
-//! Quantifier `:pattern` annotations are translated to cvc5 `INST_PATTERN` / `INST_PATTERN_LIST`
-//! terms, which guide quantifier instantiation. Other annotations are ignored.
+//! Quantifier `:pattern` annotations are preserved in both directions: translated to cvc5
+//! `INST_PATTERN` / `INST_PATTERN_LIST` terms in the forward direction, and reconstructed as
+//! `Attribute::Pattern` annotations in the backward direction.
 
 use crate::ast::alg::VarBinding;
 use crate::ast::*;
@@ -112,8 +129,22 @@ pub trait ConvertToCvc5<Env> {
     fn to_cvc5(&self, env: &mut Env) -> Res<Self::Output>;
 }
 
+/// Convert a cvc5 object back to its yaspar-ir typed AST counterpart.
+///
+/// This trait is implemented for [`CSort`] and [`CTerm`], both using
+/// [`FromCvc5Env`] as the environment:
+///
+/// | cvc5 type   | Environment      | Output   |
+/// |-------------|------------------|----------|
+/// | [`CSort`]   | [`FromCvc5Env`]  | [`Sort`] |
+/// | [`CTerm`]   | [`FromCvc5Env`]  | [`Term`] |
+///
+/// Translation may fail if the cvc5 object uses features not supported by yaspar-ir
+/// (e.g. floating-point sorts, set operations).
 pub trait ConvertFromCvc5<Env> {
+    /// The yaspar-ir type produced by the translation.
     type Output;
+    /// Translate `self` into a yaspar-ir object, using `env` for allocation and scope tracking.
     fn conv_from_cvc5(&self, env: &mut Env) -> Res<Self::Output>;
 }
 
@@ -252,12 +283,17 @@ impl<'a, 'tm> Cvc5EnvSolver<'a, 'tm> {
 
 /// Environment for translating cvc5 objects back to yaspar-ir typed ASTs.
 ///
-/// This is independent of [`Cvc5Env`] / [`Cvc5EnvInner`] — the forward and reverse
-/// translations have no shared mutable state.
+/// This struct manages:
+/// - **Sort caching**: avoids redundant sort translations via a [`CSort`] → [`Sort`] cache.
+/// - **Term caching**: avoids redundant term translations via a [`CTerm`] → [`Term`] cache.
+/// - **Scoped variable bindings**: tracks bound variables introduced by quantifiers and match
+///   expressions, ensuring that variable references in the body resolve to the correct local IDs.
+/// - **Uninterpreted sort values**: records names of uninterpreted sort values encountered
+///   during translation (e.g. `@U0`, `@U1` from models), queryable after translation.
 ///
-/// The type parameter `Env` must implement [`HasArena`], providing the [`Arena`] used
-/// to allocate yaspar-ir objects. This lets callers reuse an existing [`Context`] (or
-/// any other `HasArena` implementor) instead of creating a throwaway fenv.env.
+/// The environment requires a mutable reference to a [`Context`] to access the arena for
+/// allocation and the active theories for sort-aware constant construction (e.g. distinguishing
+/// `Int` numerals from `Real` decimals in mixed `RealInts` logics).
 ///
 /// # Example
 ///
@@ -272,6 +308,8 @@ impl<'a, 'tm> Cvc5EnvSolver<'a, 'tm> {
 pub struct FromCvc5Env<'tm, 'env> {
     /// Cache from [`CSort`] to yaspar-ir [`Sort`], avoiding redundant work.
     sort_cache: HashMap<CSort<'tm>, Sort>,
+    /// Cache from [`CTerm`] to yaspar-ir [`Term`], avoiding redundant work.
+    term_cache: HashMap<CTerm<'tm>, Term>,
     /// Bound variable map: cvc5 term id → VarBinding.
     locals: HashMap<u64, VarBinding<Str, Sort>>,
     /// Stack of bound variable ids for scope cleanup.
@@ -287,6 +325,7 @@ impl<'tm, 'env> FromCvc5Env<'tm, 'env> {
     pub fn new(env: &'env mut Context) -> Self {
         Self {
             sort_cache: HashMap::new(),
+            term_cache: HashMap::new(),
             locals: HashMap::new(),
             scope_stack: Vec::new(),
             uninterpreted_values: HashSet::new(),
@@ -477,7 +516,12 @@ impl<'tm, 'env> ConvertFromCvc5<FromCvc5Env<'tm, 'env>> for CTerm<'tm> {
     type Output = Term;
 
     fn conv_from_cvc5(&self, fenv: &mut FromCvc5Env<'tm, 'env>) -> Res<Term> {
-        translate_term_from_cvc5(self, fenv)
+        if let Some(t) = fenv.term_cache.get(self) {
+            return Ok(t.clone());
+        }
+        let t = translate_term_from_cvc5(self, fenv)?;
+        fenv.term_cache.insert(self.clone(), t.clone());
+        Ok(t)
     }
 }
 
@@ -591,7 +635,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
             return Ok(fenv.env.xor(children));
         }
         Kind::Not => {
-            let child = translate_term_from_cvc5(&ct.child(0), fenv)?;
+            let child = ct.child(0).conv_from_cvc5(fenv)?;
 
             return Ok(fenv.env.not(child));
         }
@@ -599,9 +643,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let n = ct.num_children();
             let mut premises = Vec::with_capacity(n - 1);
             for i in 0..n - 1 {
-                premises.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
+                premises.push(ct.child(i).conv_from_cvc5(fenv)?);
             }
-            let concl = translate_term_from_cvc5(&ct.child(n - 1), fenv)?;
+            let concl = ct.child(n - 1).conv_from_cvc5(fenv)?;
 
             return Ok(fenv.env.implies(premises, concl));
         }
@@ -624,9 +668,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
             return Ok(fenv.env.distinct(children));
         }
         Kind::Ite => {
-            let b = translate_term_from_cvc5(&ct.child(0), fenv)?;
-            let t = translate_term_from_cvc5(&ct.child(1), fenv)?;
-            let e = translate_term_from_cvc5(&ct.child(2), fenv)?;
+            let b = ct.child(0).conv_from_cvc5(fenv)?;
+            let t = ct.child(1).conv_from_cvc5(fenv)?;
+            let e = ct.child(2).conv_from_cvc5(fenv)?;
 
             return Ok(fenv.env.ite(b, t, e));
         }
@@ -647,7 +691,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 scope_ids.push(cvc5_id);
             }
             fenv.push_scope(scope_ids);
-            let result = translate_term_from_cvc5(&body_ct, fenv).and_then(|body| {
+            let result = body_ct.conv_from_cvc5(fenv).and_then(|body| {
                 // Translate :pattern annotations if present (child 2 is INST_PATTERN_LIST)
                 if ct.num_children() > 2 {
                     let plist = ct.child(2);
@@ -657,7 +701,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
                         if pat.kind() == Kind::InstPattern {
                             let mut pat_terms = Vec::new();
                             for j in 0..pat.num_children() {
-                                pat_terms.push(translate_term_from_cvc5(&pat.child(j), fenv)?);
+                                pat_terms.push(pat.child(j).conv_from_cvc5(fenv)?);
                             }
                             attrs.push(Attribute::Pattern(pat_terms));
                         }
@@ -682,7 +726,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
         }
         // ── Negation (unary minus) ──────────────────────────────
         Kind::Neg => {
-            let child = translate_term_from_cvc5(&ct.child(0), fenv)?;
+            let child = ct.child(0).conv_from_cvc5(fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
             let sym = fenv.env.allocate_symbol(SUB);
@@ -705,7 +749,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let name = head.symbol().to_string();
             let mut args = Vec::with_capacity(ct.num_children() - 1);
             for i in 1..ct.num_children() {
-                args.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
+                args.push(ct.child(i).conv_from_cvc5(fenv)?);
             }
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
@@ -745,7 +789,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
             }
             let mut args = Vec::with_capacity(n - 1);
             for i in 1..n {
-                args.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
+                args.push(ct.child(i).conv_from_cvc5(fenv)?);
             }
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
@@ -760,7 +804,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
             } else {
                 format!("{head}")
             };
-            let arg = translate_term_from_cvc5(&ct.child(1), fenv)?;
+            let arg = ct.child(1).conv_from_cvc5(fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
             let sym = fenv.env.allocate_symbol(&name);
@@ -776,7 +820,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
             };
             // cvc5 tester names are "is_<ctor>"; extract the constructor name
             let ctor_name = tester_name.strip_prefix("is_").unwrap_or(&tester_name);
-            let arg = translate_term_from_cvc5(&ct.child(1), fenv)?;
+            let arg = ct.child(1).conv_from_cvc5(fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
             let is_sym = fenv.env.allocate_symbol(IS);
@@ -799,17 +843,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
                     sort: vb.2.clone(),
                 }));
             }
-            // Fallback: unregistered variable (shouldn't happen in well-formed terms)
-            let name = ct.symbol().to_string();
-            let sort = ct.sort().conv_from_cvc5(fenv)?;
-
-            let id = fenv.env.new_local();
-            let sym = fenv.env.allocate_symbol(&name);
-            return Ok(fenv.env.local(alg::Local {
-                id,
-                symbol: sym,
-                sort,
-            }));
+            return Err(format!(
+                "unexpected and fatal scope management error: local variable {ct} is not bound!"
+            ));
         }
         // ── Nullary regexp constants ───────────────────────────────
         Kind::RegexpNone | Kind::RegexpAll | Kind::RegexpAllchar => {
@@ -823,7 +859,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
 
         // ── BitvectorToNat ──────────────────────────────────────
         Kind::BitvectorToNat => {
-            let child = translate_term_from_cvc5(&ct.child(0), fenv)?;
+            let child = ct.child(0).conv_from_cvc5(fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
             let sym = fenv.env.allocate_symbol(BV2NAT);
@@ -833,7 +869,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
 
         // ── Match expressions ───────────────────────────────────
         Kind::Match => {
-            let scrutinee = translate_term_from_cvc5(&ct.child(0), fenv)?;
+            let scrutinee = ct.child(0).conv_from_cvc5(fenv)?;
             let n = ct.num_children();
             let mut arms = Vec::with_capacity(n - 1);
             for i in 1..n {
@@ -917,7 +953,7 @@ fn translate_children<'tm, 'env>(
     let n = ct.num_children();
     let mut children = Vec::with_capacity(n);
     for i in 0..n {
-        children.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
+        children.push(ct.child(i).conv_from_cvc5(fenv)?);
     }
     Ok(children)
 }
@@ -947,7 +983,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
                 }
                 name
             };
-            let body = translate_term_from_cvc5(&case.child(1), fenv)?;
+            let body = case.child(1).conv_from_cvc5(fenv)?;
 
             let sym = fenv.env.allocate_symbol(&ctor_name);
             Ok(alg::PatternArm {
@@ -977,7 +1013,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
                     fenv.locals.insert(cvc5_id, vb);
                     fenv.push_scope(vec![cvc5_id]);
 
-                    let result = translate_term_from_cvc5(&body_ct, fenv);
+                    let result = body_ct.conv_from_cvc5(fenv);
                     fenv.pop_scope();
                     let body = result?;
                     Ok(alg::PatternArm {
@@ -986,7 +1022,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
                     })
                 } else {
                     // Anonymous wildcard — no variable binding
-                    let body = translate_term_from_cvc5(&body_ct, fenv)?;
+                    let body = body_ct.conv_from_cvc5(fenv)?;
                     Ok(alg::PatternArm {
                         pattern: Pattern::Wildcard(None),
                         body,
@@ -1022,7 +1058,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
                 }
                 fenv.push_scope(scope_ids);
 
-                let result = translate_term_from_cvc5(&body_ct, fenv);
+                let result = body_ct.conv_from_cvc5(fenv);
                 fenv.pop_scope();
                 let body = result?;
 

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -1096,26 +1096,29 @@ fn translate_indexed_from_cvc5<'tm, 'env>(
     let children = translate_children(ct, fenv)?;
     let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-    let idx_u32 = |i: usize| -> Res<UBig> {
+    let idx_ubig = |i: usize| -> Res<UBig> {
         let idx_term = op.index(i);
-        Ok(UBig::from(idx_term.uint32_value()))
+        idx_term
+            .integer_value()
+            .parse::<UBig>()
+            .map_err(|e| format!("Big integer parse error: {e}"))
     };
 
     let (name, indices) = match op_kind {
         Kind::BitvectorExtract => (
             BV_EXTRACT,
-            vec![Index::Numeral(idx_u32(0)?), Index::Numeral(idx_u32(1)?)],
+            vec![Index::Numeral(idx_ubig(0)?), Index::Numeral(idx_ubig(1)?)],
         ),
-        Kind::BitvectorRepeat => (BV_REPEAT, vec![Index::Numeral(idx_u32(0)?)]),
-        Kind::BitvectorZeroExtend => (BV_ZERO_EXTEND, vec![Index::Numeral(idx_u32(0)?)]),
-        Kind::BitvectorSignExtend => (BV_SIGN_EXTEND, vec![Index::Numeral(idx_u32(0)?)]),
-        Kind::BitvectorRotateLeft => (BV_ROTATE_LEFT, vec![Index::Numeral(idx_u32(0)?)]),
-        Kind::BitvectorRotateRight => (BV_ROTATE_RIGHT, vec![Index::Numeral(idx_u32(0)?)]),
-        Kind::IntToBitvector => (INT2BV, vec![Index::Numeral(idx_u32(0)?)]),
-        Kind::RegexpRepeat => (RE_POWER, vec![Index::Numeral(idx_u32(0)?)]),
+        Kind::BitvectorRepeat => (BV_REPEAT, vec![Index::Numeral(idx_ubig(0)?)]),
+        Kind::BitvectorZeroExtend => (BV_ZERO_EXTEND, vec![Index::Numeral(idx_ubig(0)?)]),
+        Kind::BitvectorSignExtend => (BV_SIGN_EXTEND, vec![Index::Numeral(idx_ubig(0)?)]),
+        Kind::BitvectorRotateLeft => (BV_ROTATE_LEFT, vec![Index::Numeral(idx_ubig(0)?)]),
+        Kind::BitvectorRotateRight => (BV_ROTATE_RIGHT, vec![Index::Numeral(idx_ubig(0)?)]),
+        Kind::IntToBitvector => (INT2BV, vec![Index::Numeral(idx_ubig(0)?)]),
+        Kind::RegexpRepeat => (RE_POWER, vec![Index::Numeral(idx_ubig(0)?)]),
         Kind::RegexpLoop => (
             RE_LOOP,
-            vec![Index::Numeral(idx_u32(0)?), Index::Numeral(idx_u32(1)?)],
+            vec![Index::Numeral(idx_ubig(0)?), Index::Numeral(idx_ubig(1)?)],
         ),
         _ => return Ok(None),
     };

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -55,6 +55,7 @@ use crate::raw::alg;
 use crate::raw::alg::CheckIdentifier;
 use crate::traits::{Contains, Repr};
 pub use cvc5::{Kind, ProofComponent, Solver, TermManager};
+use dashu::integer::UBig;
 use std::collections::HashMap;
 use yaspar::ast::Keyword;
 use yaspar::{binary_to_string, hex_to_string};
@@ -346,6 +347,10 @@ impl<'tm> ConvertToCvc5<Cvc5Env<'tm>> for Sort {
 pub struct FromCvc5Env<'tm, 'env, Env> {
     /// Cache from [`CSort`] to yaspar-ir [`Sort`], avoiding redundant work.
     sort_cache: HashMap<CSort<'tm>, Sort>,
+    /// Bound variable map: cvc5 term id → VarBinding.
+    locals: HashMap<u64, VarBinding<Str, Sort>>,
+    /// Stack of bound variable ids for scope cleanup.
+    scope_stack: Vec<Vec<u64>>,
     /// The backing environment that provides the [`Arena`].
     pub env: &'env mut Env,
 }
@@ -355,6 +360,8 @@ impl<'tm, 'env, Env: HasArena> FromCvc5Env<'tm, 'env, Env> {
     pub fn new(env: &'env mut Env) -> Self {
         Self {
             sort_cache: HashMap::new(),
+            locals: HashMap::new(),
+            scope_stack: Vec::new(),
             env,
         }
     }
@@ -433,6 +440,478 @@ fn translate_sort_from_cvc5<'tm>(cs: &CSort<'tm>, arena: &mut Arena) -> Res<Sort
         return Ok(arena.simple_sort(name));
     }
     Err(format!("unsupported cvc5 sort: {cs}"))
+}
+
+// ── Term: cvc5 → yaspar-ir ───────────────────────────────────
+
+impl<'tm, 'env, Env: HasArena> ConvertFromCvc5<FromCvc5Env<'tm, 'env, Env>> for CTerm<'tm> {
+    type Output = Term;
+
+    fn conv_from_cvc5(&self, fenv: &mut FromCvc5Env<'tm, 'env, Env>) -> Res<Term> {
+        translate_term_from_cvc5(self, fenv)
+    }
+}
+
+fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
+    ct: &CTerm<'tm>,
+    fenv: &mut FromCvc5Env<'tm, 'env, Env>,
+) -> Res<Term> {
+    let arena = fenv.env.arena();
+    let kind = ct.kind();
+
+    // ── Constants ────────────────────────────────────────────
+    if ct.is_boolean_value() {
+        let sort = Some(arena.bool_sort());
+        return Ok(arena.allocate_term(ATerm::Constant(Constant::Bool(ct.boolean_value()), sort)));
+    }
+    if ct.is_integer_value() {
+        let sort = ct.sort().conv_from_cvc5(fenv)?;
+        let n: UBig = ct
+            .integer_value()
+            .parse()
+            .map_err(|e| format!("Big integer parse error: {e}"))?;
+        let arena = fenv.env.arena();
+        return Ok(arena.allocate_term(ATerm::Constant(Constant::Numeral(n), Some(sort))));
+    }
+    if ct.is_real_value() {
+        let sort = ct.sort().conv_from_cvc5(fenv)?;
+        let s = ct.real_value();
+        let arena = fenv.env.arena();
+        // cvc5 returns rationals as "num/den" or just "num"
+        if let Some((num, den)) = s.split_once('/') {
+            let n: dashu::float::DBig =
+                format!("{num}/{den}").parse().map_err(|e| format!("{e}"))?;
+            return Ok(arena.allocate_term(ATerm::Constant(Constant::Decimal(n), Some(sort))));
+        }
+        let n: dashu::float::DBig = format!("{s}/1").parse().map_err(|e| format!("{e}"))?;
+        return Ok(arena.allocate_term(ATerm::Constant(Constant::Decimal(n), Some(sort))));
+    }
+    if ct.is_string_value() {
+        let sort = ct.sort().conv_from_cvc5(fenv)?;
+        let chars = ct.u32string_value();
+        let s: String = chars
+            .iter()
+            .map(|&c| char::from_u32(c).unwrap_or('\u{FFFD}'))
+            .collect();
+        let arena = fenv.env.arena();
+        let str_val = arena.allocate_str(&s);
+        return Ok(arena.allocate_term(ATerm::Constant(Constant::String(str_val), Some(sort))));
+    }
+    if ct.is_bv_value() {
+        let sort = ct.sort().conv_from_cvc5(fenv)?;
+        let bits = ct.bv_value(2);
+        let input = format!("#b{bits}");
+        let mut tokenizer = yaspar::tokenize_str(&input, false);
+        let (bytes, len) = match tokenizer.next_token() {
+            Some(Ok(rt)) => match rt.tok {
+                yaspar::tokens::Token::Binary(v) => v,
+                _ => return Err(format!("failed to parse bitvector literal: {input}")),
+            },
+            _ => return Err(format!("failed to parse bitvector literal: {input}")),
+        };
+        let arena = fenv.env.arena();
+        return Ok(arena.allocate_term(ATerm::Constant(Constant::Binary(bytes, len), Some(sort))));
+    }
+
+    // ── Logical connectives ─────────────────────────────────
+    match kind {
+        Kind::And => {
+            let children = translate_children(ct, fenv)?;
+            let arena = fenv.env.arena();
+            return Ok(arena.and(children));
+        }
+        Kind::Or => {
+            let children = translate_children(ct, fenv)?;
+            let arena = fenv.env.arena();
+            return Ok(arena.or(children));
+        }
+        Kind::Xor => {
+            let children = translate_children(ct, fenv)?;
+            let arena = fenv.env.arena();
+            return Ok(arena.xor(children));
+        }
+        Kind::Not => {
+            let child = translate_term_from_cvc5(&ct.child(0), fenv)?;
+            let arena = fenv.env.arena();
+            return Ok(arena.not(child));
+        }
+        Kind::Implies => {
+            let n = ct.num_children();
+            let mut premises = Vec::with_capacity(n - 1);
+            for i in 0..n - 1 {
+                premises.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
+            }
+            let concl = translate_term_from_cvc5(&ct.child(n - 1), fenv)?;
+            let arena = fenv.env.arena();
+            return Ok(arena.implies(premises, concl));
+        }
+        Kind::Equal => {
+            let children = translate_children(ct, fenv)?;
+            let arena = fenv.env.arena();
+            if children.len() == 2 {
+                return Ok(arena.eq(children[0].clone(), children[1].clone()));
+            }
+            // Chain: (= a b c) → (and (= a b) (= b c))
+            let mut eqs = Vec::with_capacity(children.len() - 1);
+            for i in 0..children.len() - 1 {
+                eqs.push(arena.eq(children[i].clone(), children[i + 1].clone()));
+            }
+            return Ok(arena.and(eqs));
+        }
+        Kind::Distinct => {
+            let children = translate_children(ct, fenv)?;
+            let arena = fenv.env.arena();
+            return Ok(arena.distinct(children));
+        }
+        Kind::Ite => {
+            let b = translate_term_from_cvc5(&ct.child(0), fenv)?;
+            let t = translate_term_from_cvc5(&ct.child(1), fenv)?;
+            let e = translate_term_from_cvc5(&ct.child(2), fenv)?;
+            let arena = fenv.env.arena();
+            return Ok(arena.ite(b, t, e));
+        }
+        // ── Quantifiers ─────────────────────────────────────────
+        Kind::Forall | Kind::Exists => {
+            let vlist = ct.child(0);
+            let body_ct = ct.child(1);
+            let mut scope_ids = Vec::new();
+            for i in 0..vlist.num_children() {
+                let v = vlist.child(i);
+                let cvc5_id = v.id();
+                let name = v.symbol().to_string();
+                let vs = v.sort().conv_from_cvc5(fenv)?;
+                let arena = fenv.env.arena();
+                let id = arena.new_local();
+                let sym = arena.allocate_symbol(&name);
+                fenv.locals.insert(cvc5_id, VarBinding(sym, id, vs));
+                scope_ids.push(cvc5_id);
+            }
+            fenv.scope_stack.push(scope_ids);
+            let body = translate_term_from_cvc5(&body_ct, fenv)?;
+            let scope_ids = fenv.scope_stack.pop().unwrap();
+            let bindings: Vec<_> = scope_ids
+                .iter()
+                .map(|id| fenv.locals.remove(id).unwrap())
+                .collect();
+            let arena = fenv.env.arena();
+            return if kind == Kind::Forall {
+                Ok(arena.forall(bindings, body))
+            } else {
+                Ok(arena.exists(bindings, body))
+            };
+        }
+        // ── Negation (unary minus) ──────────────────────────────
+        Kind::Neg => {
+            let child = translate_term_from_cvc5(&ct.child(0), fenv)?;
+            let sort = ct.sort().conv_from_cvc5(fenv)?;
+            let arena = fenv.env.arena();
+            let sym = arena.allocate_symbol("-");
+            let qid = QualifiedIdentifier::simple(sym);
+            return Ok(arena.app(qid, vec![child], Some(sort)));
+        }
+
+        // ── Function application (UF, constructors, selectors, testers) ──
+        Kind::Constant => {
+            // Uninterpreted constant (declared symbol)
+            let name = ct.symbol().to_string();
+            let sort = ct.sort().conv_from_cvc5(fenv)?;
+            let arena = fenv.env.arena();
+            let sym = arena.allocate_symbol(&name);
+            let qid = QualifiedIdentifier::simple(sym);
+            return Ok(arena.global(qid, Some(sort)));
+        }
+        Kind::ApplyUf => {
+            let head = ct.child(0);
+            let name = head.symbol().to_string();
+            let mut args = Vec::with_capacity(ct.num_children() - 1);
+            for i in 1..ct.num_children() {
+                args.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
+            }
+            let sort = ct.sort().conv_from_cvc5(fenv)?;
+            let arena = fenv.env.arena();
+            let sym = arena.allocate_symbol(&name);
+            let qid = QualifiedIdentifier::simple(sym);
+            return Ok(arena.app(qid, args, Some(sort)));
+        }
+        Kind::ApplyConstructor => {
+            let head = ct.child(0);
+            let name = head.symbol().to_string();
+            let n = ct.num_children();
+            if n == 1 {
+                // Nullary constructor → global
+                let sort = ct.sort().conv_from_cvc5(fenv)?;
+                let arena = fenv.env.arena();
+                let sym = arena.allocate_symbol(&name);
+                let qid = QualifiedIdentifier::simple(sym);
+                return Ok(arena.global(qid, Some(sort)));
+            }
+            let mut args = Vec::with_capacity(n - 1);
+            for i in 1..n {
+                args.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
+            }
+            let sort = ct.sort().conv_from_cvc5(fenv)?;
+            let arena = fenv.env.arena();
+            let sym = arena.allocate_symbol(&name);
+            let qid = QualifiedIdentifier::simple(sym);
+            return Ok(arena.app(qid, args, Some(sort)));
+        }
+        Kind::ApplySelector => {
+            let head = ct.child(0);
+            let name = head.symbol().to_string();
+            let arg = translate_term_from_cvc5(&ct.child(1), fenv)?;
+            let sort = ct.sort().conv_from_cvc5(fenv)?;
+            let arena = fenv.env.arena();
+            let sym = arena.allocate_symbol(&name);
+            let qid = QualifiedIdentifier::simple(sym);
+            return Ok(arena.app(qid, vec![arg], Some(sort)));
+        }
+        Kind::ApplyTester => {
+            let head = ct.child(0);
+            let ctor_name = head.symbol().to_string();
+            let arg = translate_term_from_cvc5(&ct.child(1), fenv)?;
+            let sort = ct.sort().conv_from_cvc5(fenv)?;
+            let arena = fenv.env.arena();
+            let is_sym = arena.allocate_symbol("is");
+            let ctor_sym = arena.allocate_symbol(&ctor_name);
+            let id = alg::Identifier {
+                symbol: is_sym,
+                indices: vec![Index::Symbol(ctor_sym)],
+            };
+            let qid = QualifiedIdentifier::from(id);
+            return Ok(arena.app(qid, vec![arg], Some(sort)));
+        }
+
+        // ── Variable (bound) ────────────────────────────────────
+        Kind::Variable => {
+            let cvc5_id = ct.id();
+            if let Some(vb) = fenv.locals.get(&cvc5_id) {
+                let arena = fenv.env.arena();
+                return Ok(arena.local(alg::Local {
+                    id: vb.1,
+                    symbol: vb.0.clone(),
+                    sort: vb.2.clone(),
+                }));
+            }
+            // Fallback: unregistered variable (shouldn't happen in well-formed terms)
+            let name = ct.symbol().to_string();
+            let sort = ct.sort().conv_from_cvc5(fenv)?;
+            let arena = fenv.env.arena();
+            let id = arena.new_local();
+            let sym = arena.allocate_symbol(&name);
+            return Ok(arena.local(alg::Local {
+                id,
+                symbol: sym,
+                sort,
+            }));
+        }
+        _ => {}
+    }
+    // ── Known operator kinds ────────────────────────────────
+    if let Some(ik) = cvc5_kind_to_ident_kind(kind) {
+        let children = translate_children(ct, fenv)?;
+        let sort = ct.sort().conv_from_cvc5(fenv)?;
+        let arena = fenv.env.arena();
+        let name = ik.name();
+        let sym = arena.allocate_symbol(name);
+        let qid = QualifiedIdentifier::simple(sym);
+        return Ok(arena.app(qid, children, Some(sort)));
+    }
+
+    // ── Indexed operators ───────────────────────────────────
+    if ct.has_op() {
+        let op = ct.op();
+        if let Some(term) = translate_indexed_from_cvc5(ct, &op, fenv)? {
+            return Ok(term);
+        }
+    }
+
+    Err(format!("unsupported cvc5 term kind: {:?}", kind))
+}
+
+fn translate_children<'tm, 'env, Env: HasArena>(
+    ct: &CTerm<'tm>,
+    fenv: &mut FromCvc5Env<'tm, 'env, Env>,
+) -> Res<Vec<Term>> {
+    let n = ct.num_children();
+    let mut children = Vec::with_capacity(n);
+    for i in 0..n {
+        children.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
+    }
+    Ok(children)
+}
+
+fn translate_indexed_from_cvc5<'tm, 'env, Env: HasArena>(
+    ct: &CTerm<'tm>,
+    op: &cvc5::Op<'tm>,
+    fenv: &mut FromCvc5Env<'tm, 'env, Env>,
+) -> Res<Option<Term>> {
+    let op_kind = op.kind();
+    let children = translate_children(ct, fenv)?;
+    let sort = ct.sort().conv_from_cvc5(fenv)?;
+    let arena = fenv.env.arena();
+
+    let mk_indexed = |arena: &mut Arena, name: &str, indices: Vec<Index<Str>>| -> Term {
+        let sym = arena.allocate_symbol(name);
+        let id = alg::Identifier {
+            symbol: sym,
+            indices,
+        };
+        let qid = QualifiedIdentifier::from(id);
+        arena.app(qid, children.clone(), Some(sort.clone()))
+    };
+
+    let idx_u32 = |i: usize| -> Res<UBig> {
+        let idx_term = op.index(i);
+        let val: u32 = idx_term.uint32_value();
+        Ok(UBig::from(val))
+    };
+
+    let term = match op_kind {
+        Kind::BitvectorExtract => {
+            let hi = idx_u32(0)?;
+            let lo = idx_u32(1)?;
+            mk_indexed(
+                arena,
+                "extract",
+                vec![Index::Numeral(hi), Index::Numeral(lo)],
+            )
+        }
+        Kind::BitvectorRepeat => {
+            let n = idx_u32(0)?;
+            mk_indexed(arena, "repeat", vec![Index::Numeral(n)])
+        }
+        Kind::BitvectorZeroExtend => {
+            let n = idx_u32(0)?;
+            mk_indexed(arena, "zero_extend", vec![Index::Numeral(n)])
+        }
+        Kind::BitvectorSignExtend => {
+            let n = idx_u32(0)?;
+            mk_indexed(arena, "sign_extend", vec![Index::Numeral(n)])
+        }
+        Kind::BitvectorRotateLeft => {
+            let n = idx_u32(0)?;
+            mk_indexed(arena, "rotate_left", vec![Index::Numeral(n)])
+        }
+        Kind::BitvectorRotateRight => {
+            let n = idx_u32(0)?;
+            mk_indexed(arena, "rotate_right", vec![Index::Numeral(n)])
+        }
+        Kind::IntToBitvector => {
+            let n = idx_u32(0)?;
+            mk_indexed(arena, "int2bv", vec![Index::Numeral(n)])
+        }
+        Kind::RegexpRepeat => {
+            let n = idx_u32(0)?;
+            mk_indexed(arena, "re.^", vec![Index::Numeral(n)])
+        }
+        Kind::RegexpLoop => {
+            let lo = idx_u32(0)?;
+            let hi = idx_u32(1)?;
+            mk_indexed(
+                arena,
+                "re.loop",
+                vec![Index::Numeral(lo), Index::Numeral(hi)],
+            )
+        }
+        _ => return Ok(None),
+    };
+    Ok(Some(term))
+}
+
+/// Reverse mapping from cvc5 Kind to yaspar-ir IdentifierKind.
+fn cvc5_kind_to_ident_kind(kind: Kind) -> Option<alg::IdentifierKind<Str>> {
+    use alg::IdentifierKind::*;
+    Some(match kind {
+        Kind::Add => Add,
+        Kind::Sub => Sub,
+        Kind::Mult => Mul,
+        Kind::IntsDivision => Idiv,
+        Kind::Division => Rdiv,
+        Kind::IntsModulus => Mod,
+        Kind::Abs => Abs,
+        Kind::Leq => Le,
+        Kind::Lt => Lt,
+        Kind::Geq => Ge,
+        Kind::Gt => Gt,
+        Kind::ToReal => ToReal,
+        Kind::ToInteger => ToInt,
+        Kind::IsInteger => IsInt,
+        Kind::Select => Select,
+        Kind::Store => Store,
+        Kind::StringConcat => StrConcat,
+        Kind::StringLength => StrLen,
+        Kind::StringLt => StrLt,
+        Kind::StringLeq => StrLe,
+        Kind::StringCharat => StrAt,
+        Kind::StringSubstr => StrSubstr,
+        Kind::StringPrefix => StrPrefixof,
+        Kind::StringSuffix => StrSuffixof,
+        Kind::StringContains => StrContains,
+        Kind::StringIndexof => StrIndexof,
+        Kind::StringReplace => StrReplace,
+        Kind::StringReplaceAll => StrReplaceAll,
+        Kind::StringReplaceRe => StrReplaceRe,
+        Kind::StringReplaceReAll => StrReplaceReAll,
+        Kind::StringToRegexp => StrToRe,
+        Kind::StringInRegexp => StrInRe,
+        Kind::StringIsDigit => StrIsDigit,
+        Kind::StringToCode => StrToCode,
+        Kind::StringFromCode => StrFromCode,
+        Kind::StringToInt => StrToInt,
+        Kind::StringFromInt => StrFromInt,
+        Kind::RegexpNone => ReNone,
+        Kind::RegexpAll => ReAll,
+        Kind::RegexpAllchar => ReAllChar,
+        Kind::RegexpConcat => ReConcat,
+        Kind::RegexpUnion => ReUnion,
+        Kind::RegexpInter => ReInter,
+        Kind::RegexpStar => ReStar,
+        Kind::RegexpComplement => ReComp,
+        Kind::RegexpDiff => ReDiff,
+        Kind::RegexpPlus => ReAdd,
+        Kind::RegexpOpt => ReOpt,
+        Kind::RegexpRange => ReRange,
+        Kind::BitvectorConcat => Concat,
+        Kind::BitvectorNot => BvNot,
+        Kind::BitvectorNeg => BvNeg,
+        Kind::BitvectorAnd => BvAnd,
+        Kind::BitvectorOr => BvOr,
+        Kind::BitvectorAdd => BvAdd,
+        Kind::BitvectorMult => BvMul,
+        Kind::BitvectorUdiv => BvUdiv,
+        Kind::BitvectorUrem => BvUrem,
+        Kind::BitvectorShl => BvShl,
+        Kind::BitvectorLshr => BvLshr,
+        Kind::BitvectorUlt => BvUlt,
+        Kind::BitvectorNand => BvNand,
+        Kind::BitvectorNor => BvNor,
+        Kind::BitvectorXor => BvXor,
+        Kind::BitvectorXnor => BvNxor,
+        Kind::BitvectorComp => BvComp,
+        Kind::BitvectorSub => BvSub,
+        Kind::BitvectorSdiv => BvSdiv,
+        Kind::BitvectorSrem => BvSrem,
+        Kind::BitvectorSmod => BvSmod,
+        Kind::BitvectorAshr => BvAShr,
+        Kind::BitvectorUle => BvUle,
+        Kind::BitvectorUgt => BvUgt,
+        Kind::BitvectorUge => BvUge,
+        Kind::BitvectorSlt => BvSlt,
+        Kind::BitvectorSle => BvSle,
+        Kind::BitvectorSgt => BvSgt,
+        Kind::BitvectorSge => BvSge,
+        Kind::BitvectorNego => BvNego,
+        Kind::BitvectorUaddo => BvUaddo,
+        Kind::BitvectorSaddo => BvSaddo,
+        Kind::BitvectorUmulo => BvUmulo,
+        Kind::BitvectorSmulo => BvSmulo,
+        Kind::BitvectorUbvToInt => UbvToInt,
+        Kind::BitvectorSbvToInt => SbvToInt,
+        Kind::BitvectorUsubo => BvUsubo,
+        Kind::BitvectorSsubo => BvSsubo,
+        Kind::BitvectorSdivo => BvSdivo,
+        _ => return None,
+    })
 }
 
 // ── Identifier kind → cvc5 Kind mapping ─────────────────────
@@ -619,18 +1098,6 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
         }
         Ok(())
     }
-    fn on_let(
-        &mut self,
-        current: &Term,
-        vs: &[VarBinding<Str, Term>],
-        body: &Term,
-        vs_rec: Vec<Self::Binding>,
-        body_rec: WithPattern<'tm>,
-    ) -> Res<WithPattern<'tm>> {
-        self.cleanup_let_scope_on_error(current, vs, body, vs_rec);
-        Ok(body_rec)
-    }
-
     fn cleanup_let_scope_on_error(
         &mut self,
         _current: &Term,
@@ -643,6 +1110,18 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
         }
     }
 
+    fn on_let(
+        &mut self,
+        current: &Term,
+        vs: &[VarBinding<Str, Term>],
+        body: &Term,
+        vs_rec: Vec<Self::Binding>,
+        body_rec: WithPattern<'tm>,
+    ) -> Res<WithPattern<'tm>> {
+        self.cleanup_let_scope_on_error(current, vs, body, vs_rec);
+        Ok(body_rec)
+    }
+
     fn setup_quantifier_scope(
         &mut self,
         _current: &Term,
@@ -651,6 +1130,15 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
         _is_forall: bool,
     ) -> Res<()> {
         self.bind_vars(vs)
+    }
+    fn cleanup_quantifier_scope_on_error(
+        &mut self,
+        _current: &Term,
+        vs: &[VarBinding<Str, Sort>],
+        _t: &Term,
+        _is_forall: bool,
+    ) {
+        let _ = self.unbind_vars(vs, |v| &v.1);
     }
     fn on_exists(
         &mut self,
@@ -662,6 +1150,7 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
         let bound = self.unbind_vars(vs, |v| &v.1)?;
         self.translate_quantifier_body(Kind::Exists, bound, t_rec)
     }
+
     fn on_forall(
         &mut self,
         _current: &Term,
@@ -671,16 +1160,6 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
     ) -> Res<WithPattern<'tm>> {
         let bound = self.unbind_vars(vs, |v| &v.1)?;
         self.translate_quantifier_body(Kind::Forall, bound, t_rec)
-    }
-
-    fn cleanup_quantifier_scope_on_error(
-        &mut self,
-        _current: &Term,
-        vs: &[VarBinding<Str, Sort>],
-        _t: &Term,
-        _is_forall: bool,
-    ) {
-        let _ = self.unbind_vars(vs, |v| &v.1);
     }
 
     fn setup_match_case_scope(
@@ -745,6 +1224,17 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
 
         Ok(())
     }
+    fn cleanup_match_case_scope_on_error(
+        &mut self,
+        _current: &Term,
+        _scrutinee: &Term,
+        cases: &[alg::PatternArm<Str, Term>],
+        _scrutinee_rec: Self::Out,
+        case_idx: usize,
+    ) {
+        let _ = self.unbind_vars(&cases[case_idx].pattern.variables_and_ids(), |v| &v.1);
+    }
+
     fn on_match_arm(
         &mut self,
         _current: &Term,
@@ -790,17 +1280,6 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
                     .mk_term(Kind::MatchBindCase, &[vlist, pattern, arm.into()]))
             }
         }
-    }
-
-    fn cleanup_match_case_scope_on_error(
-        &mut self,
-        _current: &Term,
-        _scrutinee: &Term,
-        cases: &[alg::PatternArm<Str, Term>],
-        _scrutinee_rec: Self::Out,
-        case_idx: usize,
-    ) {
-        let _ = self.unbind_vars(&cases[case_idx].pattern.variables_and_ids(), |v| &v.1);
     }
 
     fn on_match(

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -893,7 +893,11 @@ fn translate_term_from_cvc5<'tm, 'env>(
         }
         // ── Const array ──────────────────────────────────────────
         Kind::ConstArray => {
-            todo!("ConstArray reverse translation")
+            let value = ct.const_array_base().conv_from_cvc5(fenv)?;
+            let arr_sort = ct.sort().conv_from_cvc5(fenv)?;
+            let sym = fenv.env.allocate_symbol(CONST);
+            let qid = QualifiedIdentifier::simple_sorted(sym, arr_sort.clone());
+            return Ok(fenv.env.app(qid, vec![value], Some(arr_sort)));
         }
 
         // ── Uninterpreted sort value (from models) ──────────────

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -512,6 +512,17 @@ fn translate_sort_from_cvc5<'tm>(cs: &CSort<'tm>, arena: &mut Arena) -> Res<Sort
 
 // ── Term: cvc5 → yaspar-ir ───────────────────────────────────
 
+impl<'tm, 'env, T> ConvertFromCvc5<FromCvc5Env<'tm, 'env>> for [T]
+where
+    T: ConvertFromCvc5<FromCvc5Env<'tm, 'env>>,
+{
+    type Output = Vec<T::Output>;
+
+    fn conv_from_cvc5(&self, env: &mut FromCvc5Env<'tm, 'env>) -> Res<Self::Output> {
+        self.iter().map(|s| s.conv_from_cvc5(env)).collect()
+    }
+}
+
 impl<'tm, 'env> ConvertFromCvc5<FromCvc5Env<'tm, 'env>> for CTerm<'tm> {
     type Output = Term;
 

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -53,6 +53,7 @@ use crate::ast::alg::VarBinding;
 use crate::ast::*;
 use crate::raw::alg;
 use crate::raw::alg::CheckIdentifier;
+use crate::statics::*;
 use crate::traits::{Contains, Repr};
 pub use cvc5::{Kind, ProofComponent, Solver, TermManager};
 use dashu::integer::UBig;
@@ -332,7 +333,7 @@ impl<'tm> ConvertToCvc5<Cvc5Env<'tm>> for Sort {
 ///
 /// The type parameter `Env` must implement [`HasArena`], providing the [`Arena`] used
 /// to allocate yaspar-ir objects. This lets callers reuse an existing [`Context`] (or
-/// any other `HasArena` implementor) instead of creating a throwaway arena.
+/// any other `HasArena` implementor) instead of creating a throwaway fenv.env.
 ///
 /// # Example
 ///
@@ -344,20 +345,20 @@ impl<'tm> ConvertToCvc5<Cvc5Env<'tm>> for Sort {
 /// let mut from_env = FromCvc5Env::new(&mut ctx);
 /// // use from_env with ConvertFromCvc5::conv_from_cvc5
 /// ```
-pub struct FromCvc5Env<'tm, 'env, Env> {
+pub struct FromCvc5Env<'tm, 'env> {
     /// Cache from [`CSort`] to yaspar-ir [`Sort`], avoiding redundant work.
     sort_cache: HashMap<CSort<'tm>, Sort>,
     /// Bound variable map: cvc5 term id → VarBinding.
     locals: HashMap<u64, VarBinding<Str, Sort>>,
     /// Stack of bound variable ids for scope cleanup.
     scope_stack: Vec<Vec<u64>>,
-    /// The backing environment that provides the [`Arena`].
-    pub env: &'env mut Env,
+    /// The backing context.
+    pub env: &'env mut Context,
 }
 
-impl<'tm, 'env, Env: HasArena> FromCvc5Env<'tm, 'env, Env> {
+impl<'tm, 'env> FromCvc5Env<'tm, 'env> {
     /// Create a new reverse-translation environment backed by `env`.
-    pub fn new(env: &'env mut Env) -> Self {
+    pub fn new(env: &'env mut Context) -> Self {
         Self {
             sort_cache: HashMap::new(),
             locals: HashMap::new(),
@@ -367,10 +368,10 @@ impl<'tm, 'env, Env: HasArena> FromCvc5Env<'tm, 'env, Env> {
     }
 }
 
-impl<'tm, 'env, Env: HasArena> ConvertFromCvc5<FromCvc5Env<'tm, 'env, Env>> for CSort<'tm> {
+impl<'tm, 'env> ConvertFromCvc5<FromCvc5Env<'tm, 'env>> for CSort<'tm> {
     type Output = Sort;
 
-    fn conv_from_cvc5(&self, fenv: &mut FromCvc5Env<'tm, 'env, Env>) -> Res<Sort> {
+    fn conv_from_cvc5(&self, fenv: &mut FromCvc5Env<'tm, 'env>) -> Res<Sort> {
         if let Some(s) = fenv.sort_cache.get(self) {
             return Ok(s.clone());
         }
@@ -444,25 +445,26 @@ fn translate_sort_from_cvc5<'tm>(cs: &CSort<'tm>, arena: &mut Arena) -> Res<Sort
 
 // ── Term: cvc5 → yaspar-ir ───────────────────────────────────
 
-impl<'tm, 'env, Env: HasArena> ConvertFromCvc5<FromCvc5Env<'tm, 'env, Env>> for CTerm<'tm> {
+impl<'tm, 'env> ConvertFromCvc5<FromCvc5Env<'tm, 'env>> for CTerm<'tm> {
     type Output = Term;
 
-    fn conv_from_cvc5(&self, fenv: &mut FromCvc5Env<'tm, 'env, Env>) -> Res<Term> {
+    fn conv_from_cvc5(&self, fenv: &mut FromCvc5Env<'tm, 'env>) -> Res<Term> {
         translate_term_from_cvc5(self, fenv)
     }
 }
 
-fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
+fn translate_term_from_cvc5<'tm, 'env>(
     ct: &CTerm<'tm>,
-    fenv: &mut FromCvc5Env<'tm, 'env, Env>,
+    fenv: &mut FromCvc5Env<'tm, 'env>,
 ) -> Res<Term> {
-    let arena = fenv.env.arena();
     let kind = ct.kind();
 
     // ── Constants ────────────────────────────────────────────
     if ct.is_boolean_value() {
-        let sort = Some(arena.bool_sort());
-        return Ok(arena.allocate_term(ATerm::Constant(Constant::Bool(ct.boolean_value()), sort)));
+        let sort = Some(fenv.env.bool_sort());
+        return Ok(fenv
+            .env
+            .allocate_term(ATerm::Constant(Constant::Bool(ct.boolean_value()), sort)));
     }
     if ct.is_integer_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
@@ -470,21 +472,48 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
             .integer_value()
             .parse()
             .map_err(|e| format!("Big integer parse error: {e}"))?;
-        let arena = fenv.env.arena();
-        return Ok(arena.allocate_term(ATerm::Constant(Constant::Numeral(n), Some(sort))));
+        return Ok(fenv
+            .env
+            .allocate_term(ATerm::Constant(Constant::Numeral(n), Some(sort))));
     }
     if ct.is_real_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
         let s = ct.real_value();
-        let arena = fenv.env.arena();
+        let has_ints = fenv.env.get_theories().iter().any(|t| t.has_int());
         // cvc5 returns rationals as "num/den" or just "num"
-        if let Some((num, den)) = s.split_once('/') {
-            let n: dashu::float::DBig =
-                format!("{num}/{den}").parse().map_err(|e| format!("{e}"))?;
-            return Ok(arena.allocate_term(ATerm::Constant(Constant::Decimal(n), Some(sort))));
+        if let Some((num_s, den_s)) = s.split_once('/') {
+            let (numer, denom) = if has_ints {
+                // In RealInts, numerals are Int; use Decimal constants for Real division
+                let n = Constant::Decimal(format!("{num_s}.0").parse().unwrap());
+                let d = Constant::Decimal(format!("{den_s}.0").parse().unwrap());
+                let numer = fenv
+                    .env
+                    .allocate_term(ATerm::Constant(n, Some(sort.clone())));
+                let denom = fenv
+                    .env
+                    .allocate_term(ATerm::Constant(d, Some(sort.clone())));
+                (numer, denom)
+            } else {
+                let num: UBig = num_s.parse().map_err(|e| format!("{e}"))?;
+                let den: UBig = den_s.parse().map_err(|e| format!("{e}"))?;
+                let int = fenv.env.int_sort();
+                let numer = fenv
+                    .env
+                    .allocate_term(ATerm::Constant(Constant::Numeral(num), Some(int.clone())));
+                let denom = fenv
+                    .env
+                    .allocate_term(ATerm::Constant(Constant::Numeral(den), Some(int)));
+                (numer, denom)
+            };
+            let sym = fenv.env.allocate_symbol(RDIV);
+            let qid = QualifiedIdentifier::simple(sym);
+            return Ok(fenv.env.app(qid, vec![numer, denom], Some(sort)));
         }
-        let n: dashu::float::DBig = format!("{s}/1").parse().map_err(|e| format!("{e}"))?;
-        return Ok(arena.allocate_term(ATerm::Constant(Constant::Decimal(n), Some(sort))));
+        // No division — parse as a single decimal
+        let n: dashu::float::DBig = format!("{s}.0").parse().map_err(|e| format!("{e}"))?;
+        return Ok(fenv
+            .env
+            .allocate_term(ATerm::Constant(Constant::Decimal(n), Some(sort))));
     }
     if ct.is_string_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
@@ -493,39 +522,39 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
             .iter()
             .map(|&c| char::from_u32(c).unwrap_or('\u{FFFD}'))
             .collect();
-        let arena = fenv.env.arena();
-        let str_val = arena.allocate_str(&s);
-        return Ok(arena.allocate_term(ATerm::Constant(Constant::String(str_val), Some(sort))));
+        
+        let str_val = fenv.env.allocate_str(&s);
+        return Ok(fenv.env.allocate_term(ATerm::Constant(Constant::String(str_val), Some(sort))));
     }
     if ct.is_bv_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
         let bits = ct.bv_value(2);
         let (bytes, len) = parse_binary_str_to_bytes(&bits);
-        let arena = fenv.env.arena();
-        return Ok(arena.allocate_term(ATerm::Constant(Constant::Binary(bytes, len), Some(sort))));
+        
+        return Ok(fenv.env.allocate_term(ATerm::Constant(Constant::Binary(bytes, len), Some(sort))));
     }
 
     // ── Logical connectives ─────────────────────────────────
     match kind {
         Kind::And => {
             let children = translate_children(ct, fenv)?;
-            let arena = fenv.env.arena();
-            return Ok(arena.and(children));
+            
+            return Ok(fenv.env.and(children));
         }
         Kind::Or => {
             let children = translate_children(ct, fenv)?;
-            let arena = fenv.env.arena();
-            return Ok(arena.or(children));
+            
+            return Ok(fenv.env.or(children));
         }
         Kind::Xor => {
             let children = translate_children(ct, fenv)?;
-            let arena = fenv.env.arena();
-            return Ok(arena.xor(children));
+            
+            return Ok(fenv.env.xor(children));
         }
         Kind::Not => {
             let child = translate_term_from_cvc5(&ct.child(0), fenv)?;
-            let arena = fenv.env.arena();
-            return Ok(arena.not(child));
+            
+            return Ok(fenv.env.not(child));
         }
         Kind::Implies => {
             let n = ct.num_children();
@@ -534,33 +563,33 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
                 premises.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
             }
             let concl = translate_term_from_cvc5(&ct.child(n - 1), fenv)?;
-            let arena = fenv.env.arena();
-            return Ok(arena.implies(premises, concl));
+            
+            return Ok(fenv.env.implies(premises, concl));
         }
         Kind::Equal => {
             let children = translate_children(ct, fenv)?;
-            let arena = fenv.env.arena();
+            
             if children.len() == 2 {
-                return Ok(arena.eq(children[0].clone(), children[1].clone()));
+                return Ok(fenv.env.eq(children[0].clone(), children[1].clone()));
             }
             // Chain: (= a b c) → (and (= a b) (= b c))
             let mut eqs = Vec::with_capacity(children.len() - 1);
             for i in 0..children.len() - 1 {
-                eqs.push(arena.eq(children[i].clone(), children[i + 1].clone()));
+                eqs.push(fenv.env.eq(children[i].clone(), children[i + 1].clone()));
             }
-            return Ok(arena.and(eqs));
+            return Ok(fenv.env.and(eqs));
         }
         Kind::Distinct => {
             let children = translate_children(ct, fenv)?;
-            let arena = fenv.env.arena();
-            return Ok(arena.distinct(children));
+            
+            return Ok(fenv.env.distinct(children));
         }
         Kind::Ite => {
             let b = translate_term_from_cvc5(&ct.child(0), fenv)?;
             let t = translate_term_from_cvc5(&ct.child(1), fenv)?;
             let e = translate_term_from_cvc5(&ct.child(2), fenv)?;
-            let arena = fenv.env.arena();
-            return Ok(arena.ite(b, t, e));
+            
+            return Ok(fenv.env.ite(b, t, e));
         }
         // ── Quantifiers ─────────────────────────────────────────
         Kind::Forall | Kind::Exists => {
@@ -572,34 +601,57 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
                 let cvc5_id = v.id();
                 let name = v.symbol().to_string();
                 let vs = v.sort().conv_from_cvc5(fenv)?;
-                let arena = fenv.env.arena();
-                let id = arena.new_local();
-                let sym = arena.allocate_symbol(&name);
+                
+                let id = fenv.env.new_local();
+                let sym = fenv.env.allocate_symbol(&name);
                 fenv.locals.insert(cvc5_id, VarBinding(sym, id, vs));
                 scope_ids.push(cvc5_id);
             }
             fenv.scope_stack.push(scope_ids);
             let body = translate_term_from_cvc5(&body_ct, fenv)?;
+            // Translate :pattern annotations if present (child 2 is INST_PATTERN_LIST)
+            let body = if ct.num_children() > 2 {
+                let plist = ct.child(2);
+                let mut attrs = Vec::new();
+                for i in 0..plist.num_children() {
+                    let pat = plist.child(i);
+                    if pat.kind() == Kind::InstPattern {
+                        let mut pat_terms = Vec::new();
+                        for j in 0..pat.num_children() {
+                            pat_terms.push(translate_term_from_cvc5(&pat.child(j), fenv)?);
+                        }
+                        attrs.push(alg::Attribute::Pattern(pat_terms));
+                    }
+                }
+                if attrs.is_empty() {
+                    body
+                } else {
+                    
+                    fenv.env.annotated(body, attrs)
+                }
+            } else {
+                body
+            };
             let scope_ids = fenv.scope_stack.pop().unwrap();
             let bindings: Vec<_> = scope_ids
                 .iter()
                 .map(|id| fenv.locals.remove(id).unwrap())
                 .collect();
-            let arena = fenv.env.arena();
+            
             return if kind == Kind::Forall {
-                Ok(arena.forall(bindings, body))
+                Ok(fenv.env.forall(bindings, body))
             } else {
-                Ok(arena.exists(bindings, body))
+                Ok(fenv.env.exists(bindings, body))
             };
         }
         // ── Negation (unary minus) ──────────────────────────────
         Kind::Neg => {
             let child = translate_term_from_cvc5(&ct.child(0), fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            let arena = fenv.env.arena();
-            let sym = arena.allocate_symbol("-");
+            
+            let sym = fenv.env.allocate_symbol(SUB);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(arena.app(qid, vec![child], Some(sort)));
+            return Ok(fenv.env.app(qid, vec![child], Some(sort)));
         }
 
         // ── Function application (UF, constructors, selectors, testers) ──
@@ -607,10 +659,10 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
             // Uninterpreted constant (declared symbol)
             let name = ct.symbol().to_string();
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            let arena = fenv.env.arena();
-            let sym = arena.allocate_symbol(&name);
+            
+            let sym = fenv.env.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(arena.global(qid, Some(sort)));
+            return Ok(fenv.env.global(qid, Some(sort)));
         }
         Kind::ApplyUf => {
             let head = ct.child(0);
@@ -620,10 +672,10 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
                 args.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
             }
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            let arena = fenv.env.arena();
-            let sym = arena.allocate_symbol(&name);
+            
+            let sym = fenv.env.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(arena.app(qid, args, Some(sort)));
+            return Ok(fenv.env.app(qid, args, Some(sort)));
         }
         Kind::ApplyConstructor => {
             let head = ct.child(0);
@@ -632,53 +684,55 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
             if n == 1 {
                 // Nullary constructor → global
                 let sort = ct.sort().conv_from_cvc5(fenv)?;
-                let arena = fenv.env.arena();
-                let sym = arena.allocate_symbol(&name);
+                
+                let sym = fenv.env.allocate_symbol(&name);
                 let qid = QualifiedIdentifier::simple(sym);
-                return Ok(arena.global(qid, Some(sort)));
+                return Ok(fenv.env.global(qid, Some(sort)));
             }
             let mut args = Vec::with_capacity(n - 1);
             for i in 1..n {
                 args.push(translate_term_from_cvc5(&ct.child(i), fenv)?);
             }
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            let arena = fenv.env.arena();
-            let sym = arena.allocate_symbol(&name);
+            
+            let sym = fenv.env.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(arena.app(qid, args, Some(sort)));
+            return Ok(fenv.env.app(qid, args, Some(sort)));
         }
         Kind::ApplySelector => {
             let head = ct.child(0);
             let name = head.symbol().to_string();
             let arg = translate_term_from_cvc5(&ct.child(1), fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            let arena = fenv.env.arena();
-            let sym = arena.allocate_symbol(&name);
+            
+            let sym = fenv.env.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(arena.app(qid, vec![arg], Some(sort)));
+            return Ok(fenv.env.app(qid, vec![arg], Some(sort)));
         }
         Kind::ApplyTester => {
             let head = ct.child(0);
-            let ctor_name = head.symbol().to_string();
+            let tester_name = head.symbol().to_string();
+            // cvc5 tester names are "is_<ctor>"; extract the constructor name
+            let ctor_name = tester_name.strip_prefix("is_").unwrap_or(&tester_name);
             let arg = translate_term_from_cvc5(&ct.child(1), fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            let arena = fenv.env.arena();
-            let is_sym = arena.allocate_symbol("is");
-            let ctor_sym = arena.allocate_symbol(&ctor_name);
+            
+            let is_sym = fenv.env.allocate_symbol(IS);
+            let ctor_sym = fenv.env.allocate_symbol(ctor_name);
             let id = alg::Identifier {
                 symbol: is_sym,
                 indices: vec![Index::Symbol(ctor_sym)],
             };
             let qid = QualifiedIdentifier::from(id);
-            return Ok(arena.app(qid, vec![arg], Some(sort)));
+            return Ok(fenv.env.app(qid, vec![arg], Some(sort)));
         }
 
         // ── Variable (bound) ────────────────────────────────────
         Kind::Variable => {
             let cvc5_id = ct.id();
             if let Some(vb) = fenv.locals.get(&cvc5_id) {
-                let arena = fenv.env.arena();
-                return Ok(arena.local(alg::Local {
+                
+                return Ok(fenv.env.local(alg::Local {
                     id: vb.1,
                     symbol: vb.0.clone(),
                     sort: vb.2.clone(),
@@ -687,10 +741,10 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
             // Fallback: unregistered variable (shouldn't happen in well-formed terms)
             let name = ct.symbol().to_string();
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            let arena = fenv.env.arena();
-            let id = arena.new_local();
-            let sym = arena.allocate_symbol(&name);
-            return Ok(arena.local(alg::Local {
+            
+            let id = fenv.env.new_local();
+            let sym = fenv.env.allocate_symbol(&name);
+            return Ok(fenv.env.local(alg::Local {
                 id,
                 symbol: sym,
                 sort,
@@ -700,20 +754,20 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
         Kind::RegexpNone | Kind::RegexpAll | Kind::RegexpAllchar => {
             let ik = cvc5_kind_to_ident_kind(kind).unwrap();
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            let arena = fenv.env.arena();
-            let sym = arena.allocate_symbol(ik.name());
+            
+            let sym = fenv.env.allocate_symbol(ik.name());
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(arena.global(qid, Some(sort)));
+            return Ok(fenv.env.global(qid, Some(sort)));
         }
 
         // ── BitvectorToNat ──────────────────────────────────────
         Kind::BitvectorToNat => {
             let child = translate_term_from_cvc5(&ct.child(0), fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            let arena = fenv.env.arena();
-            let sym = arena.allocate_symbol("bv2nat");
+            
+            let sym = fenv.env.allocate_symbol(BV2NAT);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(arena.app(qid, vec![child], Some(sort)));
+            return Ok(fenv.env.app(qid, vec![child], Some(sort)));
         }
 
         // ── Match expressions ───────────────────────────────────
@@ -726,9 +780,10 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
                 let arm = translate_match_case_from_cvc5(&case, fenv)?;
                 arms.push(arm);
             }
-            let arena = fenv.env.arena();
-            return Ok(arena.matching(scrutinee, arms));
+            
+            return Ok(fenv.env.matching(scrutinee, arms));
         }
+        // todo: Const and UninterpretedSortValue
         _ => {}
     }
 
@@ -736,11 +791,11 @@ fn translate_term_from_cvc5<'tm, 'env, Env: HasArena>(
     if let Some(ik) = cvc5_kind_to_ident_kind(kind) {
         let children = translate_children(ct, fenv)?;
         let sort = ct.sort().conv_from_cvc5(fenv)?;
-        let arena = fenv.env.arena();
+        
         let name = ik.name();
-        let sym = arena.allocate_symbol(name);
+        let sym = fenv.env.allocate_symbol(name);
         let qid = QualifiedIdentifier::simple(sym);
-        return Ok(arena.app(qid, children, Some(sort)));
+        return Ok(fenv.env.app(qid, children, Some(sort)));
     }
 
     // ── Indexed operators ───────────────────────────────────
@@ -777,9 +832,9 @@ fn parse_binary_str_to_bytes(s: &str) -> (Vec<u8>, usize) {
     (ret, s.len())
 }
 
-fn translate_children<'tm, 'env, Env: HasArena>(
+fn translate_children<'tm, 'env>(
     ct: &CTerm<'tm>,
-    fenv: &mut FromCvc5Env<'tm, 'env, Env>,
+    fenv: &mut FromCvc5Env<'tm, 'env>,
 ) -> Res<Vec<Term>> {
     let n = ct.num_children();
     let mut children = Vec::with_capacity(n);
@@ -789,9 +844,9 @@ fn translate_children<'tm, 'env, Env: HasArena>(
     Ok(children)
 }
 
-fn translate_match_case_from_cvc5<'tm, 'env, Env: HasArena>(
+fn translate_match_case_from_cvc5<'tm, 'env>(
     case: &CTerm<'tm>,
-    fenv: &mut FromCvc5Env<'tm, 'env, Env>,
+    fenv: &mut FromCvc5Env<'tm, 'env>,
 ) -> Res<alg::PatternArm<Str, Term>> {
     let case_kind = case.kind();
     match case_kind {
@@ -802,8 +857,8 @@ fn translate_match_case_from_cvc5<'tm, 'env, Env: HasArena>(
             let ctor_term = pattern_ct.child(0);
             let ctor_name = ctor_term.symbol().to_string();
             let body = translate_term_from_cvc5(&case.child(1), fenv)?;
-            let arena = fenv.env.arena();
-            let sym = arena.allocate_symbol(&ctor_name);
+            
+            let sym = fenv.env.allocate_symbol(&ctor_name);
             Ok(alg::PatternArm {
                 pattern: alg::Pattern::Ctor(sym),
                 body,
@@ -823,9 +878,9 @@ fn translate_match_case_from_cvc5<'tm, 'env, Env: HasArena>(
                 let cvc5_id = v.id();
                 let name = v.symbol().to_string();
                 let vs = v.sort().conv_from_cvc5(fenv)?;
-                let arena = fenv.env.arena();
-                let id = arena.new_local();
-                let sym = arena.allocate_symbol(&name);
+                
+                let id = fenv.env.new_local();
+                let sym = fenv.env.allocate_symbol(&name);
                 let vb = VarBinding(sym.clone(), id, vs);
                 fenv.locals.insert(cvc5_id, vb);
                 fenv.scope_stack.push(vec![cvc5_id]);
@@ -857,9 +912,9 @@ fn translate_match_case_from_cvc5<'tm, 'env, Env: HasArena>(
                     let cvc5_id = v.id();
                     let name = v.symbol().to_string();
                     let vs = v.sort().conv_from_cvc5(fenv)?;
-                    let arena = fenv.env.arena();
-                    let id = arena.new_local();
-                    let sym = arena.allocate_symbol(&name);
+                    
+                    let id = fenv.env.new_local();
+                    let sym = fenv.env.allocate_symbol(&name);
                     fenv.locals.insert(cvc5_id, VarBinding(sym, id, vs));
                     scope_ids.push(cvc5_id);
                     vlist_vars.insert(cvc5_id, i);
@@ -888,8 +943,8 @@ fn translate_match_case_from_cvc5<'tm, 'env, Env: HasArena>(
                     fenv.locals.remove(sid);
                 }
 
-                let arena = fenv.env.arena();
-                let ctor_sym = arena.allocate_symbol(&ctor_name);
+                
+                let ctor_sym = fenv.env.allocate_symbol(&ctor_name);
                 Ok(alg::PatternArm {
                     pattern: alg::Pattern::Applied {
                         ctor: ctor_sym,
@@ -903,82 +958,41 @@ fn translate_match_case_from_cvc5<'tm, 'env, Env: HasArena>(
     }
 }
 
-fn translate_indexed_from_cvc5<'tm, 'env, Env: HasArena>(
+fn translate_indexed_from_cvc5<'tm, 'env>(
     ct: &CTerm<'tm>,
     op: &cvc5::Op<'tm>,
-    fenv: &mut FromCvc5Env<'tm, 'env, Env>,
+    fenv: &mut FromCvc5Env<'tm, 'env>,
 ) -> Res<Option<Term>> {
     let op_kind = op.kind();
     let children = translate_children(ct, fenv)?;
     let sort = ct.sort().conv_from_cvc5(fenv)?;
-    let arena = fenv.env.arena();
-
-    let mk_indexed = |arena: &mut Arena, name: &str, indices: Vec<Index>| -> Term {
-        let sym = arena.allocate_symbol(name);
-        let id = alg::Identifier {
-            symbol: sym,
-            indices,
-        };
-        let qid = QualifiedIdentifier::from(id);
-        arena.app(qid, children.clone(), Some(sort.clone()))
-    };
 
     let idx_u32 = |i: usize| -> Res<UBig> {
         let idx_term = op.index(i);
-        let val: u32 = idx_term.uint32_value();
-        Ok(UBig::from(val))
+        Ok(UBig::from(idx_term.uint32_value()))
     };
 
-    let term = match op_kind {
+    let (name, indices) = match op_kind {
         Kind::BitvectorExtract => {
-            let hi = idx_u32(0)?;
-            let lo = idx_u32(1)?;
-            mk_indexed(
-                arena,
-                "extract",
-                vec![Index::Numeral(hi), Index::Numeral(lo)],
-            )
+            (BV_EXTRACT, vec![Index::Numeral(idx_u32(0)?), Index::Numeral(idx_u32(1)?)])
         }
-        Kind::BitvectorRepeat => {
-            let n = idx_u32(0)?;
-            mk_indexed(arena, "repeat", vec![Index::Numeral(n)])
-        }
-        Kind::BitvectorZeroExtend => {
-            let n = idx_u32(0)?;
-            mk_indexed(arena, "zero_extend", vec![Index::Numeral(n)])
-        }
-        Kind::BitvectorSignExtend => {
-            let n = idx_u32(0)?;
-            mk_indexed(arena, "sign_extend", vec![Index::Numeral(n)])
-        }
-        Kind::BitvectorRotateLeft => {
-            let n = idx_u32(0)?;
-            mk_indexed(arena, "rotate_left", vec![Index::Numeral(n)])
-        }
-        Kind::BitvectorRotateRight => {
-            let n = idx_u32(0)?;
-            mk_indexed(arena, "rotate_right", vec![Index::Numeral(n)])
-        }
-        Kind::IntToBitvector => {
-            let n = idx_u32(0)?;
-            mk_indexed(arena, "int2bv", vec![Index::Numeral(n)])
-        }
-        Kind::RegexpRepeat => {
-            let n = idx_u32(0)?;
-            mk_indexed(arena, "re.^", vec![Index::Numeral(n)])
-        }
+        Kind::BitvectorRepeat => (BV_REPEAT, vec![Index::Numeral(idx_u32(0)?)]),
+        Kind::BitvectorZeroExtend => (BV_ZERO_EXTEND, vec![Index::Numeral(idx_u32(0)?)]),
+        Kind::BitvectorSignExtend => (BV_SIGN_EXTEND, vec![Index::Numeral(idx_u32(0)?)]),
+        Kind::BitvectorRotateLeft => (BV_ROTATE_LEFT, vec![Index::Numeral(idx_u32(0)?)]),
+        Kind::BitvectorRotateRight => (BV_ROTATE_RIGHT, vec![Index::Numeral(idx_u32(0)?)]),
+        Kind::IntToBitvector => (INT2BV, vec![Index::Numeral(idx_u32(0)?)]),
+        Kind::RegexpRepeat => (RE_POWER, vec![Index::Numeral(idx_u32(0)?)]),
         Kind::RegexpLoop => {
-            let lo = idx_u32(0)?;
-            let hi = idx_u32(1)?;
-            mk_indexed(
-                arena,
-                "re.loop",
-                vec![Index::Numeral(lo), Index::Numeral(hi)],
-            )
+            (RE_LOOP, vec![Index::Numeral(idx_u32(0)?), Index::Numeral(idx_u32(1)?)])
         }
         _ => return Ok(None),
     };
-    Ok(Some(term))
+
+    let sym = fenv.env.allocate_symbol(name);
+    let id = alg::Identifier { symbol: sym, indices };
+    let qid = QualifiedIdentifier::from(id);
+    Ok(Some(fenv.env.app(qid, children, Some(sort))))
 }
 
 /// Reverse mapping from cvc5 Kind to yaspar-ir IdentifierKind.

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -1106,6 +1106,7 @@ fn const_array_negative() {
     let mut solver = Solver::new(&tm);
     let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+
     for cmd in &cmds {
         cmd.to_cvc5(&mut es).unwrap();
     }
@@ -1115,4 +1116,143 @@ fn const_array_negative() {
         .type_check(&mut ctx)
         .unwrap();
     assert!(term.to_cvc5(&mut env).is_err());
+}
+/// Helper: translate a yaspar-ir Term to cvc5 and back, asserting the round-trip
+/// produces the same string representation.
+fn term_round_trip(script: &str, term_str: &str) {
+    let mut ctx = Context::new();
+    let _cmds = UntypedAst
+        .parse_script_str(script)
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &_cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
+    let term = UntypedAst
+        .parse_term_str(term_str)
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let cterm = term.to_cvc5(&mut *es.env).unwrap();
+    let mut from_env = FromCvc5Env::new(&mut ctx);
+    let back = cterm.conv_from_cvc5(&mut from_env).unwrap();
+    assert_eq!(term.to_string(), back.to_string());
+}
+
+#[test]
+fn from_cvc5_term_bool_true() {
+    term_round_trip("(set-logic QF_UF)", "true");
+}
+
+#[test]
+fn from_cvc5_term_bool_false() {
+    term_round_trip("(set-logic QF_UF)", "false");
+}
+
+#[test]
+fn from_cvc5_term_integer() {
+    term_round_trip("(set-logic QF_LIA) (declare-const x Int)", "x");
+}
+
+#[test]
+fn from_cvc5_term_and() {
+    term_round_trip(
+        "(set-logic QF_UF) (declare-const a Bool) (declare-const b Bool)",
+        "(and a b)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_or() {
+    term_round_trip(
+        "(set-logic QF_UF) (declare-const a Bool) (declare-const b Bool)",
+        "(or a b)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_not() {
+    term_round_trip("(set-logic QF_UF) (declare-const a Bool)", "(not a)");
+}
+
+#[test]
+fn from_cvc5_term_implies() {
+    term_round_trip(
+        "(set-logic QF_UF) (declare-const a Bool) (declare-const b Bool)",
+        "(=> a b)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_eq() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int)",
+        "(= x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_ite() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const a Bool) (declare-const x Int) (declare-const y Int)",
+        "(ite a x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_add() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int)",
+        "(+ x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_gt() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int)",
+        "(> x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv_add() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8)) (declare-const y (_ BitVec 8))",
+        "(bvadd x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_numeral() {
+    term_round_trip("(set-logic QF_LIA) (declare-const x Int)", "(+ x 42)");
+}
+
+#[test]
+fn from_cvc5_term_bv_literal() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8))",
+        "(bvadd x #b00101010)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_forall() {
+    term_round_trip(
+        "(set-logic LIA) (declare-const y Int)",
+        "(forall ((x Int)) (> x y))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_exists() {
+    term_round_trip(
+        "(set-logic LIA) (declare-const y Int)",
+        "(exists ((x Int)) (= x y))",
+    );
 }

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -1256,3 +1256,53 @@ fn from_cvc5_term_exists() {
         "(exists ((x Int)) (= x y))",
     );
 }
+
+#[test]
+fn from_cvc5_term_regexp_none() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.in_re s re.none)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_regexp_all() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.in_re s re.all)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_regexp_allchar() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.in_re s re.allchar)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv2nat() {
+    // cvc5 normalizes BitvectorToNat to BitvectorUbvToInt internally,
+    // so we test the ubv_to_int round-trip which exercises the same path.
+    term_round_trip(
+        "(set-logic ALL) (declare-const x (_ BitVec 8))",
+        "(ubv_to_int x)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_match() {
+    term_round_trip(
+        "(set-logic ALL) (declare-datatypes ((Color 0)) (((Red) (Green) (Blue)))) (declare-const c Color)",
+        "(match c ((Red 1) (Green 2) (Blue 3)))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_match_applied() {
+    term_round_trip(
+        "(set-logic ALL) (declare-datatypes ((Pair 0)) (((mkpair (fst Int) (snd Int))))) (declare-const p Pair)",
+        "(match p (((mkpair x y) (+ x y))))",
+    );
+}

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -3,9 +3,9 @@
 
 #![cfg(feature = "cvc5")]
 
-use cvc5::{Solver, TermManager};
+use cvc5::{Kind, Solver, TermManager};
 use yaspar_ir::ast::{Context, ObjectAllocatorExt, Typecheck};
-use yaspar_ir::cvc5::{ConvertToCvc5, Cvc5Env, Cvc5EnvSolver};
+use yaspar_ir::cvc5::{ConvertFromCvc5, ConvertToCvc5, Cvc5Env, Cvc5EnvSolver, FromCvc5Env};
 use yaspar_ir::untyped::UntypedAst;
 
 /// Helper: parse + type-check a script, then translate all commands to cvc5.
@@ -959,7 +959,6 @@ fn command_result_get_model_uninterpreted_sort_nested() {
 
 // ── ConvertFromCvc5 sort round-trip tests ────────────────────
 
-use yaspar_ir::cvc5::{ConvertFromCvc5, FromCvc5Env};
 
 /// Helper: translate a yaspar-ir Sort to cvc5 and back, asserting the round-trip
 /// produces the same string representation.
@@ -1304,5 +1303,378 @@ fn from_cvc5_term_match_applied() {
     term_round_trip(
         "(set-logic ALL) (declare-datatypes ((Pair 0)) (((mkpair (fst Int) (snd Int))))) (declare-const p Pair)",
         "(match p (((mkpair x y) (+ x y))))",
+    );
+}
+
+
+// ── Comprehensive backward translation tests ─────────────────
+
+#[test]
+fn from_cvc5_term_forall_pattern() {
+    term_round_trip(
+        "(set-logic ALL) (declare-fun f (Int) Int)",
+        "(forall ((x Int)) (! (> (f x) 0) :pattern ((f x))))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_forall_multi_pattern() {
+    term_round_trip(
+        "(set-logic ALL) (declare-fun f (Int) Int) (declare-fun g (Int) Int)",
+        "(forall ((x Int)) (! (> (f x) (g x)) :pattern ((f x)) :pattern ((g x))))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_forall_multi_var() {
+    term_round_trip(
+        "(set-logic ALL) (declare-fun f (Int Int) Int)",
+        "(forall ((x Int) (y Int)) (> (f x y) 0))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_nested_quantifier() {
+    term_round_trip(
+        "(set-logic ALL) (declare-const a Int)",
+        "(forall ((x Int)) (exists ((y Int)) (= (+ x y) a)))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_xor() {
+    term_round_trip(
+        "(set-logic QF_UF) (declare-const a Bool) (declare-const b Bool)",
+        "(xor a b)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_distinct() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int) (declare-const z Int)",
+        "(distinct x y z)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_chained_eq() {
+    // (= x y z) in cvc5 is n-ary; reverse translates to (and (= x y) (= y z))
+    let mut ctx = Context::new();
+    let _cmds = UntypedAst
+        .parse_script_str("(set-logic QF_LIA) (declare-const x Int) (declare-const y Int) (declare-const z Int)")
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &_cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
+    // Build (= x y z) by translating individual terms and combining
+    let x = UntypedAst.parse_term_str("x").unwrap().type_check(&mut ctx).unwrap();
+    let y = UntypedAst.parse_term_str("y").unwrap().type_check(&mut ctx).unwrap();
+    let z = UntypedAst.parse_term_str("z").unwrap().type_check(&mut ctx).unwrap();
+    let cx = x.to_cvc5(&mut *es.env).unwrap();
+    let cy = y.to_cvc5(&mut *es.env).unwrap();
+    let cz = z.to_cvc5(&mut *es.env).unwrap();
+    let eq_xyz = tm.mk_term(Kind::Equal, &[cx, cy, cz]);
+    let mut from_env = FromCvc5Env::new(&mut ctx);
+    let back = eq_xyz.conv_from_cvc5(&mut from_env).unwrap();
+    assert_eq!(back.to_string(), "(and (= x y) (= y z))");
+}
+
+#[test]
+fn from_cvc5_term_unary_minus() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int)",
+        "(- x)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_sub() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int)",
+        "(- x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_mul() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int)",
+        "(* x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_div() {
+    term_round_trip(
+        "(set-logic QF_LRA) (declare-const x Real) (declare-const y Real)",
+        "(/ x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_idiv() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int)",
+        "(div x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_mod() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int)",
+        "(mod x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_le() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int)",
+        "(<= x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_lt() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int)",
+        "(< x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_ge() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int)",
+        "(>= x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_select_store() {
+    term_round_trip(
+        "(set-logic QF_AUFLIA) (declare-const a (Array Int Int)) (declare-const i Int) (declare-const v Int)",
+        "(select (store a i v) i)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv_extract() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8))",
+        "((_ extract 3 0) x)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv_zero_extend() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8))",
+        "((_ zero_extend 8) x)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv_sign_extend() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8))",
+        "((_ sign_extend 8) x)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv_concat() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 4)) (declare-const y (_ BitVec 4))",
+        "(concat x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv_not() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8))",
+        "(bvnot x)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv_neg() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8))",
+        "(bvneg x)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv_and() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8)) (declare-const y (_ BitVec 8))",
+        "(bvand x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv_or() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8)) (declare-const y (_ BitVec 8))",
+        "(bvor x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv_ult() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8)) (declare-const y (_ BitVec 8))",
+        "(bvult x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_string_concat() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s1 String) (declare-const s2 String)",
+        "(str.++ s1 s2)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_string_len() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.len s)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_string_literal() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.++ s \"hello\")",
+    );
+}
+
+#[test]
+fn from_cvc5_term_str_to_re() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.in_re s (str.to_re \"abc\"))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_re_star() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.in_re s (re.* (str.to_re \"a\")))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_uf_application() {
+    term_round_trip(
+        "(set-logic QF_UFLIA) (declare-fun f (Int Int) Int) (declare-const x Int) (declare-const y Int)",
+        "(f x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_datatype_constructor_nullary() {
+    term_round_trip(
+        "(set-logic ALL) (declare-datatypes ((Color 0)) (((Red) (Green) (Blue))))",
+        "Red",
+    );
+}
+
+#[test]
+fn from_cvc5_term_datatype_constructor_applied() {
+    term_round_trip(
+        "(set-logic ALL) (declare-datatypes ((Pair 0)) (((mkpair (fst Int) (snd Int))))) (declare-const x Int)",
+        "(mkpair x 42)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_datatype_selector() {
+    term_round_trip(
+        "(set-logic ALL) (declare-datatypes ((Pair 0)) (((mkpair (fst Int) (snd Int))))) (declare-const p Pair)",
+        "(fst p)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_datatype_tester() {
+    term_round_trip(
+        "(set-logic ALL) (declare-datatypes ((Color 0)) (((Red) (Green) (Blue)))) (declare-const c Color)",
+        "((_ is Red) c)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_match_wildcard() {
+    term_round_trip(
+        "(set-logic ALL) (declare-datatypes ((Color 0)) (((Red) (Green) (Blue)))) (declare-const c Color)",
+        "(match c ((Red 1) (x 0)))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_real_literal() {
+    // 1.5 is represented as 3/2 in cvc5; reverse translates to (/ 3 2)
+    let mut ctx = Context::new();
+    let _cmds = UntypedAst
+        .parse_script_str("(set-logic QF_LRA) (declare-const x Real)")
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &_cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
+    let term = UntypedAst
+        .parse_term_str("(+ x 1.5)")
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let cterm = term.to_cvc5(&mut *es.env).unwrap();
+    let mut from_env = FromCvc5Env::new(&mut ctx);
+    let back = cterm.conv_from_cvc5(&mut from_env).unwrap();
+    assert_eq!(back.to_string(), "(+ x (/ 3 2))");
+}
+
+#[test]
+fn from_cvc5_term_let_eliminated() {
+    // let bindings are eliminated during forward translation; the reverse should still work
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int)",
+        "(+ (+ x 1) (+ x 1))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_deeply_nested() {
+    term_round_trip(
+        "(set-logic QF_LIA) (declare-const x Int)",
+        "(+ (+ (+ (+ x 1) 2) 3) 4)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_implies_chain() {
+    // cvc5 normalizes (=> a b c) to (=> a (=> b c))
+    term_round_trip(
+        "(set-logic QF_UF) (declare-const a Bool) (declare-const b Bool) (declare-const c Bool)",
+        "(=> a (=> b c))",
     );
 }

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -959,7 +959,6 @@ fn command_result_get_model_uninterpreted_sort_nested() {
 
 // ── ConvertFromCvc5 sort round-trip tests ────────────────────
 
-
 /// Helper: translate a yaspar-ir Sort to cvc5 and back, asserting the round-trip
 /// produces the same string representation.
 fn sort_round_trip(script: &str, sort_str: &str) {
@@ -1306,7 +1305,6 @@ fn from_cvc5_term_match_applied() {
     );
 }
 
-
 // ── Comprehensive backward translation tests ─────────────────
 
 #[test]
@@ -1362,7 +1360,9 @@ fn from_cvc5_term_chained_eq() {
     // (= x y z) in cvc5 is n-ary; reverse translates to (and (= x y) (= y z))
     let mut ctx = Context::new();
     let _cmds = UntypedAst
-        .parse_script_str("(set-logic QF_LIA) (declare-const x Int) (declare-const y Int) (declare-const z Int)")
+        .parse_script_str(
+            "(set-logic QF_LIA) (declare-const x Int) (declare-const y Int) (declare-const z Int)",
+        )
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
@@ -1374,9 +1374,21 @@ fn from_cvc5_term_chained_eq() {
         cmd.to_cvc5(&mut es).unwrap();
     }
     // Build (= x y z) by translating individual terms and combining
-    let x = UntypedAst.parse_term_str("x").unwrap().type_check(&mut ctx).unwrap();
-    let y = UntypedAst.parse_term_str("y").unwrap().type_check(&mut ctx).unwrap();
-    let z = UntypedAst.parse_term_str("z").unwrap().type_check(&mut ctx).unwrap();
+    let x = UntypedAst
+        .parse_term_str("x")
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let y = UntypedAst
+        .parse_term_str("y")
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let z = UntypedAst
+        .parse_term_str("z")
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
     let cx = x.to_cvc5(&mut *es.env).unwrap();
     let cy = y.to_cvc5(&mut *es.env).unwrap();
     let cz = z.to_cvc5(&mut *es.env).unwrap();
@@ -1388,10 +1400,7 @@ fn from_cvc5_term_chained_eq() {
 
 #[test]
 fn from_cvc5_term_unary_minus() {
-    term_round_trip(
-        "(set-logic QF_LIA) (declare-const x Int)",
-        "(- x)",
-    );
+    term_round_trip("(set-logic QF_LIA) (declare-const x Int)", "(- x)");
 }
 
 #[test]
@@ -1548,10 +1557,7 @@ fn from_cvc5_term_string_concat() {
 
 #[test]
 fn from_cvc5_term_string_len() {
-    term_round_trip(
-        "(set-logic QF_S) (declare-const s String)",
-        "(str.len s)",
-    );
+    term_round_trip("(set-logic QF_S) (declare-const s String)", "(str.len s)");
 }
 
 #[test]
@@ -1676,5 +1682,274 @@ fn from_cvc5_term_implies_chain() {
     term_round_trip(
         "(set-logic QF_UF) (declare-const a Bool) (declare-const b Bool) (declare-const c Bool)",
         "(=> a (=> b c))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_real_integer_value() {
+    // Real value that is integral (no division) — should produce a decimal
+    let mut ctx = Context::new();
+    let _cmds = UntypedAst
+        .parse_script_str("(set-logic QF_LRA) (declare-const x Real)")
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &_cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
+    let term = UntypedAst
+        .parse_term_str("(+ x 3.0)")
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let cterm = term.to_cvc5(&mut *es.env).unwrap();
+    let mut from_env = FromCvc5Env::new(&mut ctx);
+    let back = cterm.conv_from_cvc5(&mut from_env).unwrap();
+    // cvc5 returns "3" for the real value 3.0; reverse produces (/ 3 1) or 3.0
+    assert!(back.to_string().contains("3"));
+}
+
+#[test]
+fn from_cvc5_term_real_in_lira() {
+    // In LIRA logic (RealInts), real division should use decimal constants
+    let mut ctx = Context::new();
+    let _cmds = UntypedAst
+        .parse_script_str("(set-logic AUFLIRA) (declare-const x Real)")
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &_cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
+    let term = UntypedAst
+        .parse_term_str("(+ x 1.5)")
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let cterm = term.to_cvc5(&mut *es.env).unwrap();
+    let mut from_env = FromCvc5Env::new(&mut ctx);
+    let back = cterm.conv_from_cvc5(&mut from_env).unwrap();
+    // In LIRA, 1.5 = 3/2 should use decimal constants: (/ 3.0 2.0)
+    assert_eq!(back.to_string(), "(+ x (/ 3.0 2.0))");
+}
+
+#[test]
+fn from_cvc5_term_bv_rotate_left() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8))",
+        "((_ rotate_left 3) x)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv_rotate_right() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8))",
+        "((_ rotate_right 3) x)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv_repeat() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 4))",
+        "((_ repeat 2) x)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_int2bv() {
+    term_round_trip("(set-logic ALL) (declare-const x Int)", "((_ int2bv 8) x)");
+}
+
+#[test]
+fn from_cvc5_term_re_power() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.in_re s ((_ re.^ 3) (str.to_re \"a\")))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_re_loop() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.in_re s ((_ re.loop 2 5) (str.to_re \"a\")))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_string_contains() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.contains s \"hello\")",
+    );
+}
+
+#[test]
+fn from_cvc5_term_abs() {
+    term_round_trip("(set-logic QF_NIA) (declare-const x Int)", "(abs x)");
+}
+
+#[test]
+fn from_cvc5_term_to_real() {
+    term_round_trip("(set-logic AUFLIRA) (declare-const x Int)", "(to_real x)");
+}
+
+#[test]
+fn from_cvc5_term_to_int() {
+    term_round_trip("(set-logic AUFLIRA) (declare-const x Real)", "(to_int x)");
+}
+
+#[test]
+fn from_cvc5_term_bv_slt() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8)) (declare-const y (_ BitVec 8))",
+        "(bvslt x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_bv_sdiv() {
+    term_round_trip(
+        "(set-logic QF_BV) (declare-const x (_ BitVec 8)) (declare-const y (_ BitVec 8))",
+        "(bvsdiv x y)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_re_union() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.in_re s (re.union (str.to_re \"a\") (str.to_re \"b\")))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_re_inter() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.in_re s (re.inter (re.* (str.to_re \"a\")) (re.* (str.to_re \"b\"))))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_re_comp() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.in_re s (re.comp (str.to_re \"a\")))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_str_replace() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.replace s \"a\" \"b\")",
+    );
+}
+
+#[test]
+fn from_cvc5_term_str_indexof() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.indexof s \"a\" 0)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_str_substr() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.substr s 0 3)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_str_prefixof() {
+    term_round_trip(
+        "(set-logic QF_S) (declare-const s String)",
+        "(str.prefixof \"he\" s)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_hex_bv_literal() {
+    // Hex literals are normalized to binary in the round-trip
+    let mut ctx = Context::new();
+    let _cmds = UntypedAst
+        .parse_script_str("(set-logic QF_BV) (declare-const x (_ BitVec 8))")
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::create(&tm);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &_cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
+    let term = UntypedAst
+        .parse_term_str("(bvadd x #xab)")
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let cterm = term.to_cvc5(&mut *es.env).unwrap();
+    let mut from_env = FromCvc5Env::new(&mut ctx);
+    let back = cterm.conv_from_cvc5(&mut from_env).unwrap();
+    assert_eq!(back.to_string(), "(bvadd x #b10101011)");
+}
+
+#[test]
+fn from_cvc5_term_exists_with_pattern() {
+    term_round_trip(
+        "(set-logic ALL) (declare-fun f (Int) Int)",
+        "(exists ((x Int)) (! (= (f x) 0) :pattern ((f x))))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_match_wildcard_catchall() {
+    term_round_trip(
+        "(set-logic ALL) (declare-datatypes ((Color 0)) (((Red) (Green) (Blue)))) (declare-const c Color)",
+        "(match c ((Red 1) (x 0)))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_parametric_datatype_constructor() {
+    term_round_trip(
+        "(set-logic ALL)
+         (declare-datatypes ((List 1)) ((par (T) ((nil) (cons (head T) (tail (List T)))))))
+         (declare-const x Int)",
+        "(cons x (as nil (List Int)))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_parametric_datatype_selector() {
+    term_round_trip(
+        "(set-logic ALL)
+         (declare-datatypes ((List 1)) ((par (T) ((nil) (cons (head T) (tail (List T)))))))
+         (declare-const l (List Int))",
+        "(head l)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_parametric_datatype_tester() {
+    term_round_trip(
+        "(set-logic ALL)
+         (declare-datatypes ((List 1)) ((par (T) ((nil) (cons (head T) (tail (List T)))))))
+         (declare-const l (List Int))",
+        "((_ is cons) l)",
     );
 }

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -1953,3 +1953,39 @@ fn from_cvc5_term_parametric_datatype_tester() {
         "((_ is cons) l)",
     );
 }
+
+#[test]
+fn from_cvc5_term_match_anonymous_wildcard() {
+    // Wildcard without a variable name: (_ 0)
+    term_round_trip(
+        "(set-logic ALL) (declare-datatypes ((Color 0)) (((Red) (Green) (Blue)))) (declare-const c Color)",
+        "(match c ((Red 1) (_ 0)))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_match_applied_with_anonymous_arg() {
+    // Applied pattern with anonymous wildcard in selector position
+    term_round_trip(
+        "(set-logic ALL) (declare-datatypes ((Pair 0)) (((mkpair (fst Int) (snd Int))))) (declare-const p Pair)",
+        "(match p (((mkpair x _) x)))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_match_multiple_arms() {
+    term_round_trip(
+        "(set-logic ALL) (declare-datatypes ((Color 0)) (((Red) (Green) (Blue)))) (declare-const c Color)",
+        "(match c ((Red 10) (Green 20) (Blue 30)))",
+    );
+}
+
+#[test]
+fn from_cvc5_term_match_nested() {
+    term_round_trip(
+        "(set-logic ALL)
+         (declare-datatypes ((List 1)) ((par (T) ((nil) (cons (head T) (tail (List T)))))))
+         (declare-const l (List Int))",
+        "(match l ((nil 0) ((cons h t) (match t ((nil h) ((cons h2 t2) (+ h h2)))))))",
+    );
+}

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -1989,3 +1989,19 @@ fn from_cvc5_term_match_nested() {
         "(match l ((nil 0) ((cons h t) (match t ((nil h) ((cons h2 t2) (+ h h2)))))))",
     );
 }
+
+#[test]
+fn from_cvc5_term_const_array() {
+    term_round_trip(
+        "(set-logic ALL) (set-option :arrays-exp true) (declare-const a (Array Int Int))",
+        "((as const (Array Int Int)) 0)",
+    );
+}
+
+#[test]
+fn from_cvc5_term_const_array_bool() {
+    term_round_trip(
+        "(set-logic ALL) (set-option :arrays-exp true) (declare-const a (Array Int Bool))",
+        "((as const (Array Int Bool)) true)",
+    );
+}

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -1119,7 +1119,7 @@ fn const_array_negative() {
 /// produces the same string representation.
 fn term_round_trip(script: &str, term_str: &str) {
     let mut ctx = Context::new();
-    let _cmds = UntypedAst
+    let cmds = UntypedAst
         .parse_script_str(script)
         .unwrap()
         .type_check(&mut ctx)
@@ -1128,7 +1128,7 @@ fn term_round_trip(script: &str, term_str: &str) {
     let mut solver = Solver::new(&tm);
     let mut env = Cvc5Env::create(&tm);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
-    for cmd in &_cmds {
+    for cmd in &cmds {
         cmd.to_cvc5(&mut es).unwrap();
     }
     let term = UntypedAst
@@ -2003,5 +2003,55 @@ fn from_cvc5_term_const_array_bool() {
     term_round_trip(
         "(set-logic ALL) (set-option :arrays-exp true) (declare-const a (Array Int Bool))",
         "((as const (Array Int Bool)) true)",
+    );
+}
+
+// ── Tests for parametric match pattern constructor resolution ─────────
+// These exercise the else branch in translate_match_case_from_cvc5 where
+// ctor_term.has_symbol() is false (parametric/instantiated constructors).
+
+#[test]
+fn from_cvc5_match_parametric_nullary_single() {
+    // Parametric List with nil (nullary) in a match pattern
+    term_round_trip(
+        "(set-logic ALL)
+         (declare-datatypes ((List 1)) ((par (T) ((nil) (cons (head T) (tail (List T)))))))
+         (declare-const l (List Int))",
+        "(match l ((nil 0) ((cons h t) 1)))",
+    );
+}
+
+#[test]
+fn from_cvc5_match_parametric_multi_nullary() {
+    // Parametric datatype with multiple nullary constructors — the key regression case.
+    // The old code would always pick the first nullary constructor; this verifies each
+    // nullary constructor is correctly identified.
+    term_round_trip(
+        "(set-logic ALL)
+         (declare-datatypes ((Maybe 1)) ((par (T) ((nothing) (just (val T)) (unknown)))))
+         (declare-const m (Maybe Int))",
+        "(match m ((nothing 0) ((just x) x) (unknown (- 1))))",
+    );
+}
+
+#[test]
+fn from_cvc5_match_parametric_second_nullary() {
+    // Match where the second nullary constructor appears — ensures we don't just pick the first.
+    term_round_trip(
+        "(set-logic ALL)
+         (declare-datatypes ((Maybe 1)) ((par (T) ((nothing) (just (val T)) (unknown)))))
+         (declare-const m (Maybe Int))",
+        "(match m (((just x) x) (nothing 1) (unknown 2)))",
+    );
+}
+
+#[test]
+fn from_cvc5_match_parametric_bool_instantiation() {
+    // Same parametric datatype instantiated at Bool
+    term_round_trip(
+        "(set-logic ALL)
+         (declare-datatypes ((List 1)) ((par (T) ((nil) (cons (head T) (tail (List T)))))))
+         (declare-const l (List Bool))",
+        "(match l ((nil false) ((cons h t) h)))",
     );
 }


### PR DESCRIPTION
*Issue #, if available:*

Closes #80 

*Description of changes:*

This PR implements initial functionality to do the backward translation. The API is not stable, however. In particular, I am wondering whether there should be a separate environment for backward translation. It seems the caches for sorts and terms between yaspar and cvc5 should maintain one to one relation. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
