### PR TITLE
Use the same Cvc5Env to handle the relation between yaspar-ir context and cvc5 context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ either = "1.15"
 num-traits = "0.2.19"
 num-order = "1.2.0"
 delegate = "0.13"
+bimap = "0.6"
 
 [lib]
 name = "yaspar_ir"

--- a/README.md
+++ b/README.md
@@ -717,28 +717,42 @@ Currently, the crate provides the following functionalities:
     `cvc5`. It translates typed `Sort`s, `Term`s, and `Command`s to their cvc5 counterparts, with memoized caching
     and support for quantifier `:pattern` annotations.
 14. Translation from cvc5: see the `cvc5` module and the `ConvertFromCvc5` trait. This functionality requires the
-    feature `cvc5`. It translates cvc5 `Sort`s and `Term`s back to yaspar-ir typed ASTs, with sort caching and
-    scoped variable tracking for quantifiers and match expressions.
+    feature `cvc5`. It translates cvc5 `Sort`s and `Term`s back to yaspar-ir typed ASTs, sharing the same `Cvc5Env`
+    (and its sort/term caches) used for forward translation. Command results carrying terms are auto-backward-
+    translated, and `:named` assertion labels are recovered in `get-unsat-core`/`get-assertions`/
+    `get-unsat-assumptions` results.
 
 ### Translation to and from cvc5
 
 The `cvc5` module provides bidirectional translation between yaspar-ir and cvc5. It exposes two
-traits and three environment types:
+traits and two environment types:
 
 **Forward** (`ConvertToCvc5<Env>`): translates yaspar-ir `Sort`s, `Term`s, and `Command`s to cvc5.
 
-- `Cvc5Env` — a memoized environment that caches sort and term translations. Used for `Sort`s and `Term`s.
-- `Cvc5EnvSolver` — wraps a `Cvc5Env` and a `Solver`. Used for `Command`s.
+- `Cvc5Env<'tm, Ctx>` — the unified environment. Generic over `Ctx: HasMutRef<Context>` so it
+  works with `&mut Context`, `Rc<RefCell<Context>>`, or any other handle that yields a
+  mutable reference to a `Context`. A single environment carries the sort/term caches,
+  global/local symbol tables, and scope stacks needed by both directions.
+- `Cvc5EnvSolver` — wraps a `Cvc5Env` and a `Solver`. Used for `Command`s, since commands
+  may issue solver calls (`assert`, `check-sat`, `define-fun`, …).
 
-**Backward** (`ConvertFromCvc5<Env>`): translates cvc5 sorts and terms back to yaspar-ir.
+**Backward** (`ConvertFromCvc5<Env>`): translates cvc5 sorts and terms back to yaspar-ir,
+using the same `Cvc5Env` (its sort/term `BiHashMap` caches are shared with the forward
+direction, so a forward translation seeds a subsequent reverse lookup).
 
-- `FromCvc5Env` — manages sort/term caching, scoped variable bindings for quantifiers and match
-  expressions, and tracking of uninterpreted sort values from models.
+`Command::to_cvc5` returns a `CommandResult`. Variants that carry terms
+(`GetValue` and `Terms` — the latter covers `get-assertions`, `get-unsat-core`, and
+`get-unsat-assumptions`) hold `Vec<Term>`: each cvc5-returned term is automatically
+backward-translated. As a special case, when an assertion was registered via
+`(assert (! ... :named X))`, the corresponding `CTerm` is mapped back to `X` (a global
+identifier) instead of to the assertion body — recovering the SMT-LIB label that cvc5's
+solver-level API would otherwise drop. A `Terms` result can therefore mix labels and
+backward-translated formulas, depending on which assertions were named.
 
 ```rust
 use cvc5::{Solver, TermManager};
 use yaspar_ir::ast::{Context, Typecheck};
-use yaspar_ir::cvc5::{ConvertFromCvc5, ConvertToCvc5, Cvc5Env, Cvc5EnvSolver, FromCvc5Env};
+use yaspar_ir::cvc5::{ConvertFromCvc5, ConvertToCvc5, Cvc5Env, Cvc5EnvSolver};
 use yaspar_ir::untyped::UntypedAst;
 
 fn main() {
@@ -756,7 +770,7 @@ fn main() {
 
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
 
     // translate commands to cvc5 (which internally translate sorts and terms)
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
@@ -764,12 +778,10 @@ fn main() {
         cmd.to_cvc5(&mut es).unwrap();
     }
 
-    // translate a term to cvc5 and back
+    // translate a term to cvc5 and back, reusing the same environment
     let term = UntypedAst.parse_term_str("(+ x 1)").unwrap().type_check(&mut ctx).unwrap();
     let cvc5_term = term.to_cvc5(&mut *es.env).unwrap();
-
-    let mut from_env = FromCvc5Env::new(&mut ctx);
-    let back = cvc5_term.conv_from_cvc5(&mut from_env).unwrap();
+    let back = cvc5_term.conv_from_cvc5(&mut *es.env).unwrap();
     assert_eq!(term.to_string(), back.to_string());
 }
 ```

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -247,6 +247,10 @@ pub struct Cvc5Env<'tm, Ctx> {
     scope_stack_from: Vec<Vec<u64>>,
     /// Allocated symbols for uninterpreted sort values encountered during reverse translation.
     uninterpreted_values: HashSet<Str>,
+    /// Reverse map from a translated assertion's [`CTerm`] back to the SMT-LIB `:named`
+    /// label(s) declared on its enclosing `(assert (! ... :named X))` form.
+    /// Used to recover names when cvc5 returns terms in `get-unsat-core` etc.
+    named_assertions: HashMap<CTerm<'tm>, Str>,
 }
 
 impl<'tm, Ctx> Cvc5Env<'tm, Ctx>
@@ -269,6 +273,7 @@ where
             locals_from: HashMap::new(),
             scope_stack_from: Vec::new(),
             uninterpreted_values: HashSet::new(),
+            named_assertions: HashMap::new(),
         }
     }
 
@@ -276,6 +281,23 @@ where
     pub fn check_uninterpreted_value<S: AllocatableString<Arena>>(&mut self, name: S) -> bool {
         let sym = name.allocate(self.ctx.ref_mut().arena());
         self.uninterpreted_values.contains(&sym)
+    }
+
+    /// Backward-translate a list of cvc5 terms, substituting any `:named` label
+    /// recorded for an asserted formula in place of that formula's translation.
+    fn conv_terms_with_names(&mut self, cts: &[CTerm<'tm>]) -> Res<Vec<Term>> {
+        cts.iter()
+            .map(|ct| {
+                if let Some(name) = self.named_assertions.get(ct).cloned() {
+                    let mut rf = self.ctx.ref_mut();
+                    let bool_sort = rf.bool_sort();
+                    let qid = QualifiedIdentifier::simple(name);
+                    Ok(rf.global(qid, Some(bool_sort)))
+                } else {
+                    ct.conv_from_cvc5(self)
+                }
+            })
+            .collect()
     }
 }
 
@@ -2213,8 +2235,9 @@ where
                 let ct = cur.to_cvc5(env)?;
                 for name in names {
                     env.globals.insert(name.clone(), ct.clone());
+                    env.named_assertions.insert(ct.clone(), name);
                 }
-                solver.assert_formula(CTerm::clone(&ct));
+                solver.assert_formula(ct);
                 Ok(CommandResult::None)
             }
             AC::CheckSat => {
@@ -2257,17 +2280,17 @@ where
             }
             AC::GetAssertions => {
                 let cts = solver.get_assertions();
-                let ts = cts.conv_from_cvc5(env)?;
+                let ts = env.conv_terms_with_names(&cts)?;
                 Ok(CommandResult::Terms(ts))
             }
             AC::GetUnsatCore => {
                 let cts = solver.get_unsat_core();
-                let ts = cts.conv_from_cvc5(env)?;
+                let ts = env.conv_terms_with_names(&cts)?;
                 Ok(CommandResult::Terms(ts))
             }
             AC::GetUnsatAssumptions => {
                 let cts = solver.get_unsat_assumptions();
-                let ts = cts.conv_from_cvc5(env)?;
+                let ts = env.conv_terms_with_names(&cts)?;
                 Ok(CommandResult::Terms(ts))
             }
             AC::GetInfo(kw) => {

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -103,11 +103,11 @@ pub enum CommandResult<'tm> {
     /// Result of `check-sat` or `check-sat-assuming`.
     CheckSat(CResult<'tm>),
     /// Result of `get-value`: a list of terms.
-    GetValue(Vec<CTerm<'tm>>),
+    GetValue(Vec<Term>),
     /// Result of `get-model`: the model as a string.
     GetModel(String),
     /// Result of `get-assertions`, `get-unsat-core`, or `get-unsat-assumptions`: a list of terms.
-    Terms(Vec<CTerm<'tm>>),
+    Terms(Vec<Term>),
     /// Result of `get-info` or `get-option`: a string response.
     Info(String),
     /// Result of `get-proof`: the full proof tree.
@@ -218,7 +218,7 @@ pub struct Cvc5Env<'tm, Ctx> {
     tm: &'tm TermManager,
     /// The backing yaspar-ir context, used during reverse translation for arena
     /// allocation and theory-aware constant construction.
-    pub ctx: Ctx,
+    ctx: Ctx,
     /// Named sorts registered by `declare-sort` or datatype declarations.
     sort: HashMap<Str, CSort<'tm>>,
     /// Global symbols (constants, functions, constructors, selectors, testers).
@@ -2229,7 +2229,8 @@ where
             AC::GetValue(terms) => {
                 let cts = terms.to_cvc5(env)?;
                 let vals = solver.get_values(&cts);
-                Ok(CommandResult::GetValue(vals))
+                let ts: Vec<Term> = vals.as_slice().conv_from_cvc5(env)?;
+                Ok(CommandResult::GetValue(ts))
             }
             AC::GetModel => {
                 let sorts = env
@@ -2255,15 +2256,18 @@ where
                 Ok(CommandResult::GetModel(m))
             }
             AC::GetAssertions => {
-                let ts = solver.get_assertions();
+                let cts = solver.get_assertions();
+                let ts = cts.conv_from_cvc5(env)?;
                 Ok(CommandResult::Terms(ts))
             }
             AC::GetUnsatCore => {
-                let ts = solver.get_unsat_core();
+                let cts = solver.get_unsat_core();
+                let ts = cts.conv_from_cvc5(env)?;
                 Ok(CommandResult::Terms(ts))
             }
             AC::GetUnsatAssumptions => {
-                let ts = solver.get_unsat_assumptions();
+                let cts = solver.get_unsat_assumptions();
+                let ts = cts.conv_from_cvc5(env)?;
                 Ok(CommandResult::Terms(ts))
             }
             AC::GetInfo(kw) => {

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -13,9 +13,10 @@
 //! # Forward translation
 //!
 //! - [`ConvertToCvc5<Env>`] — the core trait, implemented for [`Sort`], [`Term`], and [`Command`].
-//! - [`Cvc5Env`] — holds a [`cvc5::TermManager`], a mutable reference to a [`Context`], and
-//!   caches for sort/term/symbol translation in both directions. Used as the environment
-//!   for `Sort::to_cvc5`, `Term::to_cvc5`, `CSort::conv_from_cvc5`, and `CTerm::conv_from_cvc5`.
+//! - [`Cvc5Env<'tm, Ctx>`] — holds a [`cvc5::TermManager`], a [`Context`] handle (any
+//!   `Ctx: HasMutRef<Context>` — e.g. `&mut Context`, `Rc<RefCell<Context>>`), and caches
+//!   for sort/term/symbol translation in both directions. Used as the environment for
+//!   `Sort::to_cvc5`, `Term::to_cvc5`, `CSort::conv_from_cvc5`, and `CTerm::conv_from_cvc5`.
 //! - [`Cvc5EnvSolver`] — wraps a [`Cvc5Env`] and a [`Solver`]. Used as the environment
 //!   for `Command::to_cvc5`, since commands may interact with the solver (e.g. `assert`,
 //!   `check-sat`, `define-fun`).
@@ -23,13 +24,17 @@
 //! # Backward translation
 //!
 //! - [`ConvertFromCvc5<Env>`] — the core trait, implemented for [`CSort`] and [`CTerm`].
-//! - [`Cvc5Env`] — also serves as the environment for backward translation, holding the
-//!   `Context` reference, scoped variable bindings, sort/term reverse caches, and a record
-//!   of uninterpreted sort values encountered.
+//! - [`Cvc5Env`] — also serves as the environment for backward translation, sharing the
+//!   sort/term caches with the forward direction, and additionally holding scoped variable
+//!   bindings and a record of uninterpreted sort values encountered.
 //!
 //! The backward translation handles constants, logical connectives, quantifiers (including
 //! `:pattern` annotations), arithmetic/bitvector/string operators, indexed operators,
 //! datatype constructors/selectors/testers, match expressions, and uninterpreted sort values.
+//!
+//! Command results that carry terms ([`CommandResult::GetValue`] and [`CommandResult::Terms`])
+//! are backward-translated into yaspar-ir [`Term`] values before being returned, so callers
+//! never see raw [`CTerm`] handles.
 //!
 //! # Example
 //!
@@ -57,15 +62,22 @@
 //!
 //! # Caching
 //!
-//! [`Cvc5Env`] caches translated sorts and terms in both directions so that repeated
-//! translations of the same hash-consed object (forward) or cvc5 object (backward)
-//! return the cached counterpart directly.
+//! [`Cvc5Env`] keeps a single [`BiHashMap`] for sorts and a single one for terms, shared by
+//! both directions: a forward translation that produces a `(yaspar, cvc5)` pair populates
+//! the cache, and a subsequent reverse translation of the same cvc5 object hits it without
+//! recomputing.
 //!
 //! # Annotations
 //!
 //! Quantifier `:pattern` annotations are preserved in both directions: translated to cvc5
 //! `INST_PATTERN` / `INST_PATTERN_LIST` terms in the forward direction, and reconstructed as
 //! `Attribute::Pattern` annotations in the backward direction.
+//!
+//! `:named` annotations on `assert` are recorded in a `CTerm → name` table during forward
+//! translation. When cvc5 returns terms that match a named assertion (e.g. via
+//! `get-unsat-core`, `get-assertions`, or `get-unsat-assumptions`), the recorded name is
+//! returned as a yaspar-ir global identifier rather than the assertion body — recovering
+//! the SMT-LIB label that cvc5's solver-level API would otherwise drop.
 
 use crate::ast::alg::VarBinding;
 use crate::ast::*;
@@ -102,11 +114,15 @@ pub enum CommandResult<'tm> {
     None,
     /// Result of `check-sat` or `check-sat-assuming`.
     CheckSat(CResult<'tm>),
-    /// Result of `get-value`: a list of terms.
+    /// Result of `get-value`: a list of yaspar-ir terms (each cvc5-returned value
+    /// is backward-translated into [`Term`]).
     GetValue(Vec<Term>),
     /// Result of `get-model`: the model as a string.
     GetModel(String),
-    /// Result of `get-assertions`, `get-unsat-core`, or `get-unsat-assumptions`: a list of terms.
+    /// Result of `get-assertions`, `get-unsat-core`, or `get-unsat-assumptions`: a list
+    /// of yaspar-ir terms. For each cvc5-returned formula, if its `CTerm` was registered
+    /// via an `(assert (! ... :named X))` form, `X` is returned as a global identifier;
+    /// otherwise the formula is backward-translated into a [`Term`].
     Terms(Vec<Term>),
     /// Result of `get-info` or `get-option`: a string response.
     Info(String),
@@ -189,18 +205,16 @@ type SortSubst<'tm> = Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)>;
 
 /// The unified environment for bidirectional translation between yaspar-ir and cvc5.
 ///
-/// This struct holds the [`TermManager`] reference, a mutable reference to a [`Context`],
-/// and all translation state for both directions:
+/// This struct holds the [`TermManager`] reference, a [`Context`] handle (any
+/// `Ctx: HasMutRef<Context>`, e.g. `&mut Context` or `Rc<RefCell<Context>>`), and all
+/// translation state for both directions:
 ///
-/// - **Forward (yaspar-ir → cvc5)**: sort/term caches, global and local symbol tables,
-///   datatype bookkeeping, and a memoization cache for hashconsed term translation.
-/// - **Backward (cvc5 → yaspar-ir)**: sort/term reverse caches, scoped variable bindings,
-///   and tracking of uninterpreted sort values.
-///
-/// It implements [`TermRecursor`] for stack-safe, memoized term translation. Because
-/// yaspar-ir terms are hashconsed, structurally identical sub-terms share the same
-/// pointer — the memoization layer (via the [`Memoizing`](crate::raw::alg::rec_memo)
-/// trait, pointing to `term_cache`) ensures each unique sub-term is translated at most once.
+/// - **Shared**: bidirectional [`BiHashMap`] caches for sorts and terms, plus a `CTerm →
+///   :named` table for recovering SMT-LIB labels in command results.
+/// - **Forward (yaspar-ir → cvc5)**: global and local symbol tables, datatype
+///   bookkeeping, scope stacks, and parametric-match substitutions.
+/// - **Backward (cvc5 → yaspar-ir)**: scoped variable bindings keyed by cvc5 ids and
+///   tracking of uninterpreted sort values.
 ///
 /// # Construction
 ///
@@ -214,43 +228,45 @@ type SortSubst<'tm> = Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)>;
 /// let mut env = Cvc5Env::new(&tm, &mut ctx);
 /// ```
 pub struct Cvc5Env<'tm, Ctx> {
+    // ── Shared (used by both forward and reverse translation) ────────────
     /// The cvc5 term manager that owns all created sorts and terms.
     tm: &'tm TermManager,
     /// The backing yaspar-ir context, used during reverse translation for arena
     /// allocation and theory-aware constant construction.
     ctx: Ctx,
+    /// Bidirectional cache between yaspar-ir [`Sort`] and translated [`CSort`].
+    /// Used for both forward and reverse sort translation.
+    sort_cache: BiHashMap<Sort, CSort<'tm>>,
+    /// Bidirectional cache between yaspar-ir [`Term`] and translated [`WithPattern`].
+    /// Used for forward memoization and reverse term lookup.
+    term_cache: BiHashMap<Term, WithPattern<'tm>>,
+    /// Reverse map from a translated assertion's [`CTerm`] back to the SMT-LIB `:named`
+    /// label(s) declared on its enclosing `(assert (! ... :named X))` form. Populated
+    /// during forward translation of `assert` commands and consulted during reverse
+    /// translation of cvc5-returned terms (e.g. `get-unsat-core`).
+    named_assertions: HashMap<CTerm<'tm>, Str>,
+
+    // ── Forward direction (yaspar-ir → cvc5) ─────────────────────────────
     /// Named sorts registered by `declare-sort` or datatype declarations.
     sort: HashMap<Str, CSort<'tm>>,
     /// Global symbols (constants, functions, constructors, selectors, testers).
     globals: HashMap<Str, CTerm<'tm>>,
-    /// Forward-direction local (bound) variables, keyed by their yaspar-ir local id.
-    locals: HashMap<usize, WithPattern<'tm>>,
-    /// Bidirectional cache between yaspar-ir [`Sort`] and translated [`CSort`].
-    /// Used for both forward and reverse sort translation.
-    sort_cache: BiHashMap<Sort, CSort<'tm>>,
     /// Datatype sorts mapping from names to their corresponding potentially polymorphic representations.
     dt_sorts: HashMap<Str, CSort<'tm>>,
+    /// Forward-direction local (bound) variables, keyed by their yaspar-ir local id.
+    locals: HashMap<usize, WithPattern<'tm>>,
     /// Stack of bound-variable lists for scope management in quantifiers and match arms (forward direction).
     scope_stack: Vec<Vec<CTerm<'tm>>>,
     /// Cached sort-parameter substitutions for parametric datatype match translation.
     sort_subst_map: HashMap<Term, SortSubst<'tm>>,
-    /// Bidirectional cache between yaspar-ir [`Term`] and translated [`WithPattern`].
-    /// Used for forward memoization and reverse term lookup. For reverse lookups, the
-    /// [`CTerm`] is wrapped into a `WithPattern` with empty patterns before looking up
-    /// on the right side. Quantifier translation produces a `WithPattern` whose patterns
-    /// have already been consumed into the quantifier itself, so the cached `WithPattern`
-    /// on a quantifier key has empty patterns (preserving the bijection on quantifiers).
-    term_cache: BiHashMap<Term, WithPattern<'tm>>,
+
+    // ── Reverse direction (cvc5 → yaspar-ir) ─────────────────────────────
     /// Backward-direction bound variable map: cvc5 term id → VarBinding.
     locals_from: HashMap<u64, VarBinding<Str, Sort>>,
     /// Stack of bound variable cvc5 ids for scope cleanup (backward direction).
     scope_stack_from: Vec<Vec<u64>>,
     /// Allocated symbols for uninterpreted sort values encountered during reverse translation.
     uninterpreted_values: HashSet<Str>,
-    /// Reverse map from a translated assertion's [`CTerm`] back to the SMT-LIB `:named`
-    /// label(s) declared on its enclosing `(assert (! ... :named X))` form.
-    /// Used to recover names when cvc5 returns terms in `get-unsat-core` etc.
-    named_assertions: HashMap<CTerm<'tm>, Str>,
 }
 
 impl<'tm, Ctx> Cvc5Env<'tm, Ctx>
@@ -262,18 +278,18 @@ where
         Self {
             tm,
             ctx,
+            sort_cache: BiHashMap::new(),
+            term_cache: BiHashMap::new(),
+            named_assertions: HashMap::new(),
             sort: HashMap::new(),
             globals: HashMap::new(),
-            locals: HashMap::new(),
-            sort_cache: BiHashMap::new(),
             dt_sorts: HashMap::new(),
+            locals: HashMap::new(),
             scope_stack: vec![],
             sort_subst_map: Default::default(),
-            term_cache: BiHashMap::new(),
             locals_from: HashMap::new(),
             scope_stack_from: Vec::new(),
             uninterpreted_values: HashSet::new(),
-            named_assertions: HashMap::new(),
         }
     }
 

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -75,7 +75,7 @@ use crate::raw::alg::CheckIdentifier;
 use crate::raw::alg::rec::TermRecursionScheme;
 use crate::raw::alg::rec_memo::{MemoizedRecursion, MemoizedScheme, Memoizing};
 use crate::statics::*;
-use crate::traits::{Contains, Repr};
+use crate::traits::{AllocatableString, Contains, HasMutRef, Repr};
 use crate::untyped::UntypedAst;
 use bimap::BiHashMap;
 pub use cvc5::{Kind, ProofComponent, Solver, TermManager};
@@ -213,23 +213,23 @@ type SortSubst<'tm> = Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)>;
 /// let mut ctx = Context::new();
 /// let mut env = Cvc5Env::new(&tm, &mut ctx);
 /// ```
-pub struct Cvc5Env<'tm, 'env> {
+pub struct Cvc5Env<'tm, Ctx> {
     /// The cvc5 term manager that owns all created sorts and terms.
     tm: &'tm TermManager,
     /// The backing yaspar-ir context, used during reverse translation for arena
     /// allocation and theory-aware constant construction.
-    pub ctx: &'env mut Context,
+    pub ctx: Ctx,
     /// Named sorts registered by `declare-sort` or datatype declarations.
-    sort: HashMap<String, CSort<'tm>>,
+    sort: HashMap<Str, CSort<'tm>>,
     /// Global symbols (constants, functions, constructors, selectors, testers).
-    globals: HashMap<String, CTerm<'tm>>,
+    globals: HashMap<Str, CTerm<'tm>>,
     /// Forward-direction local (bound) variables, keyed by their yaspar-ir local id.
     locals: HashMap<usize, WithPattern<'tm>>,
     /// Bidirectional cache between yaspar-ir [`Sort`] and translated [`CSort`].
     /// Used for both forward and reverse sort translation.
     sort_cache: BiHashMap<Sort, CSort<'tm>>,
     /// Datatype sorts mapping from names to their corresponding potentially polymorphic representations.
-    dt_sorts: HashMap<String, CSort<'tm>>,
+    dt_sorts: HashMap<Str, CSort<'tm>>,
     /// Stack of bound-variable lists for scope management in quantifiers and match arms (forward direction).
     scope_stack: Vec<Vec<CTerm<'tm>>>,
     /// Cached sort-parameter substitutions for parametric datatype match translation.
@@ -246,12 +246,15 @@ pub struct Cvc5Env<'tm, 'env> {
     /// Stack of bound variable cvc5 ids for scope cleanup (backward direction).
     scope_stack_from: Vec<Vec<u64>>,
     /// Allocated symbols for uninterpreted sort values encountered during reverse translation.
-    uninterpreted_values: HashSet<String>,
+    uninterpreted_values: HashSet<Str>,
 }
 
-impl<'tm, 'env> Cvc5Env<'tm, 'env> {
+impl<'tm, Ctx> Cvc5Env<'tm, Ctx>
+where
+    Ctx: HasMutRef<Context>,
+{
     /// Create a new translation environment backed by the given [`TermManager`] and [`Context`].
-    pub fn new(tm: &'tm TermManager, ctx: &'env mut Context) -> Self {
+    pub fn new(tm: &'tm TermManager, ctx: Ctx) -> Self {
         Self {
             tm,
             ctx,
@@ -270,12 +273,15 @@ impl<'tm, 'env> Cvc5Env<'tm, 'env> {
     }
 
     /// Returns whether the given symbol is an uninterpreted sort value.
-    pub fn is_uninterpreted_value(&self, name: &str) -> bool {
-        self.uninterpreted_values.contains(name)
+    pub fn check_uninterpreted_value<S: AllocatableString<Arena>>(&mut self, name: S) -> bool {
+        let sym = name.allocate(self.ctx.ref_mut().arena());
+        self.uninterpreted_values.contains(&sym)
     }
+}
 
+impl<'tm, Ctx> Cvc5Env<'tm, Ctx> {
     /// Returns the set of uninterpreted sort value names encountered.
-    pub fn uninterpreted_values(&self) -> &HashSet<String> {
+    pub fn uninterpreted_values(&self) -> &HashSet<Str> {
         &self.uninterpreted_values
     }
 
@@ -323,7 +329,7 @@ where
     }
 }
 
-impl<'tm, 'env> Memoizing<Term, WithPattern<'tm>> for Cvc5Env<'tm, 'env> {
+impl<'tm, Ctx> Memoizing<Term, WithPattern<'tm>> for Cvc5Env<'tm, Ctx> {
     type Cache<'a>
         = &'a mut BiHashMap<Term, WithPattern<'tm>>
     where
@@ -354,25 +360,25 @@ impl<'tm, 'env> Memoizing<Term, WithPattern<'tm>> for Cvc5Env<'tm, 'env> {
 /// let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
 /// // now use es.to_cvc5() on Command values
 /// ```
-pub struct Cvc5EnvSolver<'a, 'tm, 'env> {
+pub struct Cvc5EnvSolver<'a, 'tm, Ctx> {
     /// The translation environment for sorts and terms.
-    pub env: &'a mut Cvc5Env<'tm, 'env>,
+    pub env: &'a mut Cvc5Env<'tm, Ctx>,
     /// The cvc5 solver instance.
     pub solver: &'a mut Solver<'tm>,
 }
 
-impl<'a, 'tm, 'env> Cvc5EnvSolver<'a, 'tm, 'env> {
+impl<'a, 'tm, Ctx> Cvc5EnvSolver<'a, 'tm, Ctx> {
     /// Create a new command-translation environment from a [`Cvc5Env`] and a [`Solver`].
-    pub fn new(env: &'a mut Cvc5Env<'tm, 'env>, solver: &'a mut Solver<'tm>) -> Self {
+    pub fn new(env: &'a mut Cvc5Env<'tm, Ctx>, solver: &'a mut Solver<'tm>) -> Self {
         Self { env, solver }
     }
 }
 
 // ── Sort translation ─────────────────────────────────────────
-impl<'tm, 'env> ConvertToCvc5<Cvc5Env<'tm, 'env>> for Sort {
+impl<'tm, Ctx> ConvertToCvc5<Cvc5Env<'tm, Ctx>> for Sort {
     type Output = CSort<'tm>;
 
-    fn to_cvc5(&self, env: &mut Cvc5Env<'tm, 'env>) -> Res<CSort<'tm>> {
+    fn to_cvc5(&self, env: &mut Cvc5Env<'tm, Ctx>) -> Res<CSort<'tm>> {
         if let Some(cs) = env.sort_cache.get_by_left(self) {
             return Ok(cs.clone());
         }
@@ -382,9 +388,9 @@ impl<'tm, 'env> ConvertToCvc5<Cvc5Env<'tm, 'env>> for Sort {
     }
 }
 
-fn translate_sort_inner<'tm, 'env>(sort: &Sort, env: &mut Cvc5Env<'tm, 'env>) -> Res<CSort<'tm>> {
+fn translate_sort_inner<'tm, Ctx>(sort: &Sort, env: &mut Cvc5Env<'tm, Ctx>) -> Res<CSort<'tm>> {
     let s = sort.repr();
-    let name = &s.sort_name().to_string();
+    let name = s.sort_name();
     if let Some(n) = s.is_bv() {
         let w: u32 = n
             .clone()
@@ -436,10 +442,13 @@ fn translate_sort_inner<'tm, 'env>(sort: &Sort, env: &mut Cvc5Env<'tm, 'env>) ->
 
 // ── Reverse sort translation (CSort → Sort) ─────────────────
 
-impl<'tm, 'env> ConvertFromCvc5<Cvc5Env<'tm, 'env>> for CSort<'tm> {
+impl<'tm, Ctx> ConvertFromCvc5<Cvc5Env<'tm, Ctx>> for CSort<'tm>
+where
+    Ctx: HasMutRef<Context>,
+{
     type Output = Sort;
 
-    fn conv_from_cvc5(&self, fenv: &mut Cvc5Env<'tm, 'env>) -> Res<Sort> {
+    fn conv_from_cvc5(&self, fenv: &mut Cvc5Env<'tm, Ctx>) -> Res<Sort> {
         if let Some(s) = fenv.sort_cache.get_by_right(self) {
             return Ok(s.clone());
         }
@@ -449,32 +458,32 @@ impl<'tm, 'env> ConvertFromCvc5<Cvc5Env<'tm, 'env>> for CSort<'tm> {
     }
 }
 
-fn translate_sort_from_cvc5<'tm, 'env>(
-    cs: &CSort<'tm>,
-    fenv: &mut Cvc5Env<'tm, 'env>,
-) -> Res<Sort> {
+fn translate_sort_from_cvc5<'tm, Ctx>(cs: &CSort<'tm>, fenv: &mut Cvc5Env<'tm, Ctx>) -> Res<Sort>
+where
+    Ctx: HasMutRef<Context>,
+{
     if cs.is_boolean() {
-        return Ok(fenv.ctx.bool_sort());
+        return Ok(fenv.ctx.ref_mut().bool_sort());
     }
     if cs.is_integer() {
-        return Ok(fenv.ctx.int_sort());
+        return Ok(fenv.ctx.ref_mut().int_sort());
     }
     if cs.is_real() {
-        return Ok(fenv.ctx.real_sort());
+        return Ok(fenv.ctx.ref_mut().real_sort());
     }
     if cs.is_string() {
-        return Ok(fenv.ctx.string_sort());
+        return Ok(fenv.ctx.ref_mut().string_sort());
     }
     if cs.is_regexp() {
-        return Ok(fenv.ctx.reglan_sort());
+        return Ok(fenv.ctx.ref_mut().reglan_sort());
     }
     if cs.is_bv() {
-        return Ok(fenv.ctx.bv_sort(cs.bv_size().into()));
+        return Ok(fenv.ctx.ref_mut().bv_sort(cs.bv_size().into()));
     }
     if cs.is_array() {
         let idx = cs.array_index_sort().conv_from_cvc5(fenv)?;
         let elem = cs.array_element_sort().conv_from_cvc5(fenv)?;
-        return Ok(fenv.ctx.array_sort(idx, elem));
+        return Ok(fenv.ctx.ref_mut().array_sort(idx, elem));
     }
     // Instantiated parametric datatype (e.g. (List Int))
     if cs.is_dt() && cs.is_instantiated() {
@@ -482,14 +491,15 @@ fn translate_sort_from_cvc5<'tm, 'env>(
         let name = dt.name();
         let params = cs.instantiated_parameters();
         let ir_params: Vec<Sort> = params.conv_from_cvc5(fenv)?;
-        let sym = fenv.ctx.allocate_symbol(name);
-        return Ok(fenv.ctx.sort_n(sym, ir_params));
+        let mut rf = fenv.ctx.ref_mut();
+        let sym = rf.allocate_symbol(name);
+        return Ok(rf.sort_n(sym, ir_params));
     }
     // Monomorphic datatype sort
     if cs.is_dt() {
         let dt = cs.datatype();
         let name = dt.name();
-        return Ok(fenv.ctx.simple_sort(name));
+        return Ok(fenv.ctx.ref_mut().simple_sort(name));
     }
     // Instantiated parametric uninterpreted sort (e.g. (Pair A B))
     if cs.is_instantiated() {
@@ -500,34 +510,38 @@ fn translate_sort_from_cvc5<'tm, 'env>(
             .iter()
             .map(|p| p.conv_from_cvc5(fenv))
             .collect::<Res<_>>()?;
-        let sym = fenv.ctx.allocate_symbol(name);
-        return Ok(fenv.ctx.sort_n(sym, ir_params));
+        let mut rf = fenv.ctx.ref_mut();
+        let sym = rf.allocate_symbol(name);
+        return Ok(rf.sort_n(sym, ir_params));
     }
     // Uninterpreted sort
     if cs.is_uninterpreted_sort() {
         let name = cs.symbol();
-        return Ok(fenv.ctx.simple_sort(name));
+        return Ok(fenv.ctx.ref_mut().simple_sort(name));
     }
     Err(format!("unsupported cvc5 sort: {cs}"))
 }
 
 // ── Term: cvc5 → yaspar-ir ───────────────────────────────────
 
-impl<'tm, 'env, T> ConvertFromCvc5<Cvc5Env<'tm, 'env>> for [T]
+impl<'tm, Ctx, T> ConvertFromCvc5<Cvc5Env<'tm, Ctx>> for [T]
 where
-    T: ConvertFromCvc5<Cvc5Env<'tm, 'env>>,
+    T: ConvertFromCvc5<Cvc5Env<'tm, Ctx>>,
 {
     type Output = Vec<T::Output>;
 
-    fn conv_from_cvc5(&self, env: &mut Cvc5Env<'tm, 'env>) -> Res<Self::Output> {
+    fn conv_from_cvc5(&self, env: &mut Cvc5Env<'tm, Ctx>) -> Res<Self::Output> {
         self.iter().map(|s| s.conv_from_cvc5(env)).collect()
     }
 }
 
-impl<'tm, 'env> ConvertFromCvc5<Cvc5Env<'tm, 'env>> for CTerm<'tm> {
+impl<'tm, Ctx> ConvertFromCvc5<Cvc5Env<'tm, Ctx>> for CTerm<'tm>
+where
+    Ctx: HasMutRef<Context>,
+{
     type Output = Term;
 
-    fn conv_from_cvc5(&self, fenv: &mut Cvc5Env<'tm, 'env>) -> Res<Term> {
+    fn conv_from_cvc5(&self, fenv: &mut Cvc5Env<'tm, Ctx>) -> Res<Term> {
         // Reverse lookup: a plain CTerm corresponds to a `WithPattern` with empty
         // patterns (the quantifier case never reaches us as a standalone CTerm).
         let key = WithPattern::from(self.clone());
@@ -540,18 +554,17 @@ impl<'tm, 'env> ConvertFromCvc5<Cvc5Env<'tm, 'env>> for CTerm<'tm> {
     }
 }
 
-fn translate_term_from_cvc5<'tm, 'env>(
-    ct: &CTerm<'tm>,
-    fenv: &mut Cvc5Env<'tm, 'env>,
-) -> Res<Term> {
+fn translate_term_from_cvc5<'tm, Ctx>(ct: &CTerm<'tm>, fenv: &mut Cvc5Env<'tm, Ctx>) -> Res<Term>
+where
+    Ctx: HasMutRef<Context>,
+{
     let kind = ct.kind();
 
     // ── Constants ────────────────────────────────────────────
     if ct.is_boolean_value() {
-        let sort = Some(fenv.ctx.bool_sort());
-        return Ok(fenv
-            .ctx
-            .allocate_term(ATerm::Constant(Constant::Bool(ct.boolean_value()), sort)));
+        let mut rf = fenv.ctx.ref_mut();
+        let sort = Some(rf.bool_sort());
+        return Ok(rf.allocate_term(ATerm::Constant(Constant::Bool(ct.boolean_value()), sort)));
     }
     if ct.is_integer_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
@@ -561,46 +574,39 @@ fn translate_term_from_cvc5<'tm, 'env>(
             .map_err(|e| format!("Big integer parse error: {e}"))?;
         return Ok(fenv
             .ctx
+            .ref_mut()
             .allocate_term(ATerm::Constant(Constant::Numeral(n), Some(sort))));
     }
     if ct.is_real_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
         let s = ct.real_value();
-        let has_ints = fenv.ctx.get_theories().iter().any(|t| t.has_int());
+        let mut rf = fenv.ctx.ref_mut();
+        let has_ints = rf.get_theories().iter().any(|t| t.has_int());
         // cvc5 returns rationals as "num/den" or just "num"
         if let Some((num_s, den_s)) = s.split_once('/') {
             let (numer, denom) = if has_ints {
                 // In RealInts, numerals are Int; use Decimal constants for Real division
                 let n = Constant::Decimal(format!("{num_s}.0").parse().unwrap());
                 let d = Constant::Decimal(format!("{den_s}.0").parse().unwrap());
-                let numer = fenv
-                    .ctx
-                    .allocate_term(ATerm::Constant(n, Some(sort.clone())));
-                let denom = fenv
-                    .ctx
-                    .allocate_term(ATerm::Constant(d, Some(sort.clone())));
+                let numer = rf.allocate_term(ATerm::Constant(n, Some(sort.clone())));
+                let denom = rf.allocate_term(ATerm::Constant(d, Some(sort.clone())));
                 (numer, denom)
             } else {
                 let num: UBig = num_s.parse().map_err(|e| format!("{e}"))?;
                 let den: UBig = den_s.parse().map_err(|e| format!("{e}"))?;
-                let int = fenv.ctx.int_sort();
-                let numer = fenv
-                    .ctx
-                    .allocate_term(ATerm::Constant(Constant::Numeral(num), Some(int.clone())));
-                let denom = fenv
-                    .ctx
-                    .allocate_term(ATerm::Constant(Constant::Numeral(den), Some(int)));
+                let int = rf.int_sort();
+                let numer =
+                    rf.allocate_term(ATerm::Constant(Constant::Numeral(num), Some(int.clone())));
+                let denom = rf.allocate_term(ATerm::Constant(Constant::Numeral(den), Some(int)));
                 (numer, denom)
             };
-            let sym = fenv.ctx.allocate_symbol(RDIV);
+            let sym = rf.allocate_symbol(RDIV);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.ctx.app(qid, vec![numer, denom], Some(sort)));
+            return Ok(rf.app(qid, vec![numer, denom], Some(sort)));
         }
         // No division — parse as a single decimal
         let n: dashu::float::DBig = format!("{s}.0").parse().map_err(|e| format!("{e}"))?;
-        return Ok(fenv
-            .ctx
-            .allocate_term(ATerm::Constant(Constant::Decimal(n), Some(sort))));
+        return Ok(rf.allocate_term(ATerm::Constant(Constant::Decimal(n), Some(sort))));
     }
     if ct.is_string_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
@@ -610,10 +616,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
             .map(|&c| char::from_u32(c).unwrap_or('\u{FFFD}'))
             .collect();
 
-        let str_val = fenv.ctx.allocate_str(&s);
-        return Ok(fenv
-            .ctx
-            .allocate_term(ATerm::Constant(Constant::String(str_val), Some(sort))));
+        let mut rf = fenv.ctx.ref_mut();
+        let str_val = rf.allocate_str(&s);
+        return Ok(rf.allocate_term(ATerm::Constant(Constant::String(str_val), Some(sort))));
     }
     if ct.is_bv_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
@@ -629,6 +634,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
 
         return Ok(fenv
             .ctx
+            .ref_mut()
             .allocate_term(ATerm::Constant(Constant::Binary(bytes, len), Some(sort))));
     }
 
@@ -636,23 +642,19 @@ fn translate_term_from_cvc5<'tm, 'env>(
     match kind {
         Kind::And => {
             let children = translate_children(ct, fenv)?;
-
-            return Ok(fenv.ctx.and(children));
+            return Ok(fenv.ctx.ref_mut().and(children));
         }
         Kind::Or => {
             let children = translate_children(ct, fenv)?;
-
-            return Ok(fenv.ctx.or(children));
+            return Ok(fenv.ctx.ref_mut().or(children));
         }
         Kind::Xor => {
             let children = translate_children(ct, fenv)?;
-
-            return Ok(fenv.ctx.xor(children));
+            return Ok(fenv.ctx.ref_mut().xor(children));
         }
         Kind::Not => {
             let child = ct.child(0).conv_from_cvc5(fenv)?;
-
-            return Ok(fenv.ctx.not(child));
+            return Ok(fenv.ctx.ref_mut().not(child));
         }
         Kind::Implies => {
             let n = ct.num_children();
@@ -662,32 +664,33 @@ fn translate_term_from_cvc5<'tm, 'env>(
             }
             let concl = ct.child(n - 1).conv_from_cvc5(fenv)?;
 
-            return Ok(fenv.ctx.implies(premises, concl));
+            return Ok(fenv.ctx.ref_mut().implies(premises, concl));
         }
         Kind::Equal => {
             let children = translate_children(ct, fenv)?;
+            let mut rf = fenv.ctx.ref_mut();
 
             if children.len() == 2 {
-                return Ok(fenv.ctx.eq(children[0].clone(), children[1].clone()));
+                return Ok(rf.eq(children[0].clone(), children[1].clone()));
             }
             // Chain: (= a b c) → (and (= a b) (= b c))
             let mut eqs = Vec::with_capacity(children.len() - 1);
             for i in 0..children.len() - 1 {
-                eqs.push(fenv.ctx.eq(children[i].clone(), children[i + 1].clone()));
+                eqs.push(rf.eq(children[i].clone(), children[i + 1].clone()));
             }
-            return Ok(fenv.ctx.and(eqs));
+            return Ok(rf.and(eqs));
         }
         Kind::Distinct => {
             let children = translate_children(ct, fenv)?;
 
-            return Ok(fenv.ctx.distinct(children));
+            return Ok(fenv.ctx.ref_mut().distinct(children));
         }
         Kind::Ite => {
             let b = ct.child(0).conv_from_cvc5(fenv)?;
             let t = ct.child(1).conv_from_cvc5(fenv)?;
             let e = ct.child(2).conv_from_cvc5(fenv)?;
 
-            return Ok(fenv.ctx.ite(b, t, e));
+            return Ok(fenv.ctx.ref_mut().ite(b, t, e));
         }
         // ── Quantifiers ─────────────────────────────────────────
         Kind::Forall | Kind::Exists => {
@@ -700,8 +703,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 let name = v.symbol().to_string();
                 let vs = v.sort().conv_from_cvc5(fenv)?;
 
-                let id = fenv.ctx.new_local();
-                let sym = fenv.ctx.allocate_symbol(&name);
+                let mut rf = fenv.ctx.ref_mut();
+                let id = rf.new_local();
+                let sym = rf.allocate_symbol(&name);
                 fenv.locals_from.insert(cvc5_id, VarBinding(sym, id, vs));
                 scope_ids.push(cvc5_id);
             }
@@ -750,7 +754,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
                             ))
                         })
                         .collect::<Res<Vec<_>>>()?;
-                    let annotated = fenv.ctx.annotated(body, attrs);
+                    let annotated = fenv.ctx.ref_mut().annotated(body, attrs);
                     // Mirror the forward-direction shape: `Annotated(body, [:pattern …])`
                     // maps to a `WithPattern` whose `term` is the body's CTerm and whose
                     // `patterns` carry the pattern triggers (later absorbed into
@@ -764,9 +768,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let body = result?;
 
             return if kind == Kind::Forall {
-                Ok(fenv.ctx.forall(bindings, body))
+                Ok(fenv.ctx.ref_mut().forall(bindings, body))
             } else {
-                Ok(fenv.ctx.exists(bindings, body))
+                Ok(fenv.ctx.ref_mut().exists(bindings, body))
             };
         }
         // ── Negation (unary minus) ──────────────────────────────
@@ -774,9 +778,10 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let child = ct.child(0).conv_from_cvc5(fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.ctx.allocate_symbol(SUB);
+            let mut rf = fenv.ctx.ref_mut();
+            let sym = rf.allocate_symbol(SUB);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.ctx.app(qid, vec![child], Some(sort)));
+            return Ok(rf.app(qid, vec![child], Some(sort)));
         }
 
         // ── Function application (UF, constructors, selectors, testers) ──
@@ -785,9 +790,10 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let name = ct.symbol().to_string();
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.ctx.allocate_symbol(&name);
+            let mut rf = fenv.ctx.ref_mut();
+            let sym = rf.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.ctx.global(qid, Some(sort)));
+            return Ok(rf.global(qid, Some(sort)));
         }
         Kind::ApplyUf => {
             let head = ct.child(0);
@@ -798,9 +804,10 @@ fn translate_term_from_cvc5<'tm, 'env>(
             }
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.ctx.allocate_symbol(&name);
+            let mut rf = fenv.ctx.ref_mut();
+            let sym = rf.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.ctx.app(qid, args, Some(sort)));
+            return Ok(rf.app(qid, args, Some(sort)));
         }
         Kind::ApplyConstructor => {
             let head = ct.child(0);
@@ -831,13 +838,14 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 // Nullary constructor → global
                 let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-                let sym = fenv.ctx.allocate_symbol(&name);
+                let mut rf = fenv.ctx.ref_mut();
+                let sym = rf.allocate_symbol(&name);
                 let qid = if ct.sort().is_dt() && ct.sort().datatype().is_parametric() {
                     QualifiedIdentifier::simple_sorted(sym, sort.clone())
                 } else {
                     QualifiedIdentifier::simple(sym)
                 };
-                return Ok(fenv.ctx.global(qid, Some(sort)));
+                return Ok(rf.global(qid, Some(sort)));
             }
             let mut args = Vec::with_capacity(n - 1);
             for i in 1..n {
@@ -845,9 +853,10 @@ fn translate_term_from_cvc5<'tm, 'env>(
             }
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.ctx.allocate_symbol(&name);
+            let mut rf = fenv.ctx.ref_mut();
+            let sym = rf.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.ctx.app(qid, args, Some(sort)));
+            return Ok(rf.app(qid, args, Some(sort)));
         }
         Kind::ApplySelector => {
             let head = ct.child(0);
@@ -859,9 +868,10 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let arg = ct.child(1).conv_from_cvc5(fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.ctx.allocate_symbol(&name);
+            let mut rf = fenv.ctx.ref_mut();
+            let sym = rf.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.ctx.app(qid, vec![arg], Some(sort)));
+            return Ok(rf.app(qid, vec![arg], Some(sort)));
         }
         Kind::ApplyTester => {
             let head = ct.child(0);
@@ -875,21 +885,22 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let arg = ct.child(1).conv_from_cvc5(fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let is_sym = fenv.ctx.allocate_symbol(IS);
-            let ctor_sym = fenv.ctx.allocate_symbol(ctor_name);
+            let mut rf = fenv.ctx.ref_mut();
+            let is_sym = rf.allocate_symbol(IS);
+            let ctor_sym = rf.allocate_symbol(ctor_name);
             let id = alg::Identifier {
                 symbol: is_sym,
                 indices: vec![Index::Symbol(ctor_sym)],
             };
             let qid = QualifiedIdentifier::from(id);
-            return Ok(fenv.ctx.app(qid, vec![arg], Some(sort)));
+            return Ok(rf.app(qid, vec![arg], Some(sort)));
         }
 
         // ── Variable (bound) ────────────────────────────────────
         Kind::Variable => {
             let cvc5_id = ct.id();
             if let Some(vb) = fenv.locals_from.get(&cvc5_id) {
-                return Ok(fenv.ctx.local(alg::Local {
+                return Ok(fenv.ctx.ref_mut().local(alg::Local {
                     id: vb.1,
                     symbol: vb.0.clone(),
                     sort: vb.2.clone(),
@@ -904,9 +915,10 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let ik = cvc5_kind_to_ident_kind(kind).unwrap();
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.ctx.allocate_symbol(ik.name());
+            let mut rf = fenv.ctx.ref_mut();
+            let sym = rf.allocate_symbol(ik.name());
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.ctx.global(qid, Some(sort)));
+            return Ok(rf.global(qid, Some(sort)));
         }
 
         // ── BitvectorToNat ──────────────────────────────────────
@@ -914,9 +926,10 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let child = ct.child(0).conv_from_cvc5(fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.ctx.allocate_symbol(BV2NAT);
+            let mut rf = fenv.ctx.ref_mut();
+            let sym = rf.allocate_symbol(BV2NAT);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.ctx.app(qid, vec![child], Some(sort)));
+            return Ok(rf.app(qid, vec![child], Some(sort)));
         }
 
         // ── Match expressions ───────────────────────────────────
@@ -930,25 +943,27 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 arms.push(arm);
             }
 
-            return Ok(fenv.ctx.matching(scrutinee, arms));
+            return Ok(fenv.ctx.ref_mut().matching(scrutinee, arms));
         }
         // ── Const array ──────────────────────────────────────────
         Kind::ConstArray => {
             let value = ct.const_array_base().conv_from_cvc5(fenv)?;
             let arr_sort = ct.sort().conv_from_cvc5(fenv)?;
-            let sym = fenv.ctx.allocate_symbol(CONST);
+            let mut rf = fenv.ctx.ref_mut();
+            let sym = rf.allocate_symbol(CONST);
             let qid = QualifiedIdentifier::simple_sorted(sym, arr_sort.clone());
-            return Ok(fenv.ctx.app(qid, vec![value], Some(arr_sort)));
+            return Ok(rf.app(qid, vec![value], Some(arr_sort)));
         }
 
         // ── Uninterpreted sort value (from models) ──────────────
         Kind::UninterpretedSortValue => {
             let name = ct.uninterpreted_sort_value();
             let sort = ct.sort().conv_from_cvc5(fenv)?;
-            fenv.uninterpreted_values.insert(name.clone());
-            let sym = fenv.ctx.allocate_symbol(&name);
+            let mut rf = fenv.ctx.ref_mut();
+            let sym = rf.allocate_symbol(&name);
+            fenv.uninterpreted_values.insert(sym.clone());
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.ctx.global(qid, Some(sort)));
+            return Ok(rf.global(qid, Some(sort)));
         }
 
         // ── Lambda ──────────────────────────────────────────────
@@ -986,9 +1001,10 @@ fn translate_term_from_cvc5<'tm, 'env>(
         let sort = ct.sort().conv_from_cvc5(fenv)?;
 
         let name = ik.name();
-        let sym = fenv.ctx.allocate_symbol(name);
+        let mut rf = fenv.ctx.ref_mut();
+        let sym = rf.allocate_symbol(name);
         let qid = QualifiedIdentifier::simple(sym);
-        return Ok(fenv.ctx.app(qid, children, Some(sort)));
+        return Ok(rf.app(qid, children, Some(sort)));
     }
 
     // ── Indexed operators ───────────────────────────────────
@@ -1002,7 +1018,10 @@ fn translate_term_from_cvc5<'tm, 'env>(
     Err(format!("unsupported cvc5 term kind: {:?}", kind))
 }
 
-fn translate_children<'tm, 'env>(ct: &CTerm<'tm>, fenv: &mut Cvc5Env<'tm, 'env>) -> Res<Vec<Term>> {
+fn translate_children<'tm, Ctx>(ct: &CTerm<'tm>, fenv: &mut Cvc5Env<'tm, Ctx>) -> Res<Vec<Term>>
+where
+    Ctx: HasMutRef<Context>,
+{
     let n = ct.num_children();
     let mut children = Vec::with_capacity(n);
     for i in 0..n {
@@ -1011,10 +1030,13 @@ fn translate_children<'tm, 'env>(ct: &CTerm<'tm>, fenv: &mut Cvc5Env<'tm, 'env>)
     Ok(children)
 }
 
-fn translate_match_case_from_cvc5<'tm, 'env>(
+fn translate_match_case_from_cvc5<'tm, Ctx>(
     case: &CTerm<'tm>,
-    fenv: &mut Cvc5Env<'tm, 'env>,
-) -> Res<alg::PatternArm<Str, Term>> {
+    fenv: &mut Cvc5Env<'tm, Ctx>,
+) -> Res<alg::PatternArm<Str, Term>>
+where
+    Ctx: HasMutRef<Context>,
+{
     let case_kind = case.kind();
     match case_kind {
         Kind::MatchCase => {
@@ -1048,7 +1070,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
             };
             let body = case.child(1).conv_from_cvc5(fenv)?;
 
-            let sym = fenv.ctx.allocate_symbol(&ctor_name);
+            let sym = fenv.ctx.ref_mut().allocate_symbol(&ctor_name);
             Ok(alg::PatternArm {
                 pattern: Pattern::Ctor(sym),
                 body,
@@ -1070,8 +1092,10 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
 
                 if v.has_symbol() {
                     let name = v.symbol().to_string();
-                    let id = fenv.ctx.new_local();
-                    let sym = fenv.ctx.allocate_symbol(&name);
+                    let mut rf = fenv.ctx.ref_mut();
+                    let id = rf.new_local();
+                    let sym = rf.allocate_symbol(&name);
+                    drop(rf);
                     let vb = VarBinding(sym.clone(), id, vs);
                     fenv.locals_from.insert(cvc5_id, vb);
                     fenv.push_scope_from(vec![cvc5_id]);
@@ -1111,8 +1135,9 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
                     if arg.has_symbol() {
                         let name = arg.symbol().to_string();
                         let vs = arg.sort().conv_from_cvc5(fenv)?;
-                        let id = fenv.ctx.new_local();
-                        let sym = fenv.ctx.allocate_symbol(&name);
+                        let mut rf = fenv.ctx.ref_mut();
+                        let id = rf.new_local();
+                        let sym = rf.allocate_symbol(&name);
                         fenv.locals_from
                             .insert(cvc5_id, VarBinding(sym.clone(), id, vs));
                         arguments.push(Some((sym, id)));
@@ -1126,7 +1151,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
                 fenv.pop_scope_from();
                 let body = result?;
 
-                let ctor_sym = fenv.ctx.allocate_symbol(&ctor_name);
+                let ctor_sym = fenv.ctx.ref_mut().allocate_symbol(&ctor_name);
                 Ok(alg::PatternArm {
                     pattern: Pattern::Applied {
                         ctor: ctor_sym,
@@ -1140,11 +1165,14 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
     }
 }
 
-fn translate_indexed_from_cvc5<'tm, 'env>(
+fn translate_indexed_from_cvc5<'tm, Ctx>(
     ct: &CTerm<'tm>,
     op: &cvc5::Op<'tm>,
-    fenv: &mut Cvc5Env<'tm, 'env>,
-) -> Res<Option<Term>> {
+    fenv: &mut Cvc5Env<'tm, Ctx>,
+) -> Res<Option<Term>>
+where
+    Ctx: HasMutRef<Context>,
+{
     let op_kind = op.kind();
     let children = translate_children(ct, fenv)?;
     let sort = ct.sort().conv_from_cvc5(fenv)?;
@@ -1176,13 +1204,14 @@ fn translate_indexed_from_cvc5<'tm, 'env>(
         _ => return Ok(None),
     };
 
-    let sym = fenv.ctx.allocate_symbol(name);
+    let mut rf = fenv.ctx.ref_mut();
+    let sym = rf.allocate_symbol(name);
     let id = alg::Identifier {
         symbol: sym,
         indices,
     };
     let qid = QualifiedIdentifier::from(id);
-    Ok(Some(fenv.ctx.app(qid, children, Some(sort))))
+    Ok(Some(rf.app(qid, children, Some(sort))))
 }
 
 /// Reverse mapping from cvc5 Kind to yaspar-ir IdentifierKind.
@@ -1380,10 +1409,10 @@ fn ident_kind_to_cvc5(k: &IdentifierKind) -> Option<Kind> {
 }
 
 // ── Term translation ─────────────────────────────────────────
-impl<'tm, 'env> ConvertToCvc5<Cvc5Env<'tm, 'env>> for Term {
+impl<'tm, Ctx> ConvertToCvc5<Cvc5Env<'tm, Ctx>> for Term {
     type Output = CTerm<'tm>;
 
-    fn to_cvc5(&self, env: &mut Cvc5Env<'tm, 'env>) -> Res<Self::Output> {
+    fn to_cvc5(&self, env: &mut Cvc5Env<'tm, Ctx>) -> Res<Self::Output> {
         let mut wrapped = MemoizedRecursion(env);
         MemoizedScheme::term_recursion(&mut wrapped, self).map(|t| t.into())
     }
@@ -1393,7 +1422,7 @@ fn to_term_vec(terms: Vec<WithPattern>) -> Vec<CTerm> {
     terms.into_iter().map(|t| t.into()).collect()
 }
 
-impl<'tm, 'env> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm, 'env> {
+impl<'tm, Ctx> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm, Ctx> {
     type Out = WithPattern<'tm>;
     type Attr = Vec<Vec<CTerm<'tm>>>;
     type Binding = (usize, WithPattern<'tm>);
@@ -1797,7 +1826,7 @@ impl<'tm, 'env> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm, 'env> {
     }
 }
 
-impl<'tm, 'env> TypedTermRecursor for Cvc5Env<'tm, 'env> {}
+impl<'tm, Ctx> TypedTermRecursor for Cvc5Env<'tm, Ctx> {}
 
 impl<T, Env, E> ConvertToCvc5<Env> for [T]
 where
@@ -1829,7 +1858,7 @@ fn is_const(t: &CTerm) -> bool {
         && (0..t.num_children()).all(|i| is_const(&t.child(i))))
 }
 
-impl<'tm, 'env> Cvc5Env<'tm, 'env> {
+impl<'tm, Ctx> Cvc5Env<'tm, Ctx> {
     fn translate_constant(&self, c: &Constant, s: &Sort) -> Res<WithPattern<'tm>> {
         use alg::Constant::*;
         match c {
@@ -1877,7 +1906,7 @@ impl<'tm, 'env> Cvc5Env<'tm, 'env> {
     /// instantiated term if the datatype is parametric. Returns `None` when the sort
     /// is not in the sort table, the datatype is not parametric, or no constructor matches.
     fn resolve_parametric_ctor(&mut self, name: &str, sort: &Sort) -> Res<Option<CTerm<'tm>>> {
-        let sort_name = &sort.sort_name().to_string();
+        let sort_name = sort.sort_name();
         if let Some(base_sort) = self.sort.get(sort_name).cloned() {
             let dt = base_sort.datatype();
             if dt.is_parametric() {
@@ -1899,7 +1928,7 @@ impl<'tm, 'env> Cvc5Env<'tm, 'env> {
         sort: &Sort,
     ) -> Res<WithPattern<'tm>> {
         use alg::IdentifierKind::*;
-        let name = &qid.id_str().to_string();
+        let name = qid.id_str();
         match qid.get_kind() {
             Some(Char(hex, _)) => Ok(self
                 .tm
@@ -1923,7 +1952,7 @@ impl<'tm, 'env> Cvc5Env<'tm, 'env> {
                     .ok_or_else(|| format!("unknown global symbol: {name}"))?;
                 let is_ctor = t.sort().is_dt_constructor();
                 if is_ctor {
-                    if let Some(ct) = self.resolve_parametric_ctor(name, sort)? {
+                    if let Some(ct) = self.resolve_parametric_ctor(name.as_str(), sort)? {
                         Ok(self.tm.mk_term(Kind::ApplyConstructor, &[ct]).into())
                     } else {
                         Ok(self.tm.mk_term(Kind::ApplyConstructor, &[t]).into())
@@ -2026,11 +2055,11 @@ impl<'tm, 'env> Cvc5Env<'tm, 'env> {
         if let Some(ref ik) = kind {
             return self.translate_indexed_app(ik, cargs);
         }
-        let name = &id.symbol.to_string();
+        let name = &id.symbol;
         if let Some(f) = self.globals.get(name).cloned() {
             let fs = f.sort();
             if fs.is_dt_constructor() {
-                if let Some(ct) = self.resolve_parametric_ctor(name, rs)? {
+                if let Some(ct) = self.resolve_parametric_ctor(name.as_str(), rs)? {
                     Ok(self.mk_applied(Kind::ApplyConstructor, ct, cargs))
                 } else {
                     Ok(self.mk_applied(Kind::ApplyConstructor, f, cargs))
@@ -2093,10 +2122,13 @@ impl<'tm, 'env> Cvc5Env<'tm, 'env> {
 }
 
 // ── Command translation ──────────────────────────────────────
-impl<'tm> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm, '_>> for Command {
+impl<'tm, Ctx> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm, Ctx>> for Command
+where
+    Ctx: HasMutRef<Context>,
+{
     type Output = CommandResult<'tm>;
 
-    fn to_cvc5(&self, es: &mut Cvc5EnvSolver<'_, 'tm, '_>) -> Res<Self::Output> {
+    fn to_cvc5(&self, es: &mut Cvc5EnvSolver<'_, 'tm, Ctx>) -> Res<Self::Output> {
         use alg::Command as AC;
         let env = &mut *es.env;
         let solver = &mut *es.solver;
@@ -2124,19 +2156,19 @@ impl<'tm> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm, '_>> for Command {
             AC::DeclareConst(name, sort) => {
                 let cs = sort.to_cvc5(env)?;
                 let ct = env.tm.mk_const(cs, name);
-                env.globals.insert(name.to_string(), ct);
+                env.globals.insert(name.clone(), ct);
                 Ok(CommandResult::None)
             }
             AC::DeclareFun(name, inp, out) => {
                 let co = out.to_cvc5(env)?;
                 if inp.is_empty() {
                     let ct = env.tm.mk_const(co, name);
-                    env.globals.insert(name.to_string(), ct);
+                    env.globals.insert(name.clone(), ct);
                 } else {
                     let ci = inp.to_cvc5(env)?;
                     let fs = env.tm.mk_fun_sort(&ci, co);
                     let ct = env.tm.mk_const(fs, name);
-                    env.globals.insert(name.to_string(), ct);
+                    env.globals.insert(name.clone(), ct);
                 }
                 Ok(CommandResult::None)
             }
@@ -2146,7 +2178,7 @@ impl<'tm> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm, '_>> for Command {
                 } else {
                     env.tm.mk_uninterpreted_sort_constructor_sort(*arity, name)
                 };
-                env.sort.insert(name.to_string(), cs);
+                env.sort.insert(name.clone(), cs);
                 Ok(CommandResult::None)
             }
             AC::DefineSort(..) => {
@@ -2155,7 +2187,7 @@ impl<'tm> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm, '_>> for Command {
             }
             AC::DefineConst(name, _sort, body) => {
                 let cbody = body.to_cvc5(env)?;
-                env.globals.insert(name.to_string(), cbody);
+                env.globals.insert(name.clone(), cbody);
                 Ok(CommandResult::None)
             }
             AC::DefineFun(fd) => es.translate_define_fun(fd, false),
@@ -2180,7 +2212,7 @@ impl<'tm> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm, '_>> for Command {
                 }
                 let ct = cur.to_cvc5(env)?;
                 for name in names {
-                    env.globals.insert(name.to_string(), ct.clone());
+                    env.globals.insert(name.clone(), ct.clone());
                 }
                 solver.assert_formula(CTerm::clone(&ct));
                 Ok(CommandResult::None)
@@ -2263,7 +2295,10 @@ impl<'tm> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm, '_>> for Command {
 }
 
 // ── Command helper methods ───────────────────────────────────
-impl<'tm> Cvc5EnvSolver<'_, 'tm, '_> {
+impl<'tm, Ctx> Cvc5EnvSolver<'_, 'tm, Ctx>
+where
+    Ctx: HasMutRef<Context>,
+{
     fn translate_define_fun(
         &mut self,
         fd: &alg::FunctionDef<Str, Sort, Term>,
@@ -2280,7 +2315,7 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm, '_> {
         } else {
             self.solver.define_fun(&fd.name, &vars, out, body, true)
         };
-        self.env.globals.insert(fd.name.to_string(), ct);
+        self.env.globals.insert(fd.name.clone(), ct);
         Ok(CommandResult::None)
     }
 
@@ -2305,7 +2340,7 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm, '_> {
                 env.tm.mk_fun_sort(&inp, out)
             };
             let ct = env.tm.mk_const(fs, &fd.name);
-            env.globals.insert(fd.name.to_string(), ct.clone());
+            env.globals.insert(fd.name.clone(), ct.clone());
             funs.push(ct);
         }
         // Second pass: translate bodies
@@ -2332,19 +2367,19 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm, '_> {
         for def in defs {
             let arity = def.dec.params.len();
             let us = env.tm.mk_unresolved_dt_sort(&def.name, arity);
-            env.dt_sorts.insert(def.name.to_string(), us);
+            env.dt_sorts.insert(def.name.clone(), us);
         }
         let result = Self::build_dt_decls(env, defs);
         env.dt_sorts.clear();
         let decls = result?;
         if decls.len() == 1 {
             let cs = env.tm.mk_dt_sort(&decls[0]);
-            env.sort.insert(defs[0].name.to_string(), cs.clone());
+            env.sort.insert(defs[0].name.clone(), cs.clone());
             Self::register_dt_functions(env, cs, &defs[0].dec);
         } else {
             let sorts = env.tm.mk_dt_sorts(&decls);
             for (def, cs) in defs.iter().zip(sorts) {
-                env.sort.insert(def.name.to_string(), cs.clone());
+                env.sort.insert(def.name.clone(), cs.clone());
                 Self::register_dt_functions(env, cs, &def.dec);
             }
         }
@@ -2352,7 +2387,7 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm, '_> {
     }
 
     fn build_dt_decls(
-        env: &mut Cvc5Env<'tm, '_>,
+        env: &mut Cvc5Env<'tm, Ctx>,
         defs: &[alg::DatatypeDef<Str, Sort>],
     ) -> Res<Vec<cvc5::DatatypeDecl<'tm>>> {
         let mut decls = Vec::with_capacity(defs.len());
@@ -2361,7 +2396,7 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm, '_> {
             let cvc5_params: Vec<CSort<'tm>> =
                 params.iter().map(|p| env.tm.mk_param_sort(p)).collect();
             for (p, cs) in params.iter().zip(&cvc5_params) {
-                env.dt_sorts.insert(p.to_string(), cs.clone());
+                env.dt_sorts.insert(p.clone(), cs.clone());
             }
             let mut dt_decl = if cvc5_params.is_empty() {
                 env.tm.mk_dt_decl(&def.name, false)
@@ -2378,23 +2413,25 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm, '_> {
                 dt_decl.add_constructor(&ctor_decl);
             }
             for p in params {
-                env.dt_sorts.remove(p.as_str());
+                env.dt_sorts.remove(p);
             }
             decls.push(dt_decl);
         }
         Ok(decls)
     }
 
-    fn register_dt_functions(env: &mut Cvc5Env<'tm, '_>, sort: CSort<'tm>, dec: &DatatypeDec) {
+    fn register_dt_functions(env: &mut Cvc5Env<'tm, Ctx>, sort: CSort<'tm>, dec: &DatatypeDec) {
         let dt = sort.datatype();
+        let mut rf = env.ctx.ref_mut();
         for (i, ctor_dec) in dec.constructors.iter().enumerate() {
             let ctor = dt.constructor(i);
-            env.globals.insert(ctor_dec.ctor.to_string(), ctor.term());
+            env.globals.insert(ctor_dec.ctor.clone(), ctor.term());
             let tester = ctor.tester_term();
-            env.globals.insert(format!("is-{}", ctor.name()), tester);
+            let sym = rf.allocate_symbol(&format!("is-{}", ctor.name()));
+            env.globals.insert(sym, tester);
             for (j, sel_dec) in ctor_dec.args.iter().enumerate() {
                 let sel = ctor.selector(j);
-                env.globals.insert(sel_dec.0.to_string(), sel.term());
+                env.globals.insert(sel_dec.0.clone(), sel.term());
             }
         }
     }

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -69,6 +69,7 @@
 
 use crate::ast::alg::VarBinding;
 use crate::ast::*;
+use crate::containers::{InsertableMapping, Mapping};
 use crate::raw::alg;
 use crate::raw::alg::CheckIdentifier;
 use crate::raw::alg::rec::TermRecursionScheme;
@@ -76,6 +77,7 @@ use crate::raw::alg::rec_memo::{MemoizedRecursion, MemoizedScheme, Memoizing};
 use crate::statics::*;
 use crate::traits::{Contains, Repr};
 use crate::untyped::UntypedAst;
+use bimap::BiHashMap;
 pub use cvc5::{Kind, ProofComponent, Solver, TermManager};
 use dashu::integer::UBig;
 use std::collections::{HashMap, HashSet};
@@ -223,20 +225,22 @@ pub struct Cvc5Env<'tm, 'env> {
     globals: HashMap<String, CTerm<'tm>>,
     /// Forward-direction local (bound) variables, keyed by their yaspar-ir local id.
     locals: HashMap<usize, WithPattern<'tm>>,
-    /// Cache from yaspar-ir [`Sort`] to translated [`CSort`], avoiding redundant work.
-    sort_cache: HashMap<Sort, CSort<'tm>>,
+    /// Bidirectional cache between yaspar-ir [`Sort`] and translated [`CSort`].
+    /// Used for both forward and reverse sort translation.
+    sort_cache: BiHashMap<Sort, CSort<'tm>>,
     /// Datatype sorts mapping from names to their corresponding potentially polymorphic representations.
     dt_sorts: HashMap<String, CSort<'tm>>,
     /// Stack of bound-variable lists for scope management in quantifiers and match arms (forward direction).
     scope_stack: Vec<Vec<CTerm<'tm>>>,
     /// Cached sort-parameter substitutions for parametric datatype match translation.
     sort_subst_map: HashMap<Term, SortSubst<'tm>>,
-    /// Forward memoization cache: yaspar-ir [`Term`] → translated cvc5 term (with patterns).
-    term_cache: HashMap<Term, WithPattern<'tm>>,
-    /// Reverse cache from [`CSort`] to yaspar-ir [`Sort`], avoiding redundant work.
-    sort_cache_from: HashMap<CSort<'tm>, Sort>,
-    /// Reverse cache from [`CTerm`] to yaspar-ir [`Term`], avoiding redundant work.
-    term_cache_from: HashMap<CTerm<'tm>, Term>,
+    /// Bidirectional cache between yaspar-ir [`Term`] and translated [`WithPattern`].
+    /// Used for forward memoization and reverse term lookup. For reverse lookups, the
+    /// [`CTerm`] is wrapped into a `WithPattern` with empty patterns before looking up
+    /// on the right side. Quantifier translation produces a `WithPattern` whose patterns
+    /// have already been consumed into the quantifier itself, so the cached `WithPattern`
+    /// on a quantifier key has empty patterns (preserving the bijection on quantifiers).
+    term_cache: BiHashMap<Term, WithPattern<'tm>>,
     /// Backward-direction bound variable map: cvc5 term id → VarBinding.
     locals_from: HashMap<u64, VarBinding<Str, Sort>>,
     /// Stack of bound variable cvc5 ids for scope cleanup (backward direction).
@@ -254,13 +258,11 @@ impl<'tm, 'env> Cvc5Env<'tm, 'env> {
             sort: HashMap::new(),
             globals: HashMap::new(),
             locals: HashMap::new(),
-            sort_cache: HashMap::new(),
+            sort_cache: BiHashMap::new(),
             dt_sorts: HashMap::new(),
             scope_stack: vec![],
             sort_subst_map: Default::default(),
-            term_cache: HashMap::new(),
-            sort_cache_from: HashMap::new(),
-            term_cache_from: HashMap::new(),
+            term_cache: BiHashMap::new(),
             locals_from: HashMap::new(),
             scope_stack_from: Vec::new(),
             uninterpreted_values: HashSet::new(),
@@ -295,9 +297,35 @@ impl<'tm, 'env> Cvc5Env<'tm, 'env> {
     }
 }
 
+// `BiHashMap` is treated as a left-keyed mapping for memoization purposes:
+// `lookup` finds the right value by left key, and `insert` populates the bijection
+// in both directions.
+impl<L, R> Mapping for BiHashMap<L, R>
+where
+    L: Eq + std::hash::Hash,
+    R: Eq + std::hash::Hash + Clone,
+{
+    type Key = L;
+    type Value = R;
+
+    fn lookup(&self, key: &Self::Key) -> Option<Self::Value> {
+        self.get_by_left(key).cloned()
+    }
+}
+
+impl<L, R> InsertableMapping for BiHashMap<L, R>
+where
+    L: Eq + std::hash::Hash,
+    R: Eq + std::hash::Hash + Clone,
+{
+    fn insert(&mut self, key: Self::Key, value: Self::Value) {
+        BiHashMap::insert(self, key, value);
+    }
+}
+
 impl<'tm, 'env> Memoizing<Term, WithPattern<'tm>> for Cvc5Env<'tm, 'env> {
     type Cache<'a>
-        = &'a mut HashMap<Term, WithPattern<'tm>>
+        = &'a mut BiHashMap<Term, WithPattern<'tm>>
     where
         Self: 'a;
 
@@ -345,7 +373,7 @@ impl<'tm, 'env> ConvertToCvc5<Cvc5Env<'tm, 'env>> for Sort {
     type Output = CSort<'tm>;
 
     fn to_cvc5(&self, env: &mut Cvc5Env<'tm, 'env>) -> Res<CSort<'tm>> {
-        if let Some(cs) = env.sort_cache.get(self) {
+        if let Some(cs) = env.sort_cache.get_by_left(self) {
             return Ok(cs.clone());
         }
         let cs = translate_sort_inner(self, env)?;
@@ -412,56 +440,56 @@ impl<'tm, 'env> ConvertFromCvc5<Cvc5Env<'tm, 'env>> for CSort<'tm> {
     type Output = Sort;
 
     fn conv_from_cvc5(&self, fenv: &mut Cvc5Env<'tm, 'env>) -> Res<Sort> {
-        if let Some(s) = fenv.sort_cache_from.get(self) {
+        if let Some(s) = fenv.sort_cache.get_by_right(self) {
             return Ok(s.clone());
         }
-        let s = translate_sort_from_cvc5(self, fenv.ctx.arena())?;
-        fenv.sort_cache_from.insert(self.clone(), s.clone());
+        let s = translate_sort_from_cvc5(self, fenv)?;
+        fenv.sort_cache.insert(s.clone(), self.clone());
         Ok(s)
     }
 }
 
-fn translate_sort_from_cvc5<'tm>(cs: &CSort<'tm>, arena: &mut Arena) -> Res<Sort> {
+fn translate_sort_from_cvc5<'tm, 'env>(
+    cs: &CSort<'tm>,
+    fenv: &mut Cvc5Env<'tm, 'env>,
+) -> Res<Sort> {
     if cs.is_boolean() {
-        return Ok(arena.bool_sort());
+        return Ok(fenv.ctx.bool_sort());
     }
     if cs.is_integer() {
-        return Ok(arena.int_sort());
+        return Ok(fenv.ctx.int_sort());
     }
     if cs.is_real() {
-        return Ok(arena.real_sort());
+        return Ok(fenv.ctx.real_sort());
     }
     if cs.is_string() {
-        return Ok(arena.string_sort());
+        return Ok(fenv.ctx.string_sort());
     }
     if cs.is_regexp() {
-        return Ok(arena.reglan_sort());
+        return Ok(fenv.ctx.reglan_sort());
     }
     if cs.is_bv() {
-        return Ok(arena.bv_sort(cs.bv_size().into()));
+        return Ok(fenv.ctx.bv_sort(cs.bv_size().into()));
     }
     if cs.is_array() {
-        let idx = translate_sort_from_cvc5(&cs.array_index_sort(), arena)?;
-        let elem = translate_sort_from_cvc5(&cs.array_element_sort(), arena)?;
-        return Ok(arena.array_sort(idx, elem));
+        let idx = cs.array_index_sort().conv_from_cvc5(fenv)?;
+        let elem = cs.array_element_sort().conv_from_cvc5(fenv)?;
+        return Ok(fenv.ctx.array_sort(idx, elem));
     }
     // Instantiated parametric datatype (e.g. (List Int))
     if cs.is_dt() && cs.is_instantiated() {
         let dt = cs.datatype();
         let name = dt.name();
         let params = cs.instantiated_parameters();
-        let ir_params: Vec<Sort> = params
-            .iter()
-            .map(|p| translate_sort_from_cvc5(p, arena))
-            .collect::<Res<_>>()?;
-        let sym = arena.allocate_symbol(name);
-        return Ok(arena.sort_n(sym, ir_params));
+        let ir_params: Vec<Sort> = params.conv_from_cvc5(fenv)?;
+        let sym = fenv.ctx.allocate_symbol(name);
+        return Ok(fenv.ctx.sort_n(sym, ir_params));
     }
     // Monomorphic datatype sort
     if cs.is_dt() {
         let dt = cs.datatype();
         let name = dt.name();
-        return Ok(arena.simple_sort(name));
+        return Ok(fenv.ctx.simple_sort(name));
     }
     // Instantiated parametric uninterpreted sort (e.g. (Pair A B))
     if cs.is_instantiated() {
@@ -470,15 +498,15 @@ fn translate_sort_from_cvc5<'tm>(cs: &CSort<'tm>, arena: &mut Arena) -> Res<Sort
         let params = cs.instantiated_parameters();
         let ir_params: Vec<Sort> = params
             .iter()
-            .map(|p| translate_sort_from_cvc5(p, arena))
+            .map(|p| p.conv_from_cvc5(fenv))
             .collect::<Res<_>>()?;
-        let sym = arena.allocate_symbol(name);
-        return Ok(arena.sort_n(sym, ir_params));
+        let sym = fenv.ctx.allocate_symbol(name);
+        return Ok(fenv.ctx.sort_n(sym, ir_params));
     }
     // Uninterpreted sort
     if cs.is_uninterpreted_sort() {
         let name = cs.symbol();
-        return Ok(arena.simple_sort(name));
+        return Ok(fenv.ctx.simple_sort(name));
     }
     Err(format!("unsupported cvc5 sort: {cs}"))
 }
@@ -500,11 +528,14 @@ impl<'tm, 'env> ConvertFromCvc5<Cvc5Env<'tm, 'env>> for CTerm<'tm> {
     type Output = Term;
 
     fn conv_from_cvc5(&self, fenv: &mut Cvc5Env<'tm, 'env>) -> Res<Term> {
-        if let Some(t) = fenv.term_cache_from.get(self) {
+        // Reverse lookup: a plain CTerm corresponds to a `WithPattern` with empty
+        // patterns (the quantifier case never reaches us as a standalone CTerm).
+        let key = WithPattern::from(self.clone());
+        if let Some(t) = fenv.term_cache.get_by_right(&key) {
             return Ok(t.clone());
         }
         let t = translate_term_from_cvc5(self, fenv)?;
-        fenv.term_cache_from.insert(self.clone(), t.clone());
+        fenv.term_cache.insert(t.clone(), key);
         Ok(t)
     }
 }
@@ -675,30 +706,60 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 scope_ids.push(cvc5_id);
             }
             fenv.push_scope_from(scope_ids);
-            let result = body_ct.conv_from_cvc5(fenv).and_then(|body| {
-                // Translate :pattern annotations if present (child 2 is INST_PATTERN_LIST)
-                if ct.num_children() > 2 {
-                    let plist = ct.child(2);
-                    let mut attrs = Vec::new();
-                    for i in 0..plist.num_children() {
-                        let pat = plist.child(i);
-                        if pat.kind() == Kind::InstPattern {
-                            let mut pat_terms = Vec::new();
-                            for j in 0..pat.num_children() {
-                                pat_terms.push(pat.child(j).conv_from_cvc5(fenv)?);
-                            }
-                            attrs.push(Attribute::Pattern(pat_terms));
+
+            // Collect cvc5 patterns first (without translating to ir Terms yet).
+            // This lets us probe the bimap with `WithPattern { body_ct, cvc5_patterns }`
+            // on the right side and short-circuit body translation on a hit.
+            let cvc5_patterns: Vec<Vec<CTerm<'tm>>> = if ct.num_children() > 2 {
+                let plist = ct.child(2);
+                let mut pats = Vec::with_capacity(plist.num_children());
+                for i in 0..plist.num_children() {
+                    let pat = plist.child(i);
+                    if pat.kind() == Kind::InstPattern {
+                        let mut pat_cterms = Vec::with_capacity(pat.num_children());
+                        for j in 0..pat.num_children() {
+                            pat_cterms.push(pat.child(j));
                         }
+                        pats.push(pat_cterms);
                     }
-                    if attrs.is_empty() {
-                        Ok(body)
-                    } else {
-                        Ok(fenv.ctx.annotated(body, attrs))
-                    }
-                } else {
-                    Ok(body)
                 }
-            });
+                pats
+            } else {
+                vec![]
+            };
+
+            let result = 'inner: {
+                let probe = WithPattern {
+                    term: body_ct.clone(),
+                    patterns: cvc5_patterns.clone(),
+                };
+                if let Some(cached) = fenv.term_cache.get_by_right(&probe) {
+                    break 'inner Ok(cached.clone());
+                }
+                body_ct.conv_from_cvc5(fenv).and_then(|body| {
+                    if cvc5_patterns.is_empty() {
+                        return Ok(body);
+                    }
+                    let attrs = cvc5_patterns
+                        .iter()
+                        .map(|pats| {
+                            Ok(Attribute::Pattern(
+                                pats.iter()
+                                    .map(|t| t.conv_from_cvc5(fenv))
+                                    .collect::<Res<Vec<_>>>()?,
+                            ))
+                        })
+                        .collect::<Res<Vec<_>>>()?;
+                    let annotated = fenv.ctx.annotated(body, attrs);
+                    // Mirror the forward-direction shape: `Annotated(body, [:pattern …])`
+                    // maps to a `WithPattern` whose `term` is the body's CTerm and whose
+                    // `patterns` carry the pattern triggers (later absorbed into
+                    // `INST_PATTERN_LIST`).
+                    fenv.term_cache.insert(annotated.clone(), probe);
+                    Ok(annotated)
+                })
+            };
+
             let bindings = fenv.pop_scope_from();
             let body = result?;
 
@@ -941,10 +1002,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
     Err(format!("unsupported cvc5 term kind: {:?}", kind))
 }
 
-fn translate_children<'tm, 'env>(
-    ct: &CTerm<'tm>,
-    fenv: &mut Cvc5Env<'tm, 'env>,
-) -> Res<Vec<Term>> {
+fn translate_children<'tm, 'env>(ct: &CTerm<'tm>, fenv: &mut Cvc5Env<'tm, 'env>) -> Res<Vec<Term>> {
     let n = ct.num_children();
     let mut children = Vec::with_capacity(n);
     for i in 0..n {
@@ -1055,7 +1113,8 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
                         let vs = arg.sort().conv_from_cvc5(fenv)?;
                         let id = fenv.ctx.new_local();
                         let sym = fenv.ctx.allocate_symbol(&name);
-                        fenv.locals_from.insert(cvc5_id, VarBinding(sym.clone(), id, vs));
+                        fenv.locals_from
+                            .insert(cvc5_id, VarBinding(sym.clone(), id, vs));
                         arguments.push(Some((sym, id)));
                     } else {
                         arguments.push(None);
@@ -2148,7 +2207,7 @@ impl<'tm> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm, '_>> for Command {
                     .cloned()
                     .chain(
                         env.sort_cache
-                            .values()
+                            .right_values()
                             .filter(|s| s.is_uninterpreted_sort())
                             .cloned(),
                     )

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -13,18 +13,19 @@
 //! # Forward translation
 //!
 //! - [`ConvertToCvc5<Env>`] — the core trait, implemented for [`Sort`], [`Term`], and [`Command`].
-//! - [`Cvc5Env`] — holds a [`cvc5::TermManager`] and caches for sort/term/symbol translation.
-//!   Used as the environment for `Sort::to_cvc5` and `Term::to_cvc5`.
-//! - [`Cvc5EnvSolver`] — wraps a [`Cvc5EnvInner`] and a [`Solver`]. Used as the environment
+//! - [`Cvc5Env`] — holds a [`cvc5::TermManager`], a mutable reference to a [`Context`], and
+//!   caches for sort/term/symbol translation in both directions. Used as the environment
+//!   for `Sort::to_cvc5`, `Term::to_cvc5`, `CSort::conv_from_cvc5`, and `CTerm::conv_from_cvc5`.
+//! - [`Cvc5EnvSolver`] — wraps a [`Cvc5Env`] and a [`Solver`]. Used as the environment
 //!   for `Command::to_cvc5`, since commands may interact with the solver (e.g. `assert`,
 //!   `check-sat`, `define-fun`).
 //!
 //! # Backward translation
 //!
 //! - [`ConvertFromCvc5<Env>`] — the core trait, implemented for [`CSort`] and [`CTerm`].
-//! - [`FromCvc5Env`] — holds a mutable reference to a [`Context`] and manages scoped variable
-//!   bindings, sort caching, and tracking of uninterpreted sort values. Used as the environment
-//!   for `CSort::conv_from_cvc5` and `CTerm::conv_from_cvc5`.
+//! - [`Cvc5Env`] — also serves as the environment for backward translation, holding the
+//!   `Context` reference, scoped variable bindings, sort/term reverse caches, and a record
+//!   of uninterpreted sort values encountered.
 //!
 //! The backward translation handles constants, logical connectives, quantifiers (including
 //! `:pattern` annotations), arithmetic/bitvector/string operators, indexed operators,
@@ -47,7 +48,7 @@
 //!
 //! let tm = TermManager::new();
 //! let mut solver = Solver::new(&tm);
-//! let mut env = Cvc5Env::create(&tm);
+//! let mut env = Cvc5Env::new(&tm, &mut ctx);
 //! let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
 //! for cmd in &cmds {
 //!     cmd.to_cvc5(&mut es).unwrap();
@@ -56,9 +57,9 @@
 //!
 //! # Caching
 //!
-//! [`Cvc5Env`] caches translated sorts and terms so that repeated translations of the same
-//! hash-consed object return the cached cvc5 object directly. [`FromCvc5Env`] similarly caches
-//! both sort and term translations from cvc5 back to yaspar-ir.
+//! [`Cvc5Env`] caches translated sorts and terms in both directions so that repeated
+//! translations of the same hash-consed object (forward) or cvc5 object (backward)
+//! return the cached counterpart directly.
 //!
 //! # Annotations
 //!
@@ -70,6 +71,8 @@ use crate::ast::alg::VarBinding;
 use crate::ast::*;
 use crate::raw::alg;
 use crate::raw::alg::CheckIdentifier;
+use crate::raw::alg::rec::TermRecursionScheme;
+use crate::raw::alg::rec_memo::{MemoizedRecursion, MemoizedScheme, Memoizing};
 use crate::statics::*;
 use crate::traits::{Contains, Repr};
 use crate::untyped::UntypedAst;
@@ -132,12 +135,12 @@ pub trait ConvertToCvc5<Env> {
 /// Convert a cvc5 object back to its yaspar-ir typed AST counterpart.
 ///
 /// This trait is implemented for [`CSort`] and [`CTerm`], both using
-/// [`FromCvc5Env`] as the environment:
+/// [`Cvc5Env`] as the environment:
 ///
-/// | cvc5 type   | Environment      | Output   |
-/// |-------------|------------------|----------|
-/// | [`CSort`]   | [`FromCvc5Env`]  | [`Sort`] |
-/// | [`CTerm`]   | [`FromCvc5Env`]  | [`Term`] |
+/// | cvc5 type   | Environment   | Output   |
+/// |-------------|---------------|----------|
+/// | [`CSort`]   | [`Cvc5Env`]   | [`Sort`] |
+/// | [`CTerm`]   | [`Cvc5Env`]   | [`Term`] |
 ///
 /// Translation may fail if the cvc5 object uses features not supported by yaspar-ir
 /// (e.g. floating-point sorts, set operations).
@@ -182,38 +185,72 @@ impl<'tm> From<CTerm<'tm>> for WithPattern<'tm> {
 /// `None` for monomorphic datatypes.
 type SortSubst<'tm> = Option<(Vec<CSort<'tm>>, Vec<CSort<'tm>>)>;
 
-/// Inner environment for translating yaspar-ir ASTs to cvc5 objects.
+/// The unified environment for bidirectional translation between yaspar-ir and cvc5.
 ///
-/// This struct holds the [`TermManager`] reference and all translation state: sort/term
-/// caches, global and local symbol tables, and datatype bookkeeping. It implements
-/// [`TermRecursor`] for stack-safe, memoized term translation.
+/// This struct holds the [`TermManager`] reference, a mutable reference to a [`Context`],
+/// and all translation state for both directions:
 ///
-/// Users should not construct this directly — use [`Cvc5Env::create`] instead, which
-/// wraps this in a [`Memoize`] layer for automatic term-level caching.
-pub struct Cvc5EnvInner<'tm> {
+/// - **Forward (yaspar-ir → cvc5)**: sort/term caches, global and local symbol tables,
+///   datatype bookkeeping, and a memoization cache for hashconsed term translation.
+/// - **Backward (cvc5 → yaspar-ir)**: sort/term reverse caches, scoped variable bindings,
+///   and tracking of uninterpreted sort values.
+///
+/// It implements [`TermRecursor`] for stack-safe, memoized term translation. Because
+/// yaspar-ir terms are hashconsed, structurally identical sub-terms share the same
+/// pointer — the memoization layer (via the [`Memoizing`](crate::raw::alg::rec_memo)
+/// trait, pointing to `term_cache`) ensures each unique sub-term is translated at most once.
+///
+/// # Construction
+///
+/// ```rust
+/// use cvc5::TermManager;
+/// use yaspar_ir::ast::Context;
+/// use yaspar_ir::cvc5::Cvc5Env;
+///
+/// let tm = TermManager::new();
+/// let mut ctx = Context::new();
+/// let mut env = Cvc5Env::new(&tm, &mut ctx);
+/// ```
+pub struct Cvc5Env<'tm, 'env> {
     /// The cvc5 term manager that owns all created sorts and terms.
     tm: &'tm TermManager,
+    /// The backing yaspar-ir context, used during reverse translation for arena
+    /// allocation and theory-aware constant construction.
+    pub ctx: &'env mut Context,
     /// Named sorts registered by `declare-sort` or datatype declarations.
     sort: HashMap<String, CSort<'tm>>,
     /// Global symbols (constants, functions, constructors, selectors, testers).
     globals: HashMap<String, CTerm<'tm>>,
-    /// Local (bound) variables, keyed by their uniquely assigned id.
+    /// Forward-direction local (bound) variables, keyed by their yaspar-ir local id.
     locals: HashMap<usize, WithPattern<'tm>>,
     /// Cache from yaspar-ir [`Sort`] to translated [`CSort`], avoiding redundant work.
     sort_cache: HashMap<Sort, CSort<'tm>>,
-    /// datatype sorts mapping from names to their corresponding potentially polymorphic representations.
+    /// Datatype sorts mapping from names to their corresponding potentially polymorphic representations.
     dt_sorts: HashMap<String, CSort<'tm>>,
-    /// Stack of bound-variable lists for scope management in quantifiers and match arms.
+    /// Stack of bound-variable lists for scope management in quantifiers and match arms (forward direction).
     scope_stack: Vec<Vec<CTerm<'tm>>>,
     /// Cached sort-parameter substitutions for parametric datatype match translation.
     sort_subst_map: HashMap<Term, SortSubst<'tm>>,
+    /// Forward memoization cache: yaspar-ir [`Term`] → translated cvc5 term (with patterns).
+    term_cache: HashMap<Term, WithPattern<'tm>>,
+    /// Reverse cache from [`CSort`] to yaspar-ir [`Sort`], avoiding redundant work.
+    sort_cache_from: HashMap<CSort<'tm>, Sort>,
+    /// Reverse cache from [`CTerm`] to yaspar-ir [`Term`], avoiding redundant work.
+    term_cache_from: HashMap<CTerm<'tm>, Term>,
+    /// Backward-direction bound variable map: cvc5 term id → VarBinding.
+    locals_from: HashMap<u64, VarBinding<Str, Sort>>,
+    /// Stack of bound variable cvc5 ids for scope cleanup (backward direction).
+    scope_stack_from: Vec<Vec<u64>>,
+    /// Allocated symbols for uninterpreted sort values encountered during reverse translation.
+    uninterpreted_values: HashSet<String>,
 }
 
-impl<'tm> Cvc5EnvInner<'tm> {
-    /// Create a new inner environment backed by the given [`TermManager`].
-    pub fn new(tm: &'tm TermManager) -> Self {
+impl<'tm, 'env> Cvc5Env<'tm, 'env> {
+    /// Create a new translation environment backed by the given [`TermManager`] and [`Context`].
+    pub fn new(tm: &'tm TermManager, ctx: &'env mut Context) -> Self {
         Self {
             tm,
+            ctx,
             sort: HashMap::new(),
             globals: HashMap::new(),
             locals: HashMap::new(),
@@ -221,115 +258,12 @@ impl<'tm> Cvc5EnvInner<'tm> {
             dt_sorts: HashMap::new(),
             scope_stack: vec![],
             sort_subst_map: Default::default(),
-        }
-    }
-}
-/// The main translation environment for sorts and terms.
-///
-/// This is a [`Memoize`]-wrapped [`Cvc5EnvInner`] that automatically caches translated
-/// terms by their hashconsed identity. Because yaspar-ir terms are hashconsed,
-/// structurally identical sub-terms share the same pointer — the memoization layer
-/// ensures each unique sub-term is translated at most once.
-///
-/// # Construction
-///
-/// ```rust
-/// use cvc5::TermManager;
-/// use yaspar_ir::cvc5::Cvc5Env;
-///
-/// let tm = TermManager::new();
-/// let mut env = Cvc5Env::create(&tm);
-/// ```
-pub type Cvc5Env<'tm> = Memoize<Cvc5EnvInner<'tm>, HashMap<Term, WithPattern<'tm>>>;
-
-impl<'tm> Cvc5Env<'tm> {
-    /// Create a new translation environment backed by the given [`TermManager`].
-    pub fn create(tm: &'tm TermManager) -> Self {
-        Self::new(Cvc5EnvInner::new(tm))
-    }
-}
-
-/// Environment combining a [`Cvc5Env`] with a [`Solver`] for translating commands.
-///
-/// Commands like `assert`, `check-sat`, `define-fun`, and `declare-datatypes` need
-/// access to both the translation environment (for sort/term translation) and the
-/// solver (for issuing solver calls). This struct bundles the two together.
-///
-/// # Example
-///
-/// ```rust
-/// use cvc5::{Solver, TermManager};
-/// use yaspar_ir::cvc5::{Cvc5Env, Cvc5EnvSolver};
-///
-/// let tm = TermManager::new();
-/// let mut solver = Solver::new(&tm);
-/// let mut env = Cvc5Env::create(&tm);
-/// let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
-/// // now use es.to_cvc5() on Command values
-/// ```
-pub struct Cvc5EnvSolver<'a, 'tm> {
-    /// The translation environment for sorts and terms.
-    pub env: &'a mut Cvc5Env<'tm>,
-    /// The cvc5 solver instance.
-    pub solver: &'a mut Solver<'tm>,
-}
-
-impl<'a, 'tm> Cvc5EnvSolver<'a, 'tm> {
-    /// Create a new command-translation environment from a [`Cvc5Env`] and a [`Solver`].
-    pub fn new(env: &'a mut Cvc5Env<'tm>, solver: &'a mut Solver<'tm>) -> Self {
-        Self { env, solver }
-    }
-}
-
-/// Environment for translating cvc5 objects back to yaspar-ir typed ASTs.
-///
-/// This struct manages:
-/// - **Sort caching**: avoids redundant sort translations via a [`CSort`] → [`Sort`] cache.
-/// - **Term caching**: avoids redundant term translations via a [`CTerm`] → [`Term`] cache.
-/// - **Scoped variable bindings**: tracks bound variables introduced by quantifiers and match
-///   expressions, ensuring that variable references in the body resolve to the correct local IDs.
-/// - **Uninterpreted sort values**: records names of uninterpreted sort values encountered
-///   during translation (e.g. `@U0`, `@U1` from models), queryable after translation.
-///
-/// The environment requires a mutable reference to a [`Context`] to access the arena for
-/// allocation and the active theories for sort-aware constant construction (e.g. distinguishing
-/// `Int` numerals from `Real` decimals in mixed `RealInts` logics).
-///
-/// # Example
-///
-/// ```rust
-/// use yaspar_ir::ast::Context;
-/// use yaspar_ir::cvc5::FromCvc5Env;
-///
-/// let mut ctx = Context::new();
-/// let mut from_env = FromCvc5Env::new(&mut ctx);
-/// // use from_env with ConvertFromCvc5::conv_from_cvc5
-/// ```
-pub struct FromCvc5Env<'tm, 'env> {
-    /// Cache from [`CSort`] to yaspar-ir [`Sort`], avoiding redundant work.
-    sort_cache: HashMap<CSort<'tm>, Sort>,
-    /// Cache from [`CTerm`] to yaspar-ir [`Term`], avoiding redundant work.
-    term_cache: HashMap<CTerm<'tm>, Term>,
-    /// Bound variable map: cvc5 term id → VarBinding.
-    locals: HashMap<u64, VarBinding<Str, Sort>>,
-    /// Stack of bound variable ids for scope cleanup.
-    scope_stack: Vec<Vec<u64>>,
-    /// Allocated symbols for uninterpreted sort values encountered during translation.
-    uninterpreted_values: HashSet<String>,
-    /// The backing context.
-    pub env: &'env mut Context,
-}
-
-impl<'tm, 'env> FromCvc5Env<'tm, 'env> {
-    /// Create a new reverse-translation environment backed by `env`.
-    pub fn new(env: &'env mut Context) -> Self {
-        Self {
-            sort_cache: HashMap::new(),
             term_cache: HashMap::new(),
-            locals: HashMap::new(),
-            scope_stack: Vec::new(),
+            sort_cache_from: HashMap::new(),
+            term_cache_from: HashMap::new(),
+            locals_from: HashMap::new(),
+            scope_stack_from: Vec::new(),
             uninterpreted_values: HashSet::new(),
-            env,
         }
     }
 
@@ -343,29 +277,74 @@ impl<'tm, 'env> FromCvc5Env<'tm, 'env> {
         &self.uninterpreted_values
     }
 
-    /// Push a new scope with the given cvc5 variable IDs.
-    fn push_scope(&mut self, ids: Vec<u64>) {
-        self.scope_stack.push(ids);
+    /// Push a new scope with the given cvc5 variable IDs (backward direction).
+    fn push_scope_from(&mut self, ids: Vec<u64>) {
+        self.scope_stack_from.push(ids);
     }
 
-    /// Pop the current scope and remove all its bindings from locals.
-    fn pop_scope(&mut self) -> Vec<VarBinding<Str, Sort>> {
+    /// Pop the current scope and remove all its bindings from `locals_from` (backward direction).
+    fn pop_scope_from(&mut self) -> Vec<VarBinding<Str, Sort>> {
         let scope_ids = self
-            .scope_stack
+            .scope_stack_from
             .pop()
             .expect("fatal error: unbalanced scope stack!");
         scope_ids
             .iter()
-            .filter_map(|id| self.locals.remove(id))
+            .filter_map(|id| self.locals_from.remove(id))
             .collect()
     }
 }
 
+impl<'tm, 'env> Memoizing<Term, WithPattern<'tm>> for Cvc5Env<'tm, 'env> {
+    type Cache<'a>
+        = &'a mut HashMap<Term, WithPattern<'tm>>
+    where
+        Self: 'a;
+
+    fn cache_mut(&mut self) -> Self::Cache<'_> {
+        &mut self.term_cache
+    }
+}
+
+/// Environment combining a [`Cvc5Env`] with a [`Solver`] for translating commands.
+///
+/// Commands like `assert`, `check-sat`, `define-fun`, and `declare-datatypes` need
+/// access to both the translation environment (for sort/term translation) and the
+/// solver (for issuing solver calls). This struct bundles the two together.
+///
+/// # Example
+///
+/// ```rust
+/// use cvc5::{Solver, TermManager};
+/// use yaspar_ir::ast::Context;
+/// use yaspar_ir::cvc5::{Cvc5Env, Cvc5EnvSolver};
+///
+/// let tm = TermManager::new();
+/// let mut ctx = Context::new();
+/// let mut solver = Solver::new(&tm);
+/// let mut env = Cvc5Env::new(&tm, &mut ctx);
+/// let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+/// // now use es.to_cvc5() on Command values
+/// ```
+pub struct Cvc5EnvSolver<'a, 'tm, 'env> {
+    /// The translation environment for sorts and terms.
+    pub env: &'a mut Cvc5Env<'tm, 'env>,
+    /// The cvc5 solver instance.
+    pub solver: &'a mut Solver<'tm>,
+}
+
+impl<'a, 'tm, 'env> Cvc5EnvSolver<'a, 'tm, 'env> {
+    /// Create a new command-translation environment from a [`Cvc5Env`] and a [`Solver`].
+    pub fn new(env: &'a mut Cvc5Env<'tm, 'env>, solver: &'a mut Solver<'tm>) -> Self {
+        Self { env, solver }
+    }
+}
+
 // ── Sort translation ─────────────────────────────────────────
-impl<'tm> ConvertToCvc5<Cvc5EnvInner<'tm>> for Sort {
+impl<'tm, 'env> ConvertToCvc5<Cvc5Env<'tm, 'env>> for Sort {
     type Output = CSort<'tm>;
 
-    fn to_cvc5(&self, env: &mut Cvc5EnvInner<'tm>) -> Res<CSort<'tm>> {
+    fn to_cvc5(&self, env: &mut Cvc5Env<'tm, 'env>) -> Res<CSort<'tm>> {
         if let Some(cs) = env.sort_cache.get(self) {
             return Ok(cs.clone());
         }
@@ -375,7 +354,7 @@ impl<'tm> ConvertToCvc5<Cvc5EnvInner<'tm>> for Sort {
     }
 }
 
-fn translate_sort_inner<'tm>(sort: &Sort, env: &mut Cvc5EnvInner<'tm>) -> Res<CSort<'tm>> {
+fn translate_sort_inner<'tm, 'env>(sort: &Sort, env: &mut Cvc5Env<'tm, 'env>) -> Res<CSort<'tm>> {
     let s = sort.repr();
     let name = &s.sort_name().to_string();
     if let Some(n) = s.is_bv() {
@@ -427,26 +406,17 @@ fn translate_sort_inner<'tm>(sort: &Sort, env: &mut Cvc5EnvInner<'tm>) -> Res<CS
     Err(format!("unsupported sort: {sort}"))
 }
 
-impl<'tm> ConvertToCvc5<Cvc5Env<'tm>> for Sort {
-    type Output = CSort<'tm>;
-
-    #[inline]
-    fn to_cvc5(&self, env: &mut Cvc5Env<'tm>) -> Res<Self::Output> {
-        self.to_cvc5(&mut env.inner)
-    }
-}
-
 // ── Reverse sort translation (CSort → Sort) ─────────────────
 
-impl<'tm, 'env> ConvertFromCvc5<FromCvc5Env<'tm, 'env>> for CSort<'tm> {
+impl<'tm, 'env> ConvertFromCvc5<Cvc5Env<'tm, 'env>> for CSort<'tm> {
     type Output = Sort;
 
-    fn conv_from_cvc5(&self, fenv: &mut FromCvc5Env<'tm, 'env>) -> Res<Sort> {
-        if let Some(s) = fenv.sort_cache.get(self) {
+    fn conv_from_cvc5(&self, fenv: &mut Cvc5Env<'tm, 'env>) -> Res<Sort> {
+        if let Some(s) = fenv.sort_cache_from.get(self) {
             return Ok(s.clone());
         }
-        let s = translate_sort_from_cvc5(self, fenv.env.arena())?;
-        fenv.sort_cache.insert(self.clone(), s.clone());
+        let s = translate_sort_from_cvc5(self, fenv.ctx.arena())?;
+        fenv.sort_cache_from.insert(self.clone(), s.clone());
         Ok(s)
     }
 }
@@ -515,41 +485,41 @@ fn translate_sort_from_cvc5<'tm>(cs: &CSort<'tm>, arena: &mut Arena) -> Res<Sort
 
 // ── Term: cvc5 → yaspar-ir ───────────────────────────────────
 
-impl<'tm, 'env, T> ConvertFromCvc5<FromCvc5Env<'tm, 'env>> for [T]
+impl<'tm, 'env, T> ConvertFromCvc5<Cvc5Env<'tm, 'env>> for [T]
 where
-    T: ConvertFromCvc5<FromCvc5Env<'tm, 'env>>,
+    T: ConvertFromCvc5<Cvc5Env<'tm, 'env>>,
 {
     type Output = Vec<T::Output>;
 
-    fn conv_from_cvc5(&self, env: &mut FromCvc5Env<'tm, 'env>) -> Res<Self::Output> {
+    fn conv_from_cvc5(&self, env: &mut Cvc5Env<'tm, 'env>) -> Res<Self::Output> {
         self.iter().map(|s| s.conv_from_cvc5(env)).collect()
     }
 }
 
-impl<'tm, 'env> ConvertFromCvc5<FromCvc5Env<'tm, 'env>> for CTerm<'tm> {
+impl<'tm, 'env> ConvertFromCvc5<Cvc5Env<'tm, 'env>> for CTerm<'tm> {
     type Output = Term;
 
-    fn conv_from_cvc5(&self, fenv: &mut FromCvc5Env<'tm, 'env>) -> Res<Term> {
-        if let Some(t) = fenv.term_cache.get(self) {
+    fn conv_from_cvc5(&self, fenv: &mut Cvc5Env<'tm, 'env>) -> Res<Term> {
+        if let Some(t) = fenv.term_cache_from.get(self) {
             return Ok(t.clone());
         }
         let t = translate_term_from_cvc5(self, fenv)?;
-        fenv.term_cache.insert(self.clone(), t.clone());
+        fenv.term_cache_from.insert(self.clone(), t.clone());
         Ok(t)
     }
 }
 
 fn translate_term_from_cvc5<'tm, 'env>(
     ct: &CTerm<'tm>,
-    fenv: &mut FromCvc5Env<'tm, 'env>,
+    fenv: &mut Cvc5Env<'tm, 'env>,
 ) -> Res<Term> {
     let kind = ct.kind();
 
     // ── Constants ────────────────────────────────────────────
     if ct.is_boolean_value() {
-        let sort = Some(fenv.env.bool_sort());
+        let sort = Some(fenv.ctx.bool_sort());
         return Ok(fenv
-            .env
+            .ctx
             .allocate_term(ATerm::Constant(Constant::Bool(ct.boolean_value()), sort)));
     }
     if ct.is_integer_value() {
@@ -559,13 +529,13 @@ fn translate_term_from_cvc5<'tm, 'env>(
             .parse()
             .map_err(|e| format!("Big integer parse error: {e}"))?;
         return Ok(fenv
-            .env
+            .ctx
             .allocate_term(ATerm::Constant(Constant::Numeral(n), Some(sort))));
     }
     if ct.is_real_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
         let s = ct.real_value();
-        let has_ints = fenv.env.get_theories().iter().any(|t| t.has_int());
+        let has_ints = fenv.ctx.get_theories().iter().any(|t| t.has_int());
         // cvc5 returns rationals as "num/den" or just "num"
         if let Some((num_s, den_s)) = s.split_once('/') {
             let (numer, denom) = if has_ints {
@@ -573,32 +543,32 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 let n = Constant::Decimal(format!("{num_s}.0").parse().unwrap());
                 let d = Constant::Decimal(format!("{den_s}.0").parse().unwrap());
                 let numer = fenv
-                    .env
+                    .ctx
                     .allocate_term(ATerm::Constant(n, Some(sort.clone())));
                 let denom = fenv
-                    .env
+                    .ctx
                     .allocate_term(ATerm::Constant(d, Some(sort.clone())));
                 (numer, denom)
             } else {
                 let num: UBig = num_s.parse().map_err(|e| format!("{e}"))?;
                 let den: UBig = den_s.parse().map_err(|e| format!("{e}"))?;
-                let int = fenv.env.int_sort();
+                let int = fenv.ctx.int_sort();
                 let numer = fenv
-                    .env
+                    .ctx
                     .allocate_term(ATerm::Constant(Constant::Numeral(num), Some(int.clone())));
                 let denom = fenv
-                    .env
+                    .ctx
                     .allocate_term(ATerm::Constant(Constant::Numeral(den), Some(int)));
                 (numer, denom)
             };
-            let sym = fenv.env.allocate_symbol(RDIV);
+            let sym = fenv.ctx.allocate_symbol(RDIV);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.env.app(qid, vec![numer, denom], Some(sort)));
+            return Ok(fenv.ctx.app(qid, vec![numer, denom], Some(sort)));
         }
         // No division — parse as a single decimal
         let n: dashu::float::DBig = format!("{s}.0").parse().map_err(|e| format!("{e}"))?;
         return Ok(fenv
-            .env
+            .ctx
             .allocate_term(ATerm::Constant(Constant::Decimal(n), Some(sort))));
     }
     if ct.is_string_value() {
@@ -609,9 +579,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
             .map(|&c| char::from_u32(c).unwrap_or('\u{FFFD}'))
             .collect();
 
-        let str_val = fenv.env.allocate_str(&s);
+        let str_val = fenv.ctx.allocate_str(&s);
         return Ok(fenv
-            .env
+            .ctx
             .allocate_term(ATerm::Constant(Constant::String(str_val), Some(sort))));
     }
     if ct.is_bv_value() {
@@ -627,7 +597,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
         };
 
         return Ok(fenv
-            .env
+            .ctx
             .allocate_term(ATerm::Constant(Constant::Binary(bytes, len), Some(sort))));
     }
 
@@ -636,22 +606,22 @@ fn translate_term_from_cvc5<'tm, 'env>(
         Kind::And => {
             let children = translate_children(ct, fenv)?;
 
-            return Ok(fenv.env.and(children));
+            return Ok(fenv.ctx.and(children));
         }
         Kind::Or => {
             let children = translate_children(ct, fenv)?;
 
-            return Ok(fenv.env.or(children));
+            return Ok(fenv.ctx.or(children));
         }
         Kind::Xor => {
             let children = translate_children(ct, fenv)?;
 
-            return Ok(fenv.env.xor(children));
+            return Ok(fenv.ctx.xor(children));
         }
         Kind::Not => {
             let child = ct.child(0).conv_from_cvc5(fenv)?;
 
-            return Ok(fenv.env.not(child));
+            return Ok(fenv.ctx.not(child));
         }
         Kind::Implies => {
             let n = ct.num_children();
@@ -661,32 +631,32 @@ fn translate_term_from_cvc5<'tm, 'env>(
             }
             let concl = ct.child(n - 1).conv_from_cvc5(fenv)?;
 
-            return Ok(fenv.env.implies(premises, concl));
+            return Ok(fenv.ctx.implies(premises, concl));
         }
         Kind::Equal => {
             let children = translate_children(ct, fenv)?;
 
             if children.len() == 2 {
-                return Ok(fenv.env.eq(children[0].clone(), children[1].clone()));
+                return Ok(fenv.ctx.eq(children[0].clone(), children[1].clone()));
             }
             // Chain: (= a b c) → (and (= a b) (= b c))
             let mut eqs = Vec::with_capacity(children.len() - 1);
             for i in 0..children.len() - 1 {
-                eqs.push(fenv.env.eq(children[i].clone(), children[i + 1].clone()));
+                eqs.push(fenv.ctx.eq(children[i].clone(), children[i + 1].clone()));
             }
-            return Ok(fenv.env.and(eqs));
+            return Ok(fenv.ctx.and(eqs));
         }
         Kind::Distinct => {
             let children = translate_children(ct, fenv)?;
 
-            return Ok(fenv.env.distinct(children));
+            return Ok(fenv.ctx.distinct(children));
         }
         Kind::Ite => {
             let b = ct.child(0).conv_from_cvc5(fenv)?;
             let t = ct.child(1).conv_from_cvc5(fenv)?;
             let e = ct.child(2).conv_from_cvc5(fenv)?;
 
-            return Ok(fenv.env.ite(b, t, e));
+            return Ok(fenv.ctx.ite(b, t, e));
         }
         // ── Quantifiers ─────────────────────────────────────────
         Kind::Forall | Kind::Exists => {
@@ -699,12 +669,12 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 let name = v.symbol().to_string();
                 let vs = v.sort().conv_from_cvc5(fenv)?;
 
-                let id = fenv.env.new_local();
-                let sym = fenv.env.allocate_symbol(&name);
-                fenv.locals.insert(cvc5_id, VarBinding(sym, id, vs));
+                let id = fenv.ctx.new_local();
+                let sym = fenv.ctx.allocate_symbol(&name);
+                fenv.locals_from.insert(cvc5_id, VarBinding(sym, id, vs));
                 scope_ids.push(cvc5_id);
             }
-            fenv.push_scope(scope_ids);
+            fenv.push_scope_from(scope_ids);
             let result = body_ct.conv_from_cvc5(fenv).and_then(|body| {
                 // Translate :pattern annotations if present (child 2 is INST_PATTERN_LIST)
                 if ct.num_children() > 2 {
@@ -723,19 +693,19 @@ fn translate_term_from_cvc5<'tm, 'env>(
                     if attrs.is_empty() {
                         Ok(body)
                     } else {
-                        Ok(fenv.env.annotated(body, attrs))
+                        Ok(fenv.ctx.annotated(body, attrs))
                     }
                 } else {
                     Ok(body)
                 }
             });
-            let bindings = fenv.pop_scope();
+            let bindings = fenv.pop_scope_from();
             let body = result?;
 
             return if kind == Kind::Forall {
-                Ok(fenv.env.forall(bindings, body))
+                Ok(fenv.ctx.forall(bindings, body))
             } else {
-                Ok(fenv.env.exists(bindings, body))
+                Ok(fenv.ctx.exists(bindings, body))
             };
         }
         // ── Negation (unary minus) ──────────────────────────────
@@ -743,9 +713,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let child = ct.child(0).conv_from_cvc5(fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.env.allocate_symbol(SUB);
+            let sym = fenv.ctx.allocate_symbol(SUB);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.env.app(qid, vec![child], Some(sort)));
+            return Ok(fenv.ctx.app(qid, vec![child], Some(sort)));
         }
 
         // ── Function application (UF, constructors, selectors, testers) ──
@@ -754,9 +724,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let name = ct.symbol().to_string();
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.env.allocate_symbol(&name);
+            let sym = fenv.ctx.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.env.global(qid, Some(sort)));
+            return Ok(fenv.ctx.global(qid, Some(sort)));
         }
         Kind::ApplyUf => {
             let head = ct.child(0);
@@ -767,9 +737,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
             }
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.env.allocate_symbol(&name);
+            let sym = fenv.ctx.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.env.app(qid, args, Some(sort)));
+            return Ok(fenv.ctx.app(qid, args, Some(sort)));
         }
         Kind::ApplyConstructor => {
             let head = ct.child(0);
@@ -800,13 +770,13 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 // Nullary constructor → global
                 let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-                let sym = fenv.env.allocate_symbol(&name);
+                let sym = fenv.ctx.allocate_symbol(&name);
                 let qid = if ct.sort().is_dt() && ct.sort().datatype().is_parametric() {
                     QualifiedIdentifier::simple_sorted(sym, sort.clone())
                 } else {
                     QualifiedIdentifier::simple(sym)
                 };
-                return Ok(fenv.env.global(qid, Some(sort)));
+                return Ok(fenv.ctx.global(qid, Some(sort)));
             }
             let mut args = Vec::with_capacity(n - 1);
             for i in 1..n {
@@ -814,9 +784,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
             }
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.env.allocate_symbol(&name);
+            let sym = fenv.ctx.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.env.app(qid, args, Some(sort)));
+            return Ok(fenv.ctx.app(qid, args, Some(sort)));
         }
         Kind::ApplySelector => {
             let head = ct.child(0);
@@ -828,9 +798,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let arg = ct.child(1).conv_from_cvc5(fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.env.allocate_symbol(&name);
+            let sym = fenv.ctx.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.env.app(qid, vec![arg], Some(sort)));
+            return Ok(fenv.ctx.app(qid, vec![arg], Some(sort)));
         }
         Kind::ApplyTester => {
             let head = ct.child(0);
@@ -844,21 +814,21 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let arg = ct.child(1).conv_from_cvc5(fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let is_sym = fenv.env.allocate_symbol(IS);
-            let ctor_sym = fenv.env.allocate_symbol(ctor_name);
+            let is_sym = fenv.ctx.allocate_symbol(IS);
+            let ctor_sym = fenv.ctx.allocate_symbol(ctor_name);
             let id = alg::Identifier {
                 symbol: is_sym,
                 indices: vec![Index::Symbol(ctor_sym)],
             };
             let qid = QualifiedIdentifier::from(id);
-            return Ok(fenv.env.app(qid, vec![arg], Some(sort)));
+            return Ok(fenv.ctx.app(qid, vec![arg], Some(sort)));
         }
 
         // ── Variable (bound) ────────────────────────────────────
         Kind::Variable => {
             let cvc5_id = ct.id();
-            if let Some(vb) = fenv.locals.get(&cvc5_id) {
-                return Ok(fenv.env.local(alg::Local {
+            if let Some(vb) = fenv.locals_from.get(&cvc5_id) {
+                return Ok(fenv.ctx.local(alg::Local {
                     id: vb.1,
                     symbol: vb.0.clone(),
                     sort: vb.2.clone(),
@@ -873,9 +843,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let ik = cvc5_kind_to_ident_kind(kind).unwrap();
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.env.allocate_symbol(ik.name());
+            let sym = fenv.ctx.allocate_symbol(ik.name());
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.env.global(qid, Some(sort)));
+            return Ok(fenv.ctx.global(qid, Some(sort)));
         }
 
         // ── BitvectorToNat ──────────────────────────────────────
@@ -883,9 +853,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let child = ct.child(0).conv_from_cvc5(fenv)?;
             let sort = ct.sort().conv_from_cvc5(fenv)?;
 
-            let sym = fenv.env.allocate_symbol(BV2NAT);
+            let sym = fenv.ctx.allocate_symbol(BV2NAT);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.env.app(qid, vec![child], Some(sort)));
+            return Ok(fenv.ctx.app(qid, vec![child], Some(sort)));
         }
 
         // ── Match expressions ───────────────────────────────────
@@ -899,15 +869,15 @@ fn translate_term_from_cvc5<'tm, 'env>(
                 arms.push(arm);
             }
 
-            return Ok(fenv.env.matching(scrutinee, arms));
+            return Ok(fenv.ctx.matching(scrutinee, arms));
         }
         // ── Const array ──────────────────────────────────────────
         Kind::ConstArray => {
             let value = ct.const_array_base().conv_from_cvc5(fenv)?;
             let arr_sort = ct.sort().conv_from_cvc5(fenv)?;
-            let sym = fenv.env.allocate_symbol(CONST);
+            let sym = fenv.ctx.allocate_symbol(CONST);
             let qid = QualifiedIdentifier::simple_sorted(sym, arr_sort.clone());
-            return Ok(fenv.env.app(qid, vec![value], Some(arr_sort)));
+            return Ok(fenv.ctx.app(qid, vec![value], Some(arr_sort)));
         }
 
         // ── Uninterpreted sort value (from models) ──────────────
@@ -915,9 +885,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
             let name = ct.uninterpreted_sort_value();
             let sort = ct.sort().conv_from_cvc5(fenv)?;
             fenv.uninterpreted_values.insert(name.clone());
-            let sym = fenv.env.allocate_symbol(&name);
+            let sym = fenv.ctx.allocate_symbol(&name);
             let qid = QualifiedIdentifier::simple(sym);
-            return Ok(fenv.env.global(qid, Some(sort)));
+            return Ok(fenv.ctx.global(qid, Some(sort)));
         }
 
         // ── Lambda ──────────────────────────────────────────────
@@ -955,9 +925,9 @@ fn translate_term_from_cvc5<'tm, 'env>(
         let sort = ct.sort().conv_from_cvc5(fenv)?;
 
         let name = ik.name();
-        let sym = fenv.env.allocate_symbol(name);
+        let sym = fenv.ctx.allocate_symbol(name);
         let qid = QualifiedIdentifier::simple(sym);
-        return Ok(fenv.env.app(qid, children, Some(sort)));
+        return Ok(fenv.ctx.app(qid, children, Some(sort)));
     }
 
     // ── Indexed operators ───────────────────────────────────
@@ -973,7 +943,7 @@ fn translate_term_from_cvc5<'tm, 'env>(
 
 fn translate_children<'tm, 'env>(
     ct: &CTerm<'tm>,
-    fenv: &mut FromCvc5Env<'tm, 'env>,
+    fenv: &mut Cvc5Env<'tm, 'env>,
 ) -> Res<Vec<Term>> {
     let n = ct.num_children();
     let mut children = Vec::with_capacity(n);
@@ -985,7 +955,7 @@ fn translate_children<'tm, 'env>(
 
 fn translate_match_case_from_cvc5<'tm, 'env>(
     case: &CTerm<'tm>,
-    fenv: &mut FromCvc5Env<'tm, 'env>,
+    fenv: &mut Cvc5Env<'tm, 'env>,
 ) -> Res<alg::PatternArm<Str, Term>> {
     let case_kind = case.kind();
     match case_kind {
@@ -1020,7 +990,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
             };
             let body = case.child(1).conv_from_cvc5(fenv)?;
 
-            let sym = fenv.env.allocate_symbol(&ctor_name);
+            let sym = fenv.ctx.allocate_symbol(&ctor_name);
             Ok(alg::PatternArm {
                 pattern: Pattern::Ctor(sym),
                 body,
@@ -1042,14 +1012,14 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
 
                 if v.has_symbol() {
                     let name = v.symbol().to_string();
-                    let id = fenv.env.new_local();
-                    let sym = fenv.env.allocate_symbol(&name);
+                    let id = fenv.ctx.new_local();
+                    let sym = fenv.ctx.allocate_symbol(&name);
                     let vb = VarBinding(sym.clone(), id, vs);
-                    fenv.locals.insert(cvc5_id, vb);
-                    fenv.push_scope(vec![cvc5_id]);
+                    fenv.locals_from.insert(cvc5_id, vb);
+                    fenv.push_scope_from(vec![cvc5_id]);
 
                     let result = body_ct.conv_from_cvc5(fenv);
-                    fenv.pop_scope();
+                    fenv.pop_scope_from();
                     let body = result?;
                     Ok(alg::PatternArm {
                         pattern: Pattern::Wildcard(Some((sym, id))),
@@ -1083,21 +1053,21 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
                     if arg.has_symbol() {
                         let name = arg.symbol().to_string();
                         let vs = arg.sort().conv_from_cvc5(fenv)?;
-                        let id = fenv.env.new_local();
-                        let sym = fenv.env.allocate_symbol(&name);
-                        fenv.locals.insert(cvc5_id, VarBinding(sym.clone(), id, vs));
+                        let id = fenv.ctx.new_local();
+                        let sym = fenv.ctx.allocate_symbol(&name);
+                        fenv.locals_from.insert(cvc5_id, VarBinding(sym.clone(), id, vs));
                         arguments.push(Some((sym, id)));
                     } else {
                         arguments.push(None);
                     }
                 }
-                fenv.push_scope(scope_ids);
+                fenv.push_scope_from(scope_ids);
 
                 let result = body_ct.conv_from_cvc5(fenv);
-                fenv.pop_scope();
+                fenv.pop_scope_from();
                 let body = result?;
 
-                let ctor_sym = fenv.env.allocate_symbol(&ctor_name);
+                let ctor_sym = fenv.ctx.allocate_symbol(&ctor_name);
                 Ok(alg::PatternArm {
                     pattern: Pattern::Applied {
                         ctor: ctor_sym,
@@ -1114,7 +1084,7 @@ fn translate_match_case_from_cvc5<'tm, 'env>(
 fn translate_indexed_from_cvc5<'tm, 'env>(
     ct: &CTerm<'tm>,
     op: &cvc5::Op<'tm>,
-    fenv: &mut FromCvc5Env<'tm, 'env>,
+    fenv: &mut Cvc5Env<'tm, 'env>,
 ) -> Res<Option<Term>> {
     let op_kind = op.kind();
     let children = translate_children(ct, fenv)?;
@@ -1147,13 +1117,13 @@ fn translate_indexed_from_cvc5<'tm, 'env>(
         _ => return Ok(None),
     };
 
-    let sym = fenv.env.allocate_symbol(name);
+    let sym = fenv.ctx.allocate_symbol(name);
     let id = alg::Identifier {
         symbol: sym,
         indices,
     };
     let qid = QualifiedIdentifier::from(id);
-    Ok(Some(fenv.env.app(qid, children, Some(sort))))
+    Ok(Some(fenv.ctx.app(qid, children, Some(sort))))
 }
 
 /// Reverse mapping from cvc5 Kind to yaspar-ir IdentifierKind.
@@ -1351,11 +1321,12 @@ fn ident_kind_to_cvc5(k: &IdentifierKind) -> Option<Kind> {
 }
 
 // ── Term translation ─────────────────────────────────────────
-impl<'tm> ConvertToCvc5<Cvc5Env<'tm>> for Term {
+impl<'tm, 'env> ConvertToCvc5<Cvc5Env<'tm, 'env>> for Term {
     type Output = CTerm<'tm>;
 
-    fn to_cvc5(&self, env: &mut Cvc5Env<'tm>) -> Res<Self::Output> {
-        env.recurse_on_term(self).map(|t| t.into())
+    fn to_cvc5(&self, env: &mut Cvc5Env<'tm, 'env>) -> Res<Self::Output> {
+        let mut wrapped = MemoizedRecursion(env);
+        MemoizedScheme::term_recursion(&mut wrapped, self).map(|t| t.into())
     }
 }
 
@@ -1363,7 +1334,7 @@ fn to_term_vec(terms: Vec<WithPattern>) -> Vec<CTerm> {
     terms.into_iter().map(|t| t.into()).collect()
 }
 
-impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
+impl<'tm, 'env> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm, 'env> {
     type Out = WithPattern<'tm>;
     type Attr = Vec<Vec<CTerm<'tm>>>;
     type Binding = (usize, WithPattern<'tm>);
@@ -1767,7 +1738,7 @@ impl<'tm> TermRecursor<Str, Sort, Term> for Cvc5EnvInner<'tm> {
     }
 }
 
-impl<'tm> TypedTermRecursor for Cvc5EnvInner<'tm> {}
+impl<'tm, 'env> TypedTermRecursor for Cvc5Env<'tm, 'env> {}
 
 impl<T, Env, E> ConvertToCvc5<Env> for [T]
 where
@@ -1799,7 +1770,7 @@ fn is_const(t: &CTerm) -> bool {
         && (0..t.num_children()).all(|i| is_const(&t.child(i))))
 }
 
-impl<'tm> Cvc5EnvInner<'tm> {
+impl<'tm, 'env> Cvc5Env<'tm, 'env> {
     fn translate_constant(&self, c: &Constant, s: &Sort) -> Res<WithPattern<'tm>> {
         use alg::Constant::*;
         match c {
@@ -2063,10 +2034,10 @@ impl<'tm> Cvc5EnvInner<'tm> {
 }
 
 // ── Command translation ──────────────────────────────────────
-impl<'tm> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm>> for Command {
+impl<'tm> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm, '_>> for Command {
     type Output = CommandResult<'tm>;
 
-    fn to_cvc5(&self, es: &mut Cvc5EnvSolver<'_, 'tm>) -> Res<Self::Output> {
+    fn to_cvc5(&self, es: &mut Cvc5EnvSolver<'_, 'tm, '_>) -> Res<Self::Output> {
         use alg::Command as AC;
         let env = &mut *es.env;
         let solver = &mut *es.solver;
@@ -2233,7 +2204,7 @@ impl<'tm> ConvertToCvc5<Cvc5EnvSolver<'_, 'tm>> for Command {
 }
 
 // ── Command helper methods ───────────────────────────────────
-impl<'tm> Cvc5EnvSolver<'_, 'tm> {
+impl<'tm> Cvc5EnvSolver<'_, 'tm, '_> {
     fn translate_define_fun(
         &mut self,
         fd: &alg::FunctionDef<Str, Sort, Term>,
@@ -2322,7 +2293,7 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm> {
     }
 
     fn build_dt_decls(
-        env: &mut Cvc5EnvInner<'tm>,
+        env: &mut Cvc5Env<'tm, '_>,
         defs: &[alg::DatatypeDef<Str, Sort>],
     ) -> Res<Vec<cvc5::DatatypeDecl<'tm>>> {
         let mut decls = Vec::with_capacity(defs.len());
@@ -2355,7 +2326,7 @@ impl<'tm> Cvc5EnvSolver<'_, 'tm> {
         Ok(decls)
     }
 
-    fn register_dt_functions(env: &mut Cvc5EnvInner<'tm>, sort: CSort<'tm>, dec: &DatatypeDec) {
+    fn register_dt_functions(env: &mut Cvc5Env<'tm, '_>, sort: CSort<'tm>, dec: &DatatypeDec) {
         let dt = sort.datatype();
         for (i, ctor_dec) in dec.constructors.iter().enumerate() {
             let ctor = dt.constructor(i);

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -130,7 +130,7 @@ pub(crate) trait Memoizing<K, V> {
 /// `on_match_arm`, `on_attribute_*`) delegate directly without caching.
 ///
 /// This type is not public — users interact with [`Memoize`] directly.
-pub(crate) struct MemoizedRecursion<'a, R>(&'a mut R);
+pub(crate) struct MemoizedRecursion<'a, R>(pub(crate) &'a mut R);
 
 impl<Str, So, T, R> TermRecursor<Str, So, T> for MemoizedRecursion<'_, R>
 where

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -19,6 +19,10 @@
 
 use crate::allocator::StrAllocator;
 use crate::ast::{HasArenaAlt, Str};
+use std::cell::{RefCell, RefMut};
+use std::ops::DerefMut;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 /// A unifying trait to pull content from a wrapper type
 ///
@@ -58,6 +62,15 @@ pub trait Allocatable<Env> {
     type Out;
 
     fn allocate(&self, env: &mut Env) -> Self::Out;
+}
+
+/// a trait that specifies a mutable reference of `Target` can be extract from `Self`
+pub trait HasMutRef<Target> {
+    type RefMut<'a>: DerefMut<Target = Target>
+    where
+        Self: 'a;
+
+    fn ref_mut(&mut self) -> Self::RefMut<'_>;
 }
 
 impl Contains for str {
@@ -161,3 +174,47 @@ where
 pub trait AllocatableString<Env>: Allocatable<Env, Out = Str> + MetaData {}
 
 impl<Env, T> AllocatableString<Env> for T where T: Allocatable<Env, Out = Str> + MetaData {}
+
+impl<X> HasMutRef<X> for X {
+    type RefMut<'a>
+        = &'a mut X
+    where
+        X: 'a;
+
+    fn ref_mut(&mut self) -> Self::RefMut<'_> {
+        self
+    }
+}
+
+impl<X> HasMutRef<X> for &mut X {
+    type RefMut<'a>
+        = &'a mut X
+    where
+        Self: 'a;
+
+    fn ref_mut(&mut self) -> Self::RefMut<'_> {
+        self
+    }
+}
+
+impl<X> HasMutRef<X> for Rc<RefCell<X>> {
+    type RefMut<'a>
+        = RefMut<'a, X>
+    where
+        X: 'a;
+
+    fn ref_mut(&mut self) -> Self::RefMut<'_> {
+        self.borrow_mut()
+    }
+}
+
+impl<X> HasMutRef<X> for Arc<Mutex<X>> {
+    type RefMut<'a>
+        = MutexGuard<'a, X>
+    where
+        Self: 'a;
+
+    fn ref_mut(&mut self) -> Self::RefMut<'_> {
+        self.lock().unwrap()
+    }
+}

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -5,7 +5,7 @@
 
 use cvc5::{Kind, Solver, TermManager};
 use yaspar_ir::ast::{Context, ObjectAllocatorExt, Typecheck};
-use yaspar_ir::cvc5::{ConvertFromCvc5, ConvertToCvc5, Cvc5Env, Cvc5EnvSolver};
+use yaspar_ir::cvc5::{CTerm, ConvertFromCvc5, ConvertToCvc5, Cvc5Env, Cvc5EnvSolver};
 use yaspar_ir::untyped::UntypedAst;
 
 /// Helper: parse + type-check a script, then translate all commands to cvc5.
@@ -2206,4 +2206,470 @@ fn from_cvc5_match_parametric_bool_instantiation() {
          (declare-const l (List Bool))",
         "(match l ((nil false) ((cons h t) h)))",
     );
+}
+
+// ── Backward translation built directly from cvc5 APIs ───────
+//
+// These tests construct cvc5 terms using only cvc5's own builders
+// (no yaspar-ir parsing or term construction), then back-translate via
+// `conv_from_cvc5` and compare the resulting yaspar-ir term's
+// SMT-LIB-formatted `to_string()` against an expected literal.
+
+/// Build a cvc5 environment, run a closure that constructs a CTerm using cvc5
+/// APIs only, and assert that the back-translated yaspar-ir term's string
+/// representation matches `expected`.
+fn assert_back_eq<F>(expected: &str, build: F)
+where
+    F: for<'tm> FnOnce(&'tm TermManager) -> CTerm<'tm>,
+{
+    let tm = TermManager::new();
+    let mut ctx = Context::new();
+    ctx.ensure_logic();
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let cterm = build(&tm);
+    let back = cterm.conv_from_cvc5(&mut env).unwrap();
+    assert_eq!(back.to_string(), expected);
+}
+
+#[test]
+fn back_from_cvc5_api_bool_true() {
+    assert_back_eq("true", |tm| tm.mk_true());
+}
+
+#[test]
+fn back_from_cvc5_api_bool_false() {
+    assert_back_eq("false", |tm| tm.mk_false());
+}
+
+#[test]
+fn back_from_cvc5_api_integer_literal() {
+    assert_back_eq("42", |tm| tm.mk_integer(42));
+}
+
+#[test]
+fn back_from_cvc5_api_const_int() {
+    assert_back_eq("x", |tm| tm.mk_const(tm.integer_sort(), "x"));
+}
+
+#[test]
+fn back_from_cvc5_api_add() {
+    assert_back_eq("(+ x 1)", |tm| {
+        let x = tm.mk_const(tm.integer_sort(), "x");
+        let one = tm.mk_integer(1);
+        tm.mk_term(Kind::Add, &[x, one])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_sub() {
+    assert_back_eq("(- x y)", |tm| {
+        let int = tm.integer_sort();
+        let x = tm.mk_const(int.clone(), "x");
+        let y = tm.mk_const(int, "y");
+        tm.mk_term(Kind::Sub, &[x, y])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_mul() {
+    assert_back_eq("(* x y)", |tm| {
+        let int = tm.integer_sort();
+        let x = tm.mk_const(int.clone(), "x");
+        let y = tm.mk_const(int, "y");
+        tm.mk_term(Kind::Mult, &[x, y])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_neg() {
+    assert_back_eq("(- x)", |tm| {
+        let x = tm.mk_const(tm.integer_sort(), "x");
+        tm.mk_term(Kind::Neg, &[x])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_lt() {
+    assert_back_eq("(< x y)", |tm| {
+        let int = tm.integer_sort();
+        let x = tm.mk_const(int.clone(), "x");
+        let y = tm.mk_const(int, "y");
+        tm.mk_term(Kind::Lt, &[x, y])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_le() {
+    assert_back_eq("(<= x y)", |tm| {
+        let int = tm.integer_sort();
+        let x = tm.mk_const(int.clone(), "x");
+        let y = tm.mk_const(int, "y");
+        tm.mk_term(Kind::Leq, &[x, y])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_gt() {
+    assert_back_eq("(> x y)", |tm| {
+        let int = tm.integer_sort();
+        let x = tm.mk_const(int.clone(), "x");
+        let y = tm.mk_const(int, "y");
+        tm.mk_term(Kind::Gt, &[x, y])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_ge() {
+    assert_back_eq("(>= x y)", |tm| {
+        let int = tm.integer_sort();
+        let x = tm.mk_const(int.clone(), "x");
+        let y = tm.mk_const(int, "y");
+        tm.mk_term(Kind::Geq, &[x, y])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_and() {
+    assert_back_eq("(and a b)", |tm| {
+        let bool_sort = tm.boolean_sort();
+        let a = tm.mk_const(bool_sort.clone(), "a");
+        let b = tm.mk_const(bool_sort, "b");
+        tm.mk_term(Kind::And, &[a, b])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_or() {
+    assert_back_eq("(or a b)", |tm| {
+        let bool_sort = tm.boolean_sort();
+        let a = tm.mk_const(bool_sort.clone(), "a");
+        let b = tm.mk_const(bool_sort, "b");
+        tm.mk_term(Kind::Or, &[a, b])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_not() {
+    assert_back_eq("(not a)", |tm| {
+        let a = tm.mk_const(tm.boolean_sort(), "a");
+        tm.mk_term(Kind::Not, &[a])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_xor() {
+    assert_back_eq("(xor a b)", |tm| {
+        let bool_sort = tm.boolean_sort();
+        let a = tm.mk_const(bool_sort.clone(), "a");
+        let b = tm.mk_const(bool_sort, "b");
+        tm.mk_term(Kind::Xor, &[a, b])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_implies() {
+    assert_back_eq("(=> a b)", |tm| {
+        let bool_sort = tm.boolean_sort();
+        let a = tm.mk_const(bool_sort.clone(), "a");
+        let b = tm.mk_const(bool_sort, "b");
+        tm.mk_term(Kind::Implies, &[a, b])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_eq() {
+    assert_back_eq("(= x y)", |tm| {
+        let int = tm.integer_sort();
+        let x = tm.mk_const(int.clone(), "x");
+        let y = tm.mk_const(int, "y");
+        tm.mk_term(Kind::Equal, &[x, y])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_eq_chain_three() {
+    // n-ary cvc5 equality back-translates to a conjunction of pairwise equalities
+    assert_back_eq("(and (= x y) (= y z))", |tm| {
+        let int = tm.integer_sort();
+        let x = tm.mk_const(int.clone(), "x");
+        let y = tm.mk_const(int.clone(), "y");
+        let z = tm.mk_const(int, "z");
+        tm.mk_term(Kind::Equal, &[x, y, z])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_distinct() {
+    assert_back_eq("(distinct x y z)", |tm| {
+        let int = tm.integer_sort();
+        let x = tm.mk_const(int.clone(), "x");
+        let y = tm.mk_const(int.clone(), "y");
+        let z = tm.mk_const(int, "z");
+        tm.mk_term(Kind::Distinct, &[x, y, z])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_ite() {
+    assert_back_eq("(ite a x y)", |tm| {
+        let int = tm.integer_sort();
+        let a = tm.mk_const(tm.boolean_sort(), "a");
+        let x = tm.mk_const(int.clone(), "x");
+        let y = tm.mk_const(int, "y");
+        tm.mk_term(Kind::Ite, &[a, x, y])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_uf_application() {
+    assert_back_eq("(f x y)", |tm| {
+        let int = tm.integer_sort();
+        let fun_sort = tm.mk_fun_sort(&[int.clone(), int.clone()], int.clone());
+        let f = tm.mk_const(fun_sort, "f");
+        let x = tm.mk_const(int.clone(), "x");
+        let y = tm.mk_const(int, "y");
+        tm.mk_term(Kind::ApplyUf, &[f, x, y])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_select_store() {
+    assert_back_eq("(select (store a i v) i)", |tm| {
+        let int = tm.integer_sort();
+        let arr = tm.mk_array_sort(int.clone(), int.clone());
+        let a = tm.mk_const(arr, "a");
+        let i = tm.mk_const(int.clone(), "i");
+        let v = tm.mk_const(int, "v");
+        let store = tm.mk_term(Kind::Store, &[a, i.clone(), v]);
+        tm.mk_term(Kind::Select, &[store, i])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_bv_add() {
+    assert_back_eq("(bvadd x y)", |tm| {
+        let bv8 = tm.mk_bv_sort(8);
+        let x = tm.mk_const(bv8.clone(), "x");
+        let y = tm.mk_const(bv8, "y");
+        tm.mk_term(Kind::BitvectorAdd, &[x, y])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_bv_not() {
+    assert_back_eq("(bvnot x)", |tm| {
+        let x = tm.mk_const(tm.mk_bv_sort(8), "x");
+        tm.mk_term(Kind::BitvectorNot, &[x])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_bv_concat() {
+    assert_back_eq("(concat x y)", |tm| {
+        let bv4 = tm.mk_bv_sort(4);
+        let x = tm.mk_const(bv4.clone(), "x");
+        let y = tm.mk_const(bv4, "y");
+        tm.mk_term(Kind::BitvectorConcat, &[x, y])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_bv_extract() {
+    assert_back_eq("((_ extract 3 0) x)", |tm| {
+        let x = tm.mk_const(tm.mk_bv_sort(8), "x");
+        let op = tm.mk_op(Kind::BitvectorExtract, &[3, 0]);
+        tm.mk_term_from_op(op, &[x])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_bv_zero_extend() {
+    assert_back_eq("((_ zero_extend 8) x)", |tm| {
+        let x = tm.mk_const(tm.mk_bv_sort(8), "x");
+        let op = tm.mk_op(Kind::BitvectorZeroExtend, &[8]);
+        tm.mk_term_from_op(op, &[x])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_bv_repeat() {
+    assert_back_eq("((_ repeat 2) x)", |tm| {
+        let x = tm.mk_const(tm.mk_bv_sort(4), "x");
+        let op = tm.mk_op(Kind::BitvectorRepeat, &[2]);
+        tm.mk_term_from_op(op, &[x])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_bv_rotate_left() {
+    assert_back_eq("((_ rotate_left 3) x)", |tm| {
+        let x = tm.mk_const(tm.mk_bv_sort(8), "x");
+        let op = tm.mk_op(Kind::BitvectorRotateLeft, &[3]);
+        tm.mk_term_from_op(op, &[x])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_string_concat() {
+    assert_back_eq("(str.++ s1 s2)", |tm| {
+        let str_sort = tm.string_sort();
+        let s1 = tm.mk_const(str_sort.clone(), "s1");
+        let s2 = tm.mk_const(str_sort, "s2");
+        tm.mk_term(Kind::StringConcat, &[s1, s2])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_string_len() {
+    assert_back_eq("(str.len s)", |tm| {
+        let s = tm.mk_const(tm.string_sort(), "s");
+        tm.mk_term(Kind::StringLength, &[s])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_re_none() {
+    assert_back_eq("re.none", |tm| tm.mk_regexp_none());
+}
+
+#[test]
+fn back_from_cvc5_api_re_all() {
+    assert_back_eq("re.all", |tm| tm.mk_regexp_all());
+}
+
+#[test]
+fn back_from_cvc5_api_re_allchar() {
+    assert_back_eq("re.allchar", |tm| tm.mk_regexp_allchar());
+}
+
+#[test]
+fn back_from_cvc5_api_forall() {
+    assert_back_eq("(forall ((x Int)) (> x 0))", |tm| {
+        let int = tm.integer_sort();
+        let x = tm.mk_var(int, "x");
+        let zero = tm.mk_integer(0);
+        let body = tm.mk_term(Kind::Gt, &[x.clone(), zero]);
+        let bound = tm.mk_term(Kind::VariableList, std::slice::from_ref(&x));
+        tm.mk_term(Kind::Forall, &[bound, body])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_exists() {
+    assert_back_eq("(exists ((x Int)) (= x 0))", |tm| {
+        let int = tm.integer_sort();
+        let x = tm.mk_var(int, "x");
+        let zero = tm.mk_integer(0);
+        let body = tm.mk_term(Kind::Equal, &[x.clone(), zero]);
+        let bound = tm.mk_term(Kind::VariableList, std::slice::from_ref(&x));
+        tm.mk_term(Kind::Exists, &[bound, body])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_nested_arithmetic() {
+    assert_back_eq("(+ (* x 2) y)", |tm| {
+        let int = tm.integer_sort();
+        let x = tm.mk_const(int.clone(), "x");
+        let y = tm.mk_const(int, "y");
+        let two = tm.mk_integer(2);
+        let mul = tm.mk_term(Kind::Mult, &[x, two]);
+        tm.mk_term(Kind::Add, &[mul, y])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_datatype_nullary_constructor() {
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    solver.set_logic("ALL");
+    let red = tm.mk_dt_cons_decl("Red");
+    let green = tm.mk_dt_cons_decl("Green");
+    let blue = tm.mk_dt_cons_decl("Blue");
+    let color_sort = solver.declare_dt("Color", &[red, green, blue]);
+    let dt = color_sort.datatype();
+    let ctor = dt.constructor(0).term();
+    let red_term = tm.mk_term(Kind::ApplyConstructor, &[ctor]);
+
+    let mut ctx = Context::new();
+    ctx.ensure_logic();
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let back = red_term.conv_from_cvc5(&mut env).unwrap();
+    assert_eq!(back.to_string(), "Red");
+}
+
+#[test]
+fn back_from_cvc5_api_datatype_applied_constructor() {
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    solver.set_logic("ALL");
+    let int = tm.integer_sort();
+    let mut mkpair = tm.mk_dt_cons_decl("mkpair");
+    mkpair.add_selector("fst", int.clone());
+    mkpair.add_selector("snd", int.clone());
+    let pair_sort = solver.declare_dt("Pair", &[mkpair]);
+    let dt = pair_sort.datatype();
+    let ctor = dt.constructor(0).term();
+    let one = tm.mk_integer(1);
+    let two = tm.mk_integer(2);
+    let pair = tm.mk_term(Kind::ApplyConstructor, &[ctor, one, two]);
+
+    let mut ctx = Context::new();
+    ctx.ensure_logic();
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let back = pair.conv_from_cvc5(&mut env).unwrap();
+    assert_eq!(back.to_string(), "(mkpair 1 2)");
+}
+
+#[test]
+fn back_from_cvc5_api_datatype_selector() {
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    solver.set_logic("ALL");
+    let int = tm.integer_sort();
+    let mut mkpair = tm.mk_dt_cons_decl("mkpair");
+    mkpair.add_selector("fst", int.clone());
+    mkpair.add_selector("snd", int.clone());
+    let pair_sort = solver.declare_dt("Pair", &[mkpair]);
+    let dt = pair_sort.datatype();
+    let sel = dt.constructor(0).selector(0).term();
+    let p = tm.mk_const(pair_sort, "p");
+    let fst_p = tm.mk_term(Kind::ApplySelector, &[sel, p]);
+
+    let mut ctx = Context::new();
+    ctx.ensure_logic();
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let back = fst_p.conv_from_cvc5(&mut env).unwrap();
+    assert_eq!(back.to_string(), "(fst p)");
+}
+
+#[test]
+fn back_from_cvc5_api_datatype_tester() {
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    solver.set_logic("ALL");
+    let red = tm.mk_dt_cons_decl("Red");
+    let green = tm.mk_dt_cons_decl("Green");
+    let blue = tm.mk_dt_cons_decl("Blue");
+    let color_sort = solver.declare_dt("Color", &[red, green, blue]);
+    let dt = color_sort.datatype();
+    let tester = dt.constructor(0).tester_term();
+    let c = tm.mk_const(color_sort, "c");
+    let is_red = tm.mk_term(Kind::ApplyTester, &[tester, c]);
+
+    let mut ctx = Context::new();
+    ctx.ensure_logic();
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let back = is_red.conv_from_cvc5(&mut env).unwrap();
+    assert_eq!(back.to_string(), "((_ is Red) c)");
+}
+
+#[test]
+fn back_from_cvc5_api_const_array() {
+    assert_back_eq("((as const (Array Int Int)) 0)", |tm| {
+        let int = tm.integer_sort();
+        let arr = tm.mk_array_sort(int.clone(), int);
+        let zero = tm.mk_integer(0);
+        tm.mk_const_array(arr, zero)
+    });
 }

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -5,7 +5,7 @@
 
 use cvc5::{Kind, Solver, TermManager};
 use yaspar_ir::ast::{Context, ObjectAllocatorExt, Typecheck};
-use yaspar_ir::cvc5::{ConvertFromCvc5, ConvertToCvc5, Cvc5Env, Cvc5EnvSolver, FromCvc5Env};
+use yaspar_ir::cvc5::{ConvertFromCvc5, ConvertToCvc5, Cvc5Env, Cvc5EnvSolver};
 use yaspar_ir::untyped::UntypedAst;
 
 /// Helper: parse + type-check a script, then translate all commands to cvc5.
@@ -18,7 +18,7 @@ fn run_script(script: &str) {
         .unwrap();
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     for cmd in &cmds {
         cmd.to_cvc5(&mut es).unwrap();
@@ -36,7 +36,7 @@ fn check_sat(script: &str) -> bool {
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
     solver.set_option("produce-models", "true");
-    let mut env = Cvc5Env::create(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     for cmd in &cmds {
         cmd.to_cvc5(&mut es).unwrap();
@@ -276,7 +276,7 @@ fn translate_term_standalone() {
         .unwrap();
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     for cmd in &cmds {
         cmd.to_cvc5(&mut es).unwrap();
@@ -294,7 +294,7 @@ fn error_unknown_global() {
     let int_sort = ctx.int_sort();
     let x = ctx.simple_sorted_symbol("x", int_sort);
     let tm = TermManager::new();
-    let mut env = Cvc5Env::create(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
     assert!(x.to_cvc5(&mut env).is_err());
 }
 
@@ -305,7 +305,7 @@ fn error_unsupported_sort() {
     // A custom sort that cvc5 doesn't know about
     let custom = ctx.simple_sort("MyCustomSort");
     let tm = TermManager::new();
-    let mut env = Cvc5Env::create(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
     assert!(custom.to_cvc5(&mut env).is_err());
 }
 
@@ -328,7 +328,7 @@ fn locals_cleaned_up_after_quantifier_error() {
 
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
 
     // Translate set-logic only — skip declare-const y
     cmds[0]
@@ -368,7 +368,7 @@ fn locals_cleaned_up_after_let_error() {
 
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     cmds[0].to_cvc5(&mut es).unwrap();
     // Skip declare-const y
@@ -397,7 +397,7 @@ fn locals_cleaned_up_after_define_fun_error() {
 
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     cmds[0].to_cvc5(&mut es).unwrap();
     // Skip declare-const y
@@ -428,7 +428,7 @@ fn named_annotation_registers_global() {
 
     let tm = TermManager::new();
     let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     // All commands should succeed — "pos" from :named must be usable in the second assert
     for cmd in &cmds {
@@ -634,7 +634,7 @@ fn with_script_results(script: &str, options: &[(&str, &str)], f: impl FnOnce(&[
     for (k, v) in options {
         solver.set_option(k, v);
     }
-    let mut env = Cvc5Env::create(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
     let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
     let results: Vec<_> = cmds
         .iter()
@@ -968,21 +968,20 @@ fn sort_round_trip(script: &str, sort_str: &str) {
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
-    let tm = TermManager::new();
-    let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
-    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
-    for cmd in &_cmds {
-        cmd.to_cvc5(&mut es).unwrap();
-    }
     let sort = UntypedAst
         .parse_sort_str(sort_str)
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &_cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
     let csort = sort.to_cvc5(&mut *es.env).unwrap();
-    let mut from_env = FromCvc5Env::new(&mut ctx);
-    let back = csort.conv_from_cvc5(&mut from_env).unwrap();
+    let back = csort.conv_from_cvc5(&mut *es.env).unwrap();
     assert_eq!(sort.to_string(), back.to_string());
 }
 
@@ -1044,9 +1043,9 @@ fn from_cvc5_sort_cache_hit() {
     let tm = TermManager::new();
     let csort = tm.integer_sort();
     let mut ctx = Context::new();
-    let mut from_env = FromCvc5Env::new(&mut ctx);
-    let back1 = csort.conv_from_cvc5(&mut from_env).unwrap();
-    let back2 = csort.conv_from_cvc5(&mut from_env).unwrap();
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let back1 = csort.conv_from_cvc5(&mut env).unwrap();
+    let back2 = csort.conv_from_cvc5(&mut env).unwrap();
     assert_eq!(back1, back2);
 }
 
@@ -1100,19 +1099,19 @@ fn const_array_negative() {
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
-    let tm = TermManager::new();
-    let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
-    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
-
-    for cmd in &cmds {
-        cmd.to_cvc5(&mut es).unwrap();
-    }
     let term = UntypedAst
         .parse_term_str("(= a ((as const (Array Int Bool)) b))")
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+
+    for cmd in &cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
     assert!(term.to_cvc5(&mut env).is_err());
 }
 /// Helper: translate a yaspar-ir Term to cvc5 and back, asserting the round-trip
@@ -1124,21 +1123,20 @@ fn term_round_trip(script: &str, term_str: &str) {
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
-    let tm = TermManager::new();
-    let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
-    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
-    for cmd in &cmds {
-        cmd.to_cvc5(&mut es).unwrap();
-    }
     let term = UntypedAst
         .parse_term_str(term_str)
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
     let cterm = term.to_cvc5(&mut *es.env).unwrap();
-    let mut from_env = FromCvc5Env::new(&mut ctx);
-    let back = cterm.conv_from_cvc5(&mut from_env).unwrap();
+    let back = cterm.conv_from_cvc5(&mut *es.env).unwrap();
     assert_eq!(term.to_string(), back.to_string());
 }
 
@@ -1366,14 +1364,6 @@ fn from_cvc5_term_chained_eq() {
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
-    let tm = TermManager::new();
-    let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
-    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
-    for cmd in &_cmds {
-        cmd.to_cvc5(&mut es).unwrap();
-    }
-    // Build (= x y z) by translating individual terms and combining
     let x = UntypedAst
         .parse_term_str("x")
         .unwrap()
@@ -1389,12 +1379,18 @@ fn from_cvc5_term_chained_eq() {
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &_cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
     let cx = x.to_cvc5(&mut *es.env).unwrap();
     let cy = y.to_cvc5(&mut *es.env).unwrap();
     let cz = z.to_cvc5(&mut *es.env).unwrap();
     let eq_xyz = tm.mk_term(Kind::Equal, &[cx, cy, cz]);
-    let mut from_env = FromCvc5Env::new(&mut ctx);
-    let back = eq_xyz.conv_from_cvc5(&mut from_env).unwrap();
+    let back = eq_xyz.conv_from_cvc5(&mut *es.env).unwrap();
     assert_eq!(back.to_string(), "(and (= x y) (= y z))");
 }
 
@@ -1641,21 +1637,20 @@ fn from_cvc5_term_real_literal() {
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
-    let tm = TermManager::new();
-    let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
-    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
-    for cmd in &_cmds {
-        cmd.to_cvc5(&mut es).unwrap();
-    }
     let term = UntypedAst
         .parse_term_str("(+ x 1.5)")
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &_cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
     let cterm = term.to_cvc5(&mut *es.env).unwrap();
-    let mut from_env = FromCvc5Env::new(&mut ctx);
-    let back = cterm.conv_from_cvc5(&mut from_env).unwrap();
+    let back = cterm.conv_from_cvc5(&mut *es.env).unwrap();
     assert_eq!(back.to_string(), "(+ x (/ 3 2))");
 }
 
@@ -1694,21 +1689,20 @@ fn from_cvc5_term_real_integer_value() {
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
-    let tm = TermManager::new();
-    let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
-    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
-    for cmd in &_cmds {
-        cmd.to_cvc5(&mut es).unwrap();
-    }
     let term = UntypedAst
         .parse_term_str("(+ x 3.0)")
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &_cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
     let cterm = term.to_cvc5(&mut *es.env).unwrap();
-    let mut from_env = FromCvc5Env::new(&mut ctx);
-    let back = cterm.conv_from_cvc5(&mut from_env).unwrap();
+    let back = cterm.conv_from_cvc5(&mut *es.env).unwrap();
     // cvc5 returns "3" for the real value 3.0; reverse produces (/ 3 1) or 3.0
     assert!(back.to_string().contains("3"));
 }
@@ -1722,21 +1716,20 @@ fn from_cvc5_term_real_in_lira() {
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
-    let tm = TermManager::new();
-    let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
-    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
-    for cmd in &_cmds {
-        cmd.to_cvc5(&mut es).unwrap();
-    }
     let term = UntypedAst
         .parse_term_str("(+ x 1.5)")
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &_cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
     let cterm = term.to_cvc5(&mut *es.env).unwrap();
-    let mut from_env = FromCvc5Env::new(&mut ctx);
-    let back = cterm.conv_from_cvc5(&mut from_env).unwrap();
+    let back = cterm.conv_from_cvc5(&mut *es.env).unwrap();
     // In LIRA, 1.5 = 3/2 should use decimal constants: (/ 3.0 2.0)
     assert_eq!(back.to_string(), "(+ x (/ 3.0 2.0))");
 }
@@ -1890,21 +1883,20 @@ fn from_cvc5_term_hex_bv_literal() {
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
-    let tm = TermManager::new();
-    let mut solver = Solver::new(&tm);
-    let mut env = Cvc5Env::create(&tm);
-    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
-    for cmd in &_cmds {
-        cmd.to_cvc5(&mut es).unwrap();
-    }
     let term = UntypedAst
         .parse_term_str("(bvadd x #xab)")
         .unwrap()
         .type_check(&mut ctx)
         .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &_cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
     let cterm = term.to_cvc5(&mut *es.env).unwrap();
-    let mut from_env = FromCvc5Env::new(&mut ctx);
-    let back = cterm.conv_from_cvc5(&mut from_env).unwrap();
+    let back = cterm.conv_from_cvc5(&mut *es.env).unwrap();
     assert_eq!(back.to_string(), "(bvadd x #b10101011)");
 }
 

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -851,7 +851,7 @@ fn command_result_get_assertions_preserves_terms() {
 }
 
 #[test]
-fn command_result_get_unsat_core_returns_assertion_bodies() {
+fn command_result_get_unsat_core_returns_named_labels() {
     with_script_results(
         "(set-logic QF_LIA)
          (declare-const x Int)
@@ -864,10 +864,8 @@ fn command_result_get_unsat_core_returns_assertion_bodies() {
             CommandResult::Terms(ts) => {
                 assert_eq!(ts.len(), 2);
                 let s: Vec<String> = ts.iter().map(|t| t.to_string()).collect();
-                // cvc5's get-unsat-core returns the assertion bodies, not the
-                // SMT-LIB `:named` labels.
-                let a = "(> x 0)";
-                let b = "(< x 0)";
+                let a = "a1";
+                let b = "a2";
                 assert!(
                     (s[0] == a && s[1] == b) || (s[0] == b && s[1] == a),
                     "expected {{ {a:?}, {b:?} }} in some order, got {s:?}"

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -765,6 +765,143 @@ fn command_result_get_unsat_core() {
 }
 
 #[test]
+fn command_result_get_value_returns_term_value() {
+    with_script_results(
+        "(set-logic QF_LIA)
+         (declare-const x Int)
+         (assert (= x 42))
+         (check-sat)
+         (get-value (x))",
+        &[("produce-models", "true")],
+        |results| match results.last().unwrap() {
+            CommandResult::GetValue(vals) => {
+                assert_eq!(vals.len(), 1);
+                assert_eq!(vals[0].to_string(), "42");
+            }
+            other => panic!("expected GetValue, got {other:?}"),
+        },
+    );
+}
+
+#[test]
+fn command_result_get_value_multiple() {
+    with_script_results(
+        "(set-logic QF_LIA)
+         (declare-const x Int)
+         (declare-const y Int)
+         (assert (= x 7))
+         (assert (= y 13))
+         (check-sat)
+         (get-value (x y (+ x y)))",
+        &[("produce-models", "true")],
+        |results| match results.last().unwrap() {
+            CommandResult::GetValue(vals) => {
+                assert_eq!(vals.len(), 3);
+                assert_eq!(vals[0].to_string(), "7");
+                assert_eq!(vals[1].to_string(), "13");
+                assert_eq!(vals[2].to_string(), "20");
+            }
+            other => panic!("expected GetValue, got {other:?}"),
+        },
+    );
+}
+
+#[test]
+fn command_result_get_value_bool() {
+    with_script_results(
+        "(set-logic QF_LIA)
+         (declare-const p Bool)
+         (assert p)
+         (check-sat)
+         (get-value (p))",
+        &[("produce-models", "true")],
+        |results| match results.last().unwrap() {
+            CommandResult::GetValue(vals) => {
+                assert_eq!(vals.len(), 1);
+                assert_eq!(vals[0].to_string(), "true");
+            }
+            other => panic!("expected GetValue, got {other:?}"),
+        },
+    );
+}
+
+#[test]
+fn command_result_get_assertions_preserves_terms() {
+    with_script_results(
+        "(set-logic QF_LIA)
+         (declare-const x Int)
+         (assert (> x 0))
+         (assert (< x 10))
+         (get-assertions)",
+        &[("produce-assertions", "true")],
+        |results| match results.last().unwrap() {
+            CommandResult::Terms(ts) => {
+                assert_eq!(ts.len(), 2);
+                let s: Vec<String> = ts.iter().map(|t| t.to_string()).collect();
+                let a = "(> x 0)";
+                let b = "(< x 10)";
+                assert!(
+                    (s[0] == a && s[1] == b) || (s[0] == b && s[1] == a),
+                    "expected {{ {a:?}, {b:?} }} in some order, got {s:?}"
+                );
+            }
+            other => panic!("expected Terms, got {other:?}"),
+        },
+    );
+}
+
+#[test]
+fn command_result_get_unsat_core_returns_assertion_bodies() {
+    with_script_results(
+        "(set-logic QF_LIA)
+         (declare-const x Int)
+         (assert (! (> x 0) :named a1))
+         (assert (! (< x 0) :named a2))
+         (check-sat)
+         (get-unsat-core)",
+        &[("produce-unsat-cores", "true")],
+        |results| match results.last().unwrap() {
+            CommandResult::Terms(ts) => {
+                assert_eq!(ts.len(), 2);
+                let s: Vec<String> = ts.iter().map(|t| t.to_string()).collect();
+                // cvc5's get-unsat-core returns the assertion bodies, not the
+                // SMT-LIB `:named` labels.
+                let a = "(> x 0)";
+                let b = "(< x 0)";
+                assert!(
+                    (s[0] == a && s[1] == b) || (s[0] == b && s[1] == a),
+                    "expected {{ {a:?}, {b:?} }} in some order, got {s:?}"
+                );
+            }
+            other => panic!("expected Terms, got {other:?}"),
+        },
+    );
+}
+
+#[test]
+fn command_result_get_unsat_assumptions_returns_terms() {
+    with_script_results(
+        "(set-logic QF_LIA)
+         (declare-const x Int)
+         (declare-const p Bool)
+         (declare-const q Bool)
+         (assert (=> p (> x 0)))
+         (assert (=> q (< x 0)))
+         (check-sat-assuming (p q))
+         (get-unsat-assumptions)",
+        &[("produce-unsat-assumptions", "true")],
+        |results| match results.last().unwrap() {
+            CommandResult::Terms(ts) => {
+                assert!(!ts.is_empty(), "expected at least one assumption");
+                let names: Vec<String> = ts.iter().map(|t| t.to_string()).collect();
+                assert!(names.iter().all(|n| n == "p" || n == "q"));
+            }
+            other => panic!("expected Terms, got {other:?}"),
+        },
+    );
+}
+
+#[test]
 fn command_result_get_info() {
     with_script_results(
         "(set-logic QF_LIA)

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -877,6 +877,32 @@ fn command_result_get_unsat_core_returns_named_labels() {
 }
 
 #[test]
+fn command_result_get_unsat_core_mixes_named_and_unnamed() {
+    with_script_results(
+        "(set-logic QF_LIA)
+         (declare-const x Int)
+         (assert (! (> x 0) :named pos))
+         (assert (< x 0))
+         (check-sat)
+         (get-unsat-core)",
+        &[("produce-unsat-cores", "true")],
+        |results| match results.last().unwrap() {
+            CommandResult::Terms(ts) => {
+                assert_eq!(ts.len(), 2);
+                let s: Vec<String> = ts.iter().map(|t| t.to_string()).collect();
+                let a = "pos";
+                let b = "(< x 0)";
+                assert!(
+                    (s[0] == a && s[1] == b) || (s[0] == b && s[1] == a),
+                    "expected {{ {a:?}, {b:?} }} in some order, got {s:?}"
+                );
+            }
+            other => panic!("expected Terms, got {other:?}"),
+        },
+    );
+}
+
+#[test]
 fn command_result_get_unsat_assumptions_returns_terms() {
     with_script_results(
         "(set-logic QF_LIA)

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -1630,7 +1630,7 @@ fn from_cvc5_term_match_wildcard() {
 
 #[test]
 fn from_cvc5_term_real_literal() {
-    // 1.5 is represented as 3/2 in cvc5; reverse translates to (/ 3 2)
+    // The forward-cached round-trip returns the original Term unchanged.
     let mut ctx = Context::new();
     let _cmds = UntypedAst
         .parse_script_str("(set-logic QF_LRA) (declare-const x Real)")
@@ -1651,7 +1651,7 @@ fn from_cvc5_term_real_literal() {
     }
     let cterm = term.to_cvc5(&mut *es.env).unwrap();
     let back = cterm.conv_from_cvc5(&mut *es.env).unwrap();
-    assert_eq!(back.to_string(), "(+ x (/ 3 2))");
+    assert_eq!(back.to_string(), "(+ x 1.5)");
 }
 
 #[test]
@@ -1709,7 +1709,7 @@ fn from_cvc5_term_real_integer_value() {
 
 #[test]
 fn from_cvc5_term_real_in_lira() {
-    // In LIRA logic (RealInts), real division should use decimal constants
+    // The forward-cached round-trip returns the original Term unchanged.
     let mut ctx = Context::new();
     let _cmds = UntypedAst
         .parse_script_str("(set-logic AUFLIRA) (declare-const x Real)")
@@ -1730,8 +1730,7 @@ fn from_cvc5_term_real_in_lira() {
     }
     let cterm = term.to_cvc5(&mut *es.env).unwrap();
     let back = cterm.conv_from_cvc5(&mut *es.env).unwrap();
-    // In LIRA, 1.5 = 3/2 should use decimal constants: (/ 3.0 2.0)
-    assert_eq!(back.to_string(), "(+ x (/ 3.0 2.0))");
+    assert_eq!(back.to_string(), "(+ x 1.5)");
 }
 
 #[test]
@@ -1876,7 +1875,7 @@ fn from_cvc5_term_str_prefixof() {
 
 #[test]
 fn from_cvc5_term_hex_bv_literal() {
-    // Hex literals are normalized to binary in the round-trip
+    // The forward-cached round-trip returns the original Term unchanged.
     let mut ctx = Context::new();
     let _cmds = UntypedAst
         .parse_script_str("(set-logic QF_BV) (declare-const x (_ BitVec 8))")
@@ -1897,7 +1896,7 @@ fn from_cvc5_term_hex_bv_literal() {
     }
     let cterm = term.to_cvc5(&mut *es.env).unwrap();
     let back = cterm.conv_from_cvc5(&mut *es.env).unwrap();
-    assert_eq!(back.to_string(), "(bvadd x #b10101011)");
+    assert_eq!(back.to_string(), "(bvadd x #xab)");
 }
 
 #[test]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This change primarily eliminate the needs of two environments to handle the back and forth translation. In particular,

1. `Cvc5Env` is the only env responsible for corresponding the translations in both directions, managing the caches properly, etc.
2. Use trait based memoized recursion scheme to get rid of the inconvenient `Inner` pattern. 
3. The use of yaspar context is generalized by a trait based constraint (HasMutRef)
4. Command results are now in yaspar terms for those that we care about. 
5. Docs are kept up to date. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
