### PR TITLE
support back and forth translations for finite sets in cvc5

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,7 +88,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run cvc5 tests
-        run: cargo test --features cvc5
+        run: cargo test --features cvc5,finite-set
         env:
           CVC5_DIR: ${{ steps.cvc5.outputs.cvc5-dir }}
 

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -474,6 +474,11 @@ fn translate_sort_inner<'tm, Ctx>(sort: &Sort, env: &mut Cvc5Env<'tm, Ctx>) -> R
         let ce = elem.to_cvc5(env)?;
         return Ok(env.tm.mk_array_sort(ci, ce));
     }
+    #[cfg(feature = "finite-set")]
+    if let Some(elem) = sort.is_fset() {
+        let ce = elem.to_cvc5(env)?;
+        return Ok(env.tm.mk_set_sort(ce));
+    }
 
     Err(format!("unsupported sort: {sort}"))
 }
@@ -522,6 +527,11 @@ where
         let idx = cs.array_index_sort().conv_from_cvc5(fenv)?;
         let elem = cs.array_element_sort().conv_from_cvc5(fenv)?;
         return Ok(fenv.ctx.ref_mut().array_sort(idx, elem));
+    }
+    #[cfg(feature = "finite-set")]
+    if cs.is_set() {
+        let elem = cs.set_element_sort().conv_from_cvc5(fenv)?;
+        return Ok(fenv.ctx.ref_mut().fset_sort(elem));
     }
     // Instantiated parametric datatype (e.g. (List Int))
     if cs.is_dt() && cs.is_instantiated() {
@@ -1011,6 +1021,23 @@ where
         Kind::ConstSequence => return Err("sequence operations are not supported!".into()),
 
         // ── Sets ────────────────────────────────────────────────
+        // Nullary set constants need the result sort to emit `(as set.empty …)`
+        // / `(as set.universe …)`; the n-ary connectives flow through the
+        // generic `cvc5_kind_to_ident_kind` path below.
+        #[cfg(feature = "finite-set")]
+        Kind::SetEmpty | Kind::SetUniverse => {
+            let name = if kind == Kind::SetEmpty {
+                SET_EMPTY
+            } else {
+                SET_UNIVERSE
+            };
+            let sort = ct.sort().conv_from_cvc5(fenv)?;
+            let mut rf = fenv.ctx.ref_mut();
+            let sym = rf.allocate_symbol(name);
+            let qid = QualifiedIdentifier::simple_sorted(sym, sort.clone());
+            return Ok(rf.global(qid, Some(sort)));
+        }
+        #[cfg(not(feature = "finite-set"))]
         Kind::SetEmpty
         | Kind::SetUniverse
         | Kind::SetSingleton
@@ -1020,9 +1047,11 @@ where
         | Kind::SetMember
         | Kind::SetSubset
         | Kind::SetComplement
-        | Kind::SetInsert
         | Kind::SetCard => {
             return Err("set operations are not supported!".into());
+        }
+        Kind::SetInsert => {
+            return Err("the set.insert operation is not supported!".into());
         }
 
         // ── Floating point ──────────────────────────────────────
@@ -1344,6 +1373,22 @@ fn cvc5_kind_to_ident_kind(kind: Kind) -> Option<IdentifierKind> {
         Kind::BitvectorUsubo => BvUsubo,
         Kind::BitvectorSsubo => BvSsubo,
         Kind::BitvectorSdivo => BvSdivo,
+        #[cfg(feature = "finite-set")]
+        Kind::SetUnion => SetUnion,
+        #[cfg(feature = "finite-set")]
+        Kind::SetInter => SetInter,
+        #[cfg(feature = "finite-set")]
+        Kind::SetMinus => SetMinus,
+        #[cfg(feature = "finite-set")]
+        Kind::SetMember => SetMember,
+        #[cfg(feature = "finite-set")]
+        Kind::SetSubset => SetSubset,
+        #[cfg(feature = "finite-set")]
+        Kind::SetSingleton => SetSingleton,
+        #[cfg(feature = "finite-set")]
+        Kind::SetCard => SetCard,
+        #[cfg(feature = "finite-set")]
+        Kind::SetComplement => SetComplement,
         _ => return None,
     })
 }
@@ -1442,6 +1487,22 @@ fn ident_kind_to_cvc5(k: &IdentifierKind) -> Option<Kind> {
         BvUsubo => Kind::BitvectorUsubo,
         BvSsubo => Kind::BitvectorSsubo,
         BvSdivo => Kind::BitvectorSdivo,
+        #[cfg(feature = "finite-set")]
+        SetUnion => Kind::SetUnion,
+        #[cfg(feature = "finite-set")]
+        SetInter => Kind::SetInter,
+        #[cfg(feature = "finite-set")]
+        SetMinus => Kind::SetMinus,
+        #[cfg(feature = "finite-set")]
+        SetMember => Kind::SetMember,
+        #[cfg(feature = "finite-set")]
+        SetSubset => Kind::SetSubset,
+        #[cfg(feature = "finite-set")]
+        SetSingleton => Kind::SetSingleton,
+        #[cfg(feature = "finite-set")]
+        SetCard => Kind::SetCard,
+        #[cfg(feature = "finite-set")]
+        SetComplement => Kind::SetComplement,
         _ => return None,
     })
 }
@@ -1977,6 +2038,19 @@ impl<'tm, Ctx> Cvc5Env<'tm, Ctx> {
                     false,
                 )
                 .into()),
+            // Sort-ascribed nullary set constants: (as set.empty (Set X)) and
+            // (as set.universe (Set X)) need the instantiated set sort to build
+            // the corresponding cvc5 constants.
+            #[cfg(feature = "finite-set")]
+            Some(SetEmpty) => {
+                let cs = sort.to_cvc5(self)?;
+                Ok(self.tm.mk_empty_set(cs).into())
+            }
+            #[cfg(feature = "finite-set")]
+            Some(SetUniverse) => {
+                let cs = sort.to_cvc5(self)?;
+                Ok(self.tm.mk_universe_set(cs).into())
+            }
             Some(ref ik) if let Some(k) = ident_kind_to_cvc5(ik) => {
                 Ok(self.tm.mk_term(k, &[]).into())
             }

--- a/src/raw/alg.rs
+++ b/src/raw/alg.rs
@@ -250,6 +250,26 @@ where
                 BV_SLE => Some(IdentifierKind::BvSle),
                 BV_SGT => Some(IdentifierKind::BvSgt),
                 BV_SGE => Some(IdentifierKind::BvSge),
+                #[cfg(feature = "finite-set")]
+                SET_UNION => Some(IdentifierKind::SetUnion),
+                #[cfg(feature = "finite-set")]
+                SET_INTER => Some(IdentifierKind::SetInter),
+                #[cfg(feature = "finite-set")]
+                SET_MINUS => Some(IdentifierKind::SetMinus),
+                #[cfg(feature = "finite-set")]
+                SET_MEMBER => Some(IdentifierKind::SetMember),
+                #[cfg(feature = "finite-set")]
+                SET_SUBSET => Some(IdentifierKind::SetSubset),
+                #[cfg(feature = "finite-set")]
+                SET_SINGLETON => Some(IdentifierKind::SetSingleton),
+                #[cfg(feature = "finite-set")]
+                SET_CARD => Some(IdentifierKind::SetCard),
+                #[cfg(feature = "finite-set")]
+                SET_COMPLEMENT => Some(IdentifierKind::SetComplement),
+                #[cfg(feature = "finite-set")]
+                SET_EMPTY => Some(IdentifierKind::SetEmpty),
+                #[cfg(feature = "finite-set")]
+                SET_UNIVERSE => Some(IdentifierKind::SetUniverse),
                 _ => None,
             },
             [Index::Hexadecimal(bytes, l)] => match self.symbol.inner().as_str() {

--- a/src/raw/alg/kind.rs
+++ b/src/raw/alg/kind.rs
@@ -142,6 +142,28 @@ pub enum IdentifierKind<Str> {
 
     // datatypes
     Is(Str),
+
+    // Finite sets
+    #[cfg(feature = "finite-set")]
+    SetUnion,
+    #[cfg(feature = "finite-set")]
+    SetInter,
+    #[cfg(feature = "finite-set")]
+    SetMinus,
+    #[cfg(feature = "finite-set")]
+    SetMember,
+    #[cfg(feature = "finite-set")]
+    SetSubset,
+    #[cfg(feature = "finite-set")]
+    SetSingleton,
+    #[cfg(feature = "finite-set")]
+    SetCard,
+    #[cfg(feature = "finite-set")]
+    SetComplement,
+    #[cfg(feature = "finite-set")]
+    SetEmpty,
+    #[cfg(feature = "finite-set")]
+    SetUniverse,
 }
 
 impl<Str> IdentifierKind<Str> {
@@ -259,6 +281,26 @@ impl<Str> IdentifierKind<Str> {
             IdentifierKind::BvSgt => BV_SGT,
             IdentifierKind::BvSge => BV_SGE,
             IdentifierKind::Is(_) => IS,
+            #[cfg(feature = "finite-set")]
+            IdentifierKind::SetUnion => SET_UNION,
+            #[cfg(feature = "finite-set")]
+            IdentifierKind::SetInter => SET_INTER,
+            #[cfg(feature = "finite-set")]
+            IdentifierKind::SetMinus => SET_MINUS,
+            #[cfg(feature = "finite-set")]
+            IdentifierKind::SetMember => SET_MEMBER,
+            #[cfg(feature = "finite-set")]
+            IdentifierKind::SetSubset => SET_SUBSET,
+            #[cfg(feature = "finite-set")]
+            IdentifierKind::SetSingleton => SET_SINGLETON,
+            #[cfg(feature = "finite-set")]
+            IdentifierKind::SetCard => SET_CARD,
+            #[cfg(feature = "finite-set")]
+            IdentifierKind::SetComplement => SET_COMPLEMENT,
+            #[cfg(feature = "finite-set")]
+            IdentifierKind::SetEmpty => SET_EMPTY,
+            #[cfg(feature = "finite-set")]
+            IdentifierKind::SetUniverse => SET_UNIVERSE,
         }
     }
 
@@ -366,6 +408,19 @@ impl<Str> IdentifierKind<Str> {
             | IdentifierKind::BvSle
             | IdentifierKind::BvSgt
             | IdentifierKind::BvSge => {
+                vec![]
+            }
+            #[cfg(feature = "finite-set")]
+            IdentifierKind::SetUnion
+            | IdentifierKind::SetInter
+            | IdentifierKind::SetMinus
+            | IdentifierKind::SetMember
+            | IdentifierKind::SetSubset
+            | IdentifierKind::SetSingleton
+            | IdentifierKind::SetCard
+            | IdentifierKind::SetComplement
+            | IdentifierKind::SetEmpty
+            | IdentifierKind::SetUniverse => {
                 vec![]
             }
             IdentifierKind::RePower(n)

--- a/tests/cvc5_finite_sets.rs
+++ b/tests/cvc5_finite_sets.rs
@@ -1,0 +1,485 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(all(feature = "cvc5", feature = "finite-set"))]
+
+use cvc5::{Kind, Solver, TermManager};
+use yaspar_ir::ast::{Context, Typecheck};
+use yaspar_ir::cvc5::{CTerm, ConvertFromCvc5, ConvertToCvc5, Cvc5Env, Cvc5EnvSolver};
+use yaspar_ir::untyped::UntypedAst;
+
+// ── Round-trip helpers ───────────────────────────────────────
+
+fn run_script(script: &str) {
+    let mut ctx = Context::new();
+    let cmds = UntypedAst
+        .parse_script_str(script)
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    // `set.complement` and `set.universe` are extended set operators in cvc5
+    // and require `sets-exp` to be enabled.
+    solver.set_option("sets-exp", "true");
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
+}
+
+fn sort_round_trip(script: &str, sort_str: &str) {
+    let mut ctx = Context::new();
+    let cmds = UntypedAst
+        .parse_script_str(script)
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let sort = UntypedAst
+        .parse_sort_str(sort_str)
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
+    let csort = sort.to_cvc5(&mut *es.env).unwrap();
+    let back = csort.conv_from_cvc5(&mut *es.env).unwrap();
+    assert_eq!(sort.to_string(), back.to_string());
+}
+
+fn term_round_trip(script: &str, term_str: &str) {
+    let mut ctx = Context::new();
+    let cmds = UntypedAst
+        .parse_script_str(script)
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let term = UntypedAst
+        .parse_term_str(term_str)
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+    let tm = TermManager::new();
+    let mut solver = Solver::new(&tm);
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let mut es = Cvc5EnvSolver::new(&mut env, &mut solver);
+    for cmd in &cmds {
+        cmd.to_cvc5(&mut es).unwrap();
+    }
+    let cterm = term.to_cvc5(&mut *es.env).unwrap();
+    let back = cterm.conv_from_cvc5(&mut *es.env).unwrap();
+    assert_eq!(term.to_string(), back.to_string());
+}
+
+// ── Forward: Set sort translates without error ───────────────
+
+#[test]
+fn fset_sort_int() {
+    run_script("(set-logic QF_LIAFS) (declare-const a (Set Int))");
+}
+
+#[test]
+fn fset_sort_bool() {
+    run_script("(set-logic QF_UFFS) (declare-const a (Set Bool))");
+}
+
+#[test]
+fn fset_sort_nested() {
+    run_script("(set-logic QF_LIAFS) (declare-const a (Set (Set Int)))");
+}
+
+// ── Forward: set commands run end-to-end ────────────────────
+
+#[test]
+fn fset_union_check_sat() {
+    run_script(
+        "(set-logic QF_LIAFS)
+         (declare-const a (Set Int))
+         (declare-const b (Set Int))
+         (assert (= (set.union a b) a))
+         (check-sat)",
+    );
+}
+
+#[test]
+fn fset_inter_check_sat() {
+    run_script(
+        "(set-logic QF_LIAFS)
+         (declare-const a (Set Int))
+         (declare-const b (Set Int))
+         (assert (= (set.inter a b) b))
+         (check-sat)",
+    );
+}
+
+#[test]
+fn fset_minus_check_sat() {
+    run_script(
+        "(set-logic QF_LIAFS)
+         (declare-const a (Set Int))
+         (declare-const b (Set Int))
+         (assert (= (set.minus a b) a))
+         (check-sat)",
+    );
+}
+
+#[test]
+fn fset_member_check_sat() {
+    run_script(
+        "(set-logic QF_LIAFS)
+         (declare-const x Int)
+         (declare-const a (Set Int))
+         (assert (set.member x a))
+         (check-sat)",
+    );
+}
+
+#[test]
+fn fset_subset_check_sat() {
+    run_script(
+        "(set-logic QF_LIAFS)
+         (declare-const a (Set Int))
+         (declare-const b (Set Int))
+         (assert (set.subset a b))
+         (check-sat)",
+    );
+}
+
+#[test]
+fn fset_singleton_check_sat() {
+    run_script(
+        "(set-logic QF_LIAFS)
+         (declare-const a (Set Int))
+         (assert (= a (set.singleton 1)))
+         (check-sat)",
+    );
+}
+
+#[test]
+fn fset_card_check_sat() {
+    run_script(
+        "(set-logic QF_LIAFS)
+         (declare-const a (Set Int))
+         (assert (= (set.card a) 3))
+         (check-sat)",
+    );
+}
+
+#[test]
+fn fset_complement_check_sat() {
+    run_script(
+        "(set-logic QF_LIAFS)
+         (declare-const a (Set Int))
+         (assert (= (set.complement a) a))
+         (check-sat)",
+    );
+}
+
+#[test]
+fn fset_empty_check_sat() {
+    run_script(
+        "(set-logic QF_LIAFS)
+         (declare-const a (Set Int))
+         (assert (= a (as set.empty (Set Int))))
+         (check-sat)",
+    );
+}
+
+#[test]
+fn fset_universe_check_sat() {
+    run_script(
+        "(set-logic QF_LIAFS)
+         (declare-const a (Set Int))
+         (assert (= a (as set.universe (Set Int))))
+         (check-sat)",
+    );
+}
+
+#[test]
+fn fset_combined_check_sat() {
+    run_script(
+        "(set-logic QF_LIAFS)
+         (declare-const a (Set Int))
+         (declare-const b (Set Int))
+         (declare-const x Int)
+         (assert (set.member x (set.union a b)))
+         (assert (set.subset (set.inter a b) a))
+         (assert (= (set.card (set.minus a b)) 2))
+         (assert (= (set.complement (as set.empty (Set Int))) (as set.universe (Set Int))))
+         (check-sat)",
+    );
+}
+
+// ── Round-trip: Set sorts ────────────────────────────────────
+
+#[test]
+fn from_cvc5_fset_sort_int() {
+    sort_round_trip("(set-logic QF_LIAFS)", "(Set Int)");
+}
+
+#[test]
+fn from_cvc5_fset_sort_bool() {
+    sort_round_trip("(set-logic QF_UFFS)", "(Set Bool)");
+}
+
+#[test]
+fn from_cvc5_fset_sort_nested() {
+    sort_round_trip("(set-logic QF_LIAFS)", "(Set (Set Int))");
+}
+
+// ── Round-trip: set terms ────────────────────────────────────
+
+#[test]
+fn from_cvc5_fset_term_union() {
+    term_round_trip(
+        "(set-logic QF_LIAFS) (declare-const a (Set Int)) (declare-const b (Set Int))",
+        "(set.union a b)",
+    );
+}
+
+#[test]
+fn from_cvc5_fset_term_inter() {
+    term_round_trip(
+        "(set-logic QF_LIAFS) (declare-const a (Set Int)) (declare-const b (Set Int))",
+        "(set.inter a b)",
+    );
+}
+
+#[test]
+fn from_cvc5_fset_term_minus() {
+    term_round_trip(
+        "(set-logic QF_LIAFS) (declare-const a (Set Int)) (declare-const b (Set Int))",
+        "(set.minus a b)",
+    );
+}
+
+#[test]
+fn from_cvc5_fset_term_member() {
+    term_round_trip(
+        "(set-logic QF_LIAFS) (declare-const a (Set Int)) (declare-const x Int)",
+        "(set.member x a)",
+    );
+}
+
+#[test]
+fn from_cvc5_fset_term_subset() {
+    term_round_trip(
+        "(set-logic QF_LIAFS) (declare-const a (Set Int)) (declare-const b (Set Int))",
+        "(set.subset a b)",
+    );
+}
+
+#[test]
+fn from_cvc5_fset_term_singleton() {
+    term_round_trip(
+        "(set-logic QF_LIAFS) (declare-const a (Set Int))",
+        "(set.singleton 1)",
+    );
+}
+
+#[test]
+fn from_cvc5_fset_term_card() {
+    term_round_trip(
+        "(set-logic QF_LIAFS) (declare-const a (Set Int))",
+        "(set.card a)",
+    );
+}
+
+#[test]
+fn from_cvc5_fset_term_complement() {
+    term_round_trip(
+        "(set-logic QF_LIAFS) (declare-const a (Set Int))",
+        "(set.complement a)",
+    );
+}
+
+#[test]
+fn from_cvc5_fset_term_empty() {
+    term_round_trip(
+        "(set-logic QF_LIAFS) (declare-const a (Set Int))",
+        "(as set.empty (Set Int))",
+    );
+}
+
+#[test]
+fn from_cvc5_fset_term_universe() {
+    term_round_trip(
+        "(set-logic QF_LIAFS) (declare-const a (Set Int))",
+        "(as set.universe (Set Int))",
+    );
+}
+
+#[test]
+fn from_cvc5_fset_term_nested_union_inter() {
+    term_round_trip(
+        "(set-logic QF_LIAFS)
+         (declare-const a (Set Int))
+         (declare-const b (Set Int))
+         (declare-const c (Set Int))",
+        "(set.union (set.inter a b) c)",
+    );
+}
+
+// ── Backward translation built directly from cvc5 APIs ───────
+//
+// These tests construct cvc5 terms and sorts using only cvc5's own builders
+// (no yaspar-ir parsing) and assert that the back-translated yaspar-ir term's
+// SMT-LIB-formatted `to_string()` matches an expected literal.
+
+fn assert_back_eq<F>(expected: &str, build: F)
+where
+    F: for<'tm> FnOnce(&'tm TermManager) -> CTerm<'tm>,
+{
+    let tm = TermManager::new();
+    let mut ctx = Context::new();
+    ctx.set_ctx_logic("QF_LIAFS").unwrap();
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let cterm = build(&tm);
+    let back = cterm.conv_from_cvc5(&mut env).unwrap();
+    assert_eq!(back.to_string(), expected);
+}
+
+#[test]
+fn back_from_cvc5_api_fset_sort_int() {
+    let tm = TermManager::new();
+    let mut ctx = Context::new();
+    ctx.set_ctx_logic("QF_LIAFS").unwrap();
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let cs = tm.mk_set_sort(tm.integer_sort());
+    let back = cs.conv_from_cvc5(&mut env).unwrap();
+    assert_eq!(back.to_string(), "(Set Int)");
+}
+
+#[test]
+fn back_from_cvc5_api_fset_sort_bool() {
+    let tm = TermManager::new();
+    let mut ctx = Context::new();
+    ctx.set_ctx_logic("QF_UFFS").unwrap();
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let cs = tm.mk_set_sort(tm.boolean_sort());
+    let back = cs.conv_from_cvc5(&mut env).unwrap();
+    assert_eq!(back.to_string(), "(Set Bool)");
+}
+
+#[test]
+fn back_from_cvc5_api_fset_sort_nested() {
+    let tm = TermManager::new();
+    let mut ctx = Context::new();
+    ctx.set_ctx_logic("QF_LIAFS").unwrap();
+    let mut env = Cvc5Env::new(&tm, &mut ctx);
+    let inner = tm.mk_set_sort(tm.integer_sort());
+    let outer = tm.mk_set_sort(inner);
+    let back = outer.conv_from_cvc5(&mut env).unwrap();
+    assert_eq!(back.to_string(), "(Set (Set Int))");
+}
+
+#[test]
+fn back_from_cvc5_api_fset_empty() {
+    assert_back_eq("(as set.empty (Set Int))", |tm| {
+        let s = tm.mk_set_sort(tm.integer_sort());
+        tm.mk_empty_set(s)
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_fset_universe() {
+    assert_back_eq("(as set.universe (Set Int))", |tm| {
+        let s = tm.mk_set_sort(tm.integer_sort());
+        tm.mk_universe_set(s)
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_fset_singleton() {
+    assert_back_eq("(set.singleton 1)", |tm| {
+        let one = tm.mk_integer(1);
+        tm.mk_term(Kind::SetSingleton, &[one])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_fset_union() {
+    assert_back_eq("(set.union a b)", |tm| {
+        let s = tm.mk_set_sort(tm.integer_sort());
+        let a = tm.mk_const(s.clone(), "a");
+        let b = tm.mk_const(s, "b");
+        tm.mk_term(Kind::SetUnion, &[a, b])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_fset_inter() {
+    assert_back_eq("(set.inter a b)", |tm| {
+        let s = tm.mk_set_sort(tm.integer_sort());
+        let a = tm.mk_const(s.clone(), "a");
+        let b = tm.mk_const(s, "b");
+        tm.mk_term(Kind::SetInter, &[a, b])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_fset_minus() {
+    assert_back_eq("(set.minus a b)", |tm| {
+        let s = tm.mk_set_sort(tm.integer_sort());
+        let a = tm.mk_const(s.clone(), "a");
+        let b = tm.mk_const(s, "b");
+        tm.mk_term(Kind::SetMinus, &[a, b])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_fset_member() {
+    assert_back_eq("(set.member x a)", |tm| {
+        let int = tm.integer_sort();
+        let s = tm.mk_set_sort(int.clone());
+        let x = tm.mk_const(int, "x");
+        let a = tm.mk_const(s, "a");
+        tm.mk_term(Kind::SetMember, &[x, a])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_fset_subset() {
+    assert_back_eq("(set.subset a b)", |tm| {
+        let s = tm.mk_set_sort(tm.integer_sort());
+        let a = tm.mk_const(s.clone(), "a");
+        let b = tm.mk_const(s, "b");
+        tm.mk_term(Kind::SetSubset, &[a, b])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_fset_card() {
+    assert_back_eq("(set.card a)", |tm| {
+        let s = tm.mk_set_sort(tm.integer_sort());
+        let a = tm.mk_const(s, "a");
+        tm.mk_term(Kind::SetCard, &[a])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_fset_complement() {
+    assert_back_eq("(set.complement a)", |tm| {
+        let s = tm.mk_set_sort(tm.integer_sort());
+        let a = tm.mk_const(s, "a");
+        tm.mk_term(Kind::SetComplement, &[a])
+    });
+}
+
+#[test]
+fn back_from_cvc5_api_fset_nested() {
+    assert_back_eq("(set.union (set.inter a b) c)", |tm| {
+        let s = tm.mk_set_sort(tm.integer_sort());
+        let a = tm.mk_const(s.clone(), "a");
+        let b = tm.mk_const(s.clone(), "b");
+        let c = tm.mk_const(s, "c");
+        let inter = tm.mk_term(Kind::SetInter, &[a, b]);
+        tm.mk_term(Kind::SetUnion, &[inter, c])
+    });
+}


### PR DESCRIPTION
*Issue #, if available:*

Closes #93 

*Description of changes:*

This PR supports finite set translation in cvc5 when `finite-set` feature is turned on. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
