### PR TITLE
Include TesterDefined symbols in defined_symbols()

### DIFF
--- a/src/ast/ctx/mod.rs
+++ b/src/ast/ctx/mod.rs
@@ -592,8 +592,14 @@ impl Context {
                 // scan all signatures for one that has a defined body
                 sigs.iter()
                     .filter_map(|(_, def)| {
-                        if matches!(def, FunctionMeta::Defined { .. }
-                            | FunctionMeta::Datatype { kind: DatatypeFunction::TesterDefined(_), .. }) {
+                        if matches!(
+                            def,
+                            FunctionMeta::Defined { .. }
+                                | FunctionMeta::Datatype {
+                                    kind: DatatypeFunction::TesterDefined(_),
+                                    ..
+                                }
+                        ) {
                             Some(name.clone())
                         } else {
                             None

--- a/src/ast/ctx/mod.rs
+++ b/src/ast/ctx/mod.rs
@@ -583,7 +583,7 @@ impl Context {
     /// Get all the symbols with a definition body
     ///
     /// This function is different from [Self::user_defined_symbols] in that it only returns the symbols
-    /// defined through `define-const` or `define-fun`.
+    /// defined through `define-const` or `define-fun` or datatype testers of the form `is-X`.
     pub fn defined_symbols(&self) -> HashSet<Str> {
         self.frame
             .symbol_table

--- a/src/ast/ctx/mod.rs
+++ b/src/ast/ctx/mod.rs
@@ -592,7 +592,8 @@ impl Context {
                 // scan all signatures for one that has a defined body
                 sigs.iter()
                     .filter_map(|(_, def)| {
-                        if matches!(def, FunctionMeta::Defined { .. }) {
+                        if matches!(def, FunctionMeta::Defined { .. }
+                            | FunctionMeta::Datatype { kind: DatatypeFunction::TesterDefined(_), .. }) {
                             Some(name.clone())
                         } else {
                             None


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* `defined_symbols()` only matched `FunctionMeta::Defined`, so `is-X` tester shorthands (which are registered as `TesterDefined`) were never returned. This meant `gsubst` never expanded `is-X` to `(_ is X)`, causing Sundace to treat them as uninterpreted functions. I believe this is the best way to fix this. We will have to update Sundance to use version 2.7.4 once this PR lands


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
