### PR TITLE
refactor memoization recursion for a trait based impl

### DIFF
--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -27,7 +27,7 @@ use super::rec::*;
 use crate::ast::alg::{
     Attribute, Constant, Local, PatternArm, QualifiedIdentifier, Term, VarBinding,
 };
-use crate::containers::InsertableMapping;
+use crate::containers::{InsertableMapping, Mapping};
 use crate::traits::{Contains, Repr};
 use delegate::delegate;
 use either::Either;
@@ -95,11 +95,36 @@ impl<R, M> Memoize<R, M> {
     }
 }
 
-impl<Str, So, T, R, M> TermRecursor<Str, So, T> for Memoize<R, M>
+impl<K, V, R, M> Memoizing<K, V> for Memoize<R, M>
+where
+    M: InsertableMapping<Key = K, Value = V>,
+{
+    type Cache<'a>
+        = &'a mut M
+    where
+        M: 'a,
+        R: 'a;
+
+    fn cache_mut(&mut self) -> Self::Cache<'_> {
+        &mut self.cache
+    }
+}
+
+pub(crate) trait Memoizing<K, V> {
+    type Cache<'a>: DerefMut<Target: InsertableMapping<Key = K, Value = V>>
+    where
+        Self: 'a;
+
+    fn cache_mut(&mut self) -> Self::Cache<'_>;
+}
+
+pub(crate) struct MemoizedRecursion<'a, R>(&'a mut R);
+
+impl<Str, So, T, R> TermRecursor<Str, So, T> for MemoizedRecursion<'_, R>
 where
     T: Clone,
     R: TermRecursor<Str, So, T, Out: Clone>,
-    M: InsertableMapping<Key = T, Value = R::Out>,
+    R: Memoizing<T, R::Out>,
 {
     type Out = R::Out;
     type Attr = R::Attr;
@@ -116,7 +141,7 @@ where
     }
 
     delegate! {
-        to self.inner {
+        to self.0 {
             fn on_attribute_keyword(&mut self, keyword: &Keyword) -> Result<Self::Attr, Self::Err>;
             fn on_attribute_constant(&mut self, keyword: &Keyword, constant: &Constant<Str>) -> Result<Self::Attr, Self::Err>;
             fn on_attribute_symbol(&mut self, keyword: &Keyword, symbol: &Str) -> Result<Self::Attr, Self::Err>;
@@ -139,8 +164,8 @@ where
         constant: &Constant<Str>,
         sort: &Option<So>,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_constant(current, constant, sort)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_constant(current, constant, sort)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -150,14 +175,14 @@ where
         id: &QualifiedIdentifier<Str, So>,
         sort: &Option<So>,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_global(current, id, sort)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_global(current, id, sort)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
     fn on_local(&mut self, current: &T, id: &Local<Str, So>) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_local(current, id)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_local(current, id)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -169,8 +194,8 @@ where
         s: &Option<So>,
         recs: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_app(current, id, ts, s, recs)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_app(current, id, ts, s, recs)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -182,8 +207,8 @@ where
         vs_rec: Vec<Self::Binding>,
         body_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_let(current, vs, body, vs_rec, body_rec)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_let(current, vs, body, vs_rec, body_rec)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -194,8 +219,8 @@ where
         t: &T,
         t_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_exists(current, vs, t, t_rec)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_exists(current, vs, t, t_rec)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -206,8 +231,8 @@ where
         t: &T,
         t_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_forall(current, vs, t, t_rec)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_forall(current, vs, t, t_rec)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -220,9 +245,9 @@ where
         cases_rec: Vec<Self::Arm>,
     ) -> Result<Self::Out, Self::Err> {
         let r = self
-            .inner
+            .0
             .on_match(current, scrutinee, cases, scrutinee_rec, cases_rec)?;
-        self.cache.insert(current.clone(), r.clone());
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -234,8 +259,8 @@ where
         t_rec: Self::Out,
         anns_rec: Vec<Self::Attr>,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_annotated(current, t, anns, t_rec, anns_rec)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_annotated(current, t, anns, t_rec, anns_rec)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -247,8 +272,8 @@ where
         a_rec: Self::Out,
         b_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_eq(current, a, b, a_rec, b_rec)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_eq(current, a, b, a_rec, b_rec)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -258,8 +283,8 @@ where
         ts: &[T],
         ts_rec: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_distinct(current, ts, ts_rec)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_distinct(current, ts, ts_rec)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -269,8 +294,8 @@ where
         ts: &[T],
         ts_rec: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_and(current, ts, ts_rec)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_and(current, ts, ts_rec)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -280,8 +305,8 @@ where
         ts: &[T],
         ts_rec: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_or(current, ts, ts_rec)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_or(current, ts, ts_rec)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -291,14 +316,14 @@ where
         ts: &[T],
         ts_rec: Vec<Self::Out>,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_xor(current, ts, ts_rec)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_xor(current, ts, ts_rec)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
     fn on_not(&mut self, current: &T, t: &T, t_rec: Self::Out) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_not(current, t, t_rec)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_not(current, t, t_rec)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -310,8 +335,8 @@ where
         ts_rec: Vec<Self::Out>,
         t_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_implies(current, ts, t, ts_rec, t_rec)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_implies(current, ts, t, ts_rec, t_rec)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
     }
 
@@ -325,9 +350,65 @@ where
         t_rec: Self::Out,
         e_rec: Self::Out,
     ) -> Result<Self::Out, Self::Err> {
-        let r = self.inner.on_ite(current, b, t, e, b_rec, t_rec, e_rec)?;
-        self.cache.insert(current.clone(), r.clone());
+        let r = self.0.on_ite(current, b, t, e, b_rec, t_rec, e_rec)?;
+        self.0.cache_mut().insert(current.clone(), r.clone());
         Ok(r)
+    }
+}
+
+impl<Str, So, T, R, M> TermRecursor<Str, So, T> for Memoize<R, M>
+where
+    T: Clone,
+    R: TermRecursor<Str, So, T, Out: Clone>,
+    M: InsertableMapping<Key = T, Value = R::Out>,
+{
+    type Out = R::Out;
+    type Attr = R::Attr;
+    type Binding = R::Binding;
+    type Pattern = R::Pattern;
+    type Arm = R::Arm;
+    type Err = R::Err;
+
+    fn recurse_on_term(&mut self, t: &T) -> Result<Self::Out, Self::Err>
+    where
+        T: Contains<T: Repr<T = Term<Str, So, T>>>,
+    {
+        MemoizedScheme::term_recursion(&mut MemoizedRecursion(self), t)
+    }
+
+    delegate! {
+        to self.inner {
+            fn on_attribute_keyword(&mut self, keyword: &Keyword) -> Result<Self::Attr, Self::Err>;
+            fn on_attribute_constant(&mut self, keyword: &Keyword, constant: &Constant<Str>) -> Result<Self::Attr, Self::Err>;
+            fn on_attribute_symbol(&mut self, keyword: &Keyword, symbol: &Str) -> Result<Self::Attr, Self::Err>;
+            fn on_attribute_named(&mut self, name: &Str) -> Result<Self::Attr, Self::Err>;
+            fn on_attribute_pattern(&mut self, patterns: &[T], patterns_rec: Vec<Self::Out>) -> Result<Self::Attr, Self::Err>;
+            fn on_let_binding(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, binding_idx: usize, binding_rec: Self::Out) -> Result<Self::Binding, Self::Err>;
+            fn setup_let_scope(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: &[Self::Binding]) -> Result<(), Self::Err>;
+            fn cleanup_let_scope_on_error(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: Vec<Self::Binding>);
+            fn setup_quantifier_scope(&mut self, current: &T, vs: &[VarBinding<Str, So>], t: &T, is_forall: bool) -> Result<(), Self::Err>;
+            fn cleanup_quantifier_scope_on_error(&mut self, current: &T, vs: &[VarBinding<Str, So>], t: &T, is_forall: bool);
+            fn setup_match_case_scope(&mut self, current: &T, scrutinee: &T, cases: &[PatternArm<Str, T>], scrutinee_rec: &Self::Out, case_idx: usize) -> Result<Self::Pattern, Self::Err>;
+            fn cleanup_match_case_scope_on_error(&mut self, current: &T, scrutinee: &T, cases: &[PatternArm<Str, T>], scrutinee_rec: Self::Out, case_idx: usize);
+            fn on_match_arm(&mut self, current: &T, scrutinee: &T, cases: &[PatternArm<Str, T>], scrutinee_rec: &Self::Out, case_idx: usize, current_pattern: Self::Pattern, arm: Self::Out) -> Result<Self::Arm, Self::Err>;
+            fn on_constant(&mut self, current: &T, constant: &Constant<Str>, sort: &Option<So>) -> Result<Self::Out, Self::Err>;
+            fn on_global(&mut self, current: &T, id: &QualifiedIdentifier<Str, So>, sort: &Option<So>) -> Result<Self::Out, Self::Err>;
+            fn on_local(&mut self, current: &T, id: &Local<Str, So>) -> Result<Self::Out, Self::Err>;
+            fn on_app(&mut self, current: &T, id: &QualifiedIdentifier<Str, So>, ts: &[T], s: &Option<So>, recs: Vec<Self::Out>) -> Result<Self::Out, Self::Err>;
+            fn on_let(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: Vec<Self::Binding>, body_rec: Self::Out) -> Result<Self::Out, Self::Err>;
+            fn on_exists(&mut self, current: &T, vs: &[VarBinding<Str, So>], t: &T, t_rec: Self::Out) -> Result<Self::Out, Self::Err>;
+            fn on_forall(&mut self, current: &T, vs: &[VarBinding<Str, So>], t: &T, t_rec: Self::Out) -> Result<Self::Out, Self::Err>;
+            fn on_match(&mut self, current: &T, scrutinee: &T, cases: &[PatternArm<Str, T>], scrutinee_rec: Self::Out, cases_rec: Vec<Self::Arm>) -> Result<Self::Out, Self::Err>;
+            fn on_annotated(&mut self, current: &T, t: &T, anns: &[Attribute<Str, T>], t_rec: Self::Out, anns_rec: Vec<Self::Attr>) -> Result<Self::Out, Self::Err>;
+            fn on_eq(&mut self, current: &T, a: &T, b: &T, a_rec: Self::Out, b_rec: Self::Out) -> Result<Self::Out, Self::Err>;
+            fn on_distinct(&mut self, current: &T, ts: &[T], ts_rec: Vec<Self::Out>) -> Result<Self::Out, Self::Err>;
+            fn on_and(&mut self, current: &T, ts: &[T], ts_rec: Vec<Self::Out>) -> Result<Self::Out, Self::Err>;
+            fn on_or(&mut self, current: &T, ts: &[T], ts_rec: Vec<Self::Out>) -> Result<Self::Out, Self::Err>;
+            fn on_xor(&mut self, current: &T, ts: &[T], ts_rec: Vec<Self::Out>) -> Result<Self::Out, Self::Err>;
+            fn on_not(&mut self, current: &T, t: &T, t_rec: Self::Out) -> Result<Self::Out, Self::Err>;
+            fn on_implies(&mut self, current: &T, ts: &[T], t: &T, ts_rec: Vec<Self::Out>, t_rec: Self::Out) -> Result<Self::Out, Self::Err>;
+            fn on_ite(&mut self, current: &T, b: &T, t: &T, e: &T, b_rec: Self::Out, t_rec: Self::Out, e_rec: Self::Out) -> Result<Self::Out, Self::Err>;
+        }
     }
 }
 
@@ -338,19 +419,19 @@ where
 /// skipped and the cached result is returned immediately.
 pub(crate) struct MemoizedScheme;
 
-impl<R, M, Str, So, T> TermRecursionScheme<Memoize<R, M>, Str, So, T> for MemoizedScheme
+impl<'b, R, Str, So, T> TermRecursionScheme<MemoizedRecursion<'b, R>, Str, So, T> for MemoizedScheme
 where
-    R: TermRecursor<Str, So, T, Out: Clone>,
-    M: InsertableMapping<Key = T, Value = R::Out>,
     T: Clone,
+    R: TermRecursor<Str, So, T, Out: Clone>,
+    R: Memoizing<T, R::Out>,
 {
     /// Like [`expand_and_resolve`], but checks the cache before descending.
     ///
     /// If `current` is already in the cache, the cached result is returned immediately
     /// without pushing any frames or invoking any callbacks.
     fn expand_and_resolve<'a>(
-        recursor: &mut Memoize<R, M>,
-        stack: &mut RStack<'a, Memoize<R, M>, Str, So, T>,
+        recursor: &mut MemoizedRecursion<'b, R>,
+        stack: &mut RStack<'a, MemoizedRecursion<'b, R>, Str, So, T>,
         mut current: &'a T,
     ) -> Result<R::Out, R::Err>
     where
@@ -359,7 +440,7 @@ where
         T: Contains<T: Repr<T = Term<Str, So, T>>>,
     {
         loop {
-            if let Some(r) = recursor.cache.lookup(current) {
+            if let Some(r) = recursor.0.cache_mut().lookup(current) {
                 return Ok(r);
             }
 

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -371,11 +371,11 @@ where
 /// [`TermRecursor`] implementation for [`Memoize`].
 ///
 /// All callbacks delegate directly to the inner recursor. The actual caching is performed
-/// by [`MemoizedRecursion`], which wraps `self` during [`recurse_on_term`] and inserts
+/// by `MemoizedRecursion`, which wraps `self` during [`Self::recurse_on_term`] and inserts
 /// results into the cache after each `on_*` callback that produces `Out`.
 ///
 /// This two-layer design means:
-/// - Calling [`recurse_on_term`] on a `Memoize` gives you full memoized traversal.
+/// - Calling [`Self::recurse_on_term`] on a `Memoize` gives you full memoized traversal.
 /// - Calling individual `on_*` methods directly bypasses caching (they are plain delegations).
 impl<Str, So, T, R, M> TermRecursor<Str, So, T> for Memoize<R, M>
 where

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -110,6 +110,10 @@ where
     }
 }
 
+/// Internal trait abstracting cache access for memoized recursion.
+///
+/// Implemented by [`Memoize`] to expose its cache to [`MemoizedRecursion`], which
+/// inserts results after each `on_*` callback.
 pub(crate) trait Memoizing<K, V> {
     type Cache<'a>: DerefMut<Target: InsertableMapping<Key = K, Value = V>>
     where
@@ -118,6 +122,14 @@ pub(crate) trait Memoizing<K, V> {
     fn cache_mut(&mut self) -> Self::Cache<'_>;
 }
 
+/// Internal wrapper that interposes caching logic between the traversal engine and
+/// the user's recursor.
+///
+/// All `on_*` callbacks that produce `Out` delegate to the inner recursor and then
+/// insert the result into the cache. Auxiliary callbacks (`setup_*`, `on_let_binding`,
+/// `on_match_arm`, `on_attribute_*`) delegate directly without caching.
+///
+/// This type is not public — users interact with [`Memoize`] directly.
 pub(crate) struct MemoizedRecursion<'a, R>(&'a mut R);
 
 impl<Str, So, T, R> TermRecursor<Str, So, T> for MemoizedRecursion<'_, R>
@@ -356,6 +368,15 @@ where
     }
 }
 
+/// [`TermRecursor`] implementation for [`Memoize`].
+///
+/// All callbacks delegate directly to the inner recursor. The actual caching is performed
+/// by [`MemoizedRecursion`], which wraps `self` during [`recurse_on_term`] and inserts
+/// results into the cache after each `on_*` callback that produces `Out`.
+///
+/// This two-layer design means:
+/// - Calling [`recurse_on_term`] on a `Memoize` gives you full memoized traversal.
+/// - Calling individual `on_*` methods directly bypasses caching (they are plain delegations).
 impl<Str, So, T, R, M> TermRecursor<Str, So, T> for Memoize<R, M>
 where
     T: Clone,
@@ -373,10 +394,11 @@ where
     where
         T: Contains<T: Repr<T = Term<Str, So, T>>>,
     {
-        MemoizedScheme::term_recursion(&mut MemoizedRecursion(self), t)
+        MemoizedRecursion(self).recurse_on_term(t)
     }
 
     delegate! {
+        #[inline]
         to self.inner {
             fn on_attribute_keyword(&mut self, keyword: &Keyword) -> Result<Self::Attr, Self::Err>;
             fn on_attribute_constant(&mut self, keyword: &Keyword, constant: &Constant<Str>) -> Result<Self::Attr, Self::Err>;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

a struct that implements TermRecursor and Memoizing can now invoke the memoized scheme. Memoize does not have to get involved.

This allows more freedom when handling caches, as opposed to the current Inner-Memoize pattern. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
