### PR TITLE
Fix Display of Nullary Application

### DIFF
--- a/src/raw/alg.rs
+++ b/src/raw/alg.rs
@@ -1388,7 +1388,13 @@ where
             Term::Constant(c, _) => c.fmt(f),
             Term::Global(id, _) => id.fmt(f),
             Term::Local(id) => write!(f, "{}", id.symbol.sym_quote()),
-            Term::App(id, args, _) => fmt_app(f, id, args),
+            Term::App(id, args, _) => {
+                if args.is_empty() {
+                    write!(f, "{}", id)
+                } else {
+                    fmt_app(f, id, args)
+                }
+            }
             Term::Let(vs, body) => fmt_binder(f, "let", vs, body),
             Term::Annotated(t, at) => {
                 write!(f, "(! {} ", t)?;

--- a/src/raw/alg.rs
+++ b/src/raw/alg.rs
@@ -1388,13 +1388,7 @@ where
             Term::Constant(c, _) => c.fmt(f),
             Term::Global(id, _) => id.fmt(f),
             Term::Local(id) => write!(f, "{}", id.symbol.sym_quote()),
-            Term::App(id, args, _) => {
-                if args.is_empty() {
-                    write!(f, "{}", id)
-                } else {
-                    fmt_app(f, id, args)
-                }
-            }
+            Term::App(id, args, _) => fmt_app(f, id, args),
             Term::Let(vs, body) => fmt_binder(f, "let", vs, body),
             Term::Annotated(t, at) => {
                 write!(f, "(! {} ", t)?;

--- a/src/raw/tc/app.rs
+++ b/src/raw/tc/app.rs
@@ -754,7 +754,7 @@ where
     let symbol = &f.0.symbol;
 
     // 1. Make sure that the application is not nullary
-    if args.len() == 0 {
+    if args.is_empty() {
         return Err(format!(
             "TC: Applications cannot be nullary; identifier {f}{id_meta} either is an identifier or should accept more arguments!"
         ));

--- a/src/raw/tc/app.rs
+++ b/src/raw/tc/app.rs
@@ -753,7 +753,11 @@ where
 {
     let symbol = &f.0.symbol;
 
-    // 1. we fetch the list of signatures of f (a list because of overloading).
+    // 1. Make sure that the application is not nullary
+    if args.len() == 0 {
+        return Err(format!("TC: Applications cannot be nullary, use a Global instead"))
+    }
+    // 2. we fetch the list of signatures of f (a list because of overloading).
     let sigs = match env.frame.symbol_table.get(symbol) {
         None => super::identifier_not_found(symbol, id_meta),
         Some(sigs) => Ok(sigs),
@@ -761,7 +765,7 @@ where
 
     let print_struct = alg::AppFmt::new(&f, &args);
 
-    // 2. we check each signature using this closure.
+    // 3. we check each signature using this closure.
     if sigs.len() == 1 {
         type_check_with_func_sig(
             &print_struct,
@@ -773,7 +777,7 @@ where
             app_meta,
         )
     } else {
-        // 3. if the function is overloaded, we try all signatures.
+        // 4. if the function is overloaded, we try all signatures.
         let mut tc_res = Err(format!(
             "TC: overloaded function {f}{id_meta} does not have a case to match its list of arguments! '{print_struct}'",
         ));

--- a/src/raw/tc/app.rs
+++ b/src/raw/tc/app.rs
@@ -755,7 +755,9 @@ where
 
     // 1. Make sure that the application is not nullary
     if args.len() == 0 {
-        return Err(format!("TC: Applications cannot be nullary; identifier {f}{id_meta} either is an identifier or should accept more arguments!"))
+        return Err(format!(
+            "TC: Applications cannot be nullary; identifier {f}{id_meta} either is an identifier or should accept more arguments!"
+        ));
     }
     // 2. we fetch the list of signatures of f (a list because of overloading).
     let sigs = match env.frame.symbol_table.get(symbol) {

--- a/src/raw/tc/app.rs
+++ b/src/raw/tc/app.rs
@@ -755,7 +755,7 @@ where
 
     // 1. Make sure that the application is not nullary
     if args.len() == 0 {
-        return Err(format!("TC: Applications cannot be nullary, use a Global instead"))
+        return Err(format!("TC: Applications cannot be nullary; identifier {f}{id_meta} either is an identifier or should accept more arguments!"))
     }
     // 2. we fetch the list of signatures of f (a list because of overloading).
     let sigs = match env.frame.symbol_table.get(symbol) {

--- a/tests/nullary_constructor.rs
+++ b/tests/nullary_constructor.rs
@@ -1,8 +1,6 @@
 use yaspar_ir::ast::{CheckedApi, Context, Typecheck};
 use yaspar_ir::untyped::UntypedAst;
 
-/// Regression test: when a nullary constructor is applied via `typed_simp_app`,
-/// Display must emit just the symbol name, not `(Name )` with a trailing space.
 #[test]
 fn nullary_constructor_app_no_trailing_space() {
     let mut ctx = Context::new();

--- a/tests/nullary_constructor.rs
+++ b/tests/nullary_constructor.rs
@@ -4,7 +4,7 @@ use yaspar_ir::ast::{CheckedApi, Context, Typecheck};
 use yaspar_ir::untyped::UntypedAst;
 
 #[test]
-fn nullary_constructor_app_no_trailing_space() {
+fn nullary_constructor() {
     let mut ctx = Context::new();
     ctx.ensure_logic();
 

--- a/tests/nullary_constructor.rs
+++ b/tests/nullary_constructor.rs
@@ -1,0 +1,25 @@
+use yaspar_ir::ast::{CheckedApi, Context, Typecheck};
+use yaspar_ir::untyped::UntypedAst;
+
+/// Regression test: when a nullary constructor is applied via `typed_simp_app`,
+/// Display must emit just the symbol name, not `(Name )` with a trailing space.
+#[test]
+fn nullary_constructor_app_no_trailing_space() {
+    let mut ctx = Context::new();
+    ctx.ensure_logic();
+
+    // Declare a datatype with a nullary constructor
+    let cmd = UntypedAst
+        .parse_command_str("(declare-datatype Color ((Red) (Green) (Blue)))")
+        .unwrap();
+    cmd.type_check(&mut ctx).unwrap();
+
+    // Apply the nullary constructor via the typed API (same path the solver client uses)
+    let term = ctx.typed_simp_app("Red", std::iter::empty()).unwrap();
+
+    let output = format!("{}", term);
+    assert_eq!(
+        output, "Red",
+        "nullary constructor application should print as bare symbol, got: `{output}`"
+    );
+}

--- a/tests/nullary_constructor.rs
+++ b/tests/nullary_constructor.rs
@@ -15,11 +15,6 @@ fn nullary_constructor_app_no_trailing_space() {
     cmd.type_check(&mut ctx).unwrap();
 
     // Apply the nullary constructor via the typed API (same path the solver client uses)
-    let term = ctx.typed_simp_app("Red", std::iter::empty()).unwrap();
-
-    let output = format!("{}", term);
-    assert_eq!(
-        output, "Red",
-        "nullary constructor application should print as bare symbol, got: `{output}`"
-    );
+    let term = ctx.typed_simp_app("Red", std::iter::empty());
+    assert!(term.is_err());
 }

--- a/tests/nullary_constructor.rs
+++ b/tests/nullary_constructor.rs
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 use yaspar_ir::ast::{CheckedApi, Context, Typecheck};
 use yaspar_ir::untyped::UntypedAst;
 


### PR DESCRIPTION
Previously, when doing a nullary application for a term `f`, it would be rendered like `(f )` and cvc5 would reject it due to the space.

Here is an example which demonstrates the change

```
use yaspar_ir::ast::{CheckedApi, Context, Typecheck};
use yaspar_ir::untyped::UntypedAst;

#[test]
fn nullary_constructor_app_no_trailing_space() {
    let mut ctx = Context::new();
    ctx.ensure_logic();

    let cmd = UntypedAst
        .parse_command_str("(declare-datatype Color ((Red) (Green) (Blue)))")
        .unwrap();
    cmd.type_check(&mut ctx).unwrap();

    let term = ctx.typed_simp_app("Red", std::iter::empty()).unwrap();

    let output = format!("{}", term);
    assert_eq!(
        output, "Red",
        "nullary constructor application should print as bare symbol, got: `{output}`"
    );
    
    // the old behavior would print (Red )
}
```
