### PR TITLE
feat: improve Distinct analysis during NNF

### DIFF
--- a/src/ast/cnf.rs
+++ b/src/ast/cnf.rs
@@ -138,25 +138,26 @@ impl CNFConversionHelper<&mut CNFEnv<'_>> for Term {
                 // we know from parsing that ts is non-empty.
                 let bs = env.arena.bool_sort();
                 let s = ts[0].get_sort(env.arena);
-                // 1. we check if ts are booleans
-                if bs != s {
-                    // 2. if not, then this term is considered atomic.
-                    if polarity {
-                        self.clone()
-                    } else {
-                        env.arena.not(self.clone())
+                match ts.len() {
+                    1 => env.arena.get_true().nnf_impl(env, polarity), // a single term is always distinct
+                    2 => {
+                        // If there are two terms, then they must be unequal
+                        let eq = env.arena.eq(ts[0].clone(), ts[1].clone());
+                        let eqf = env.arena.not(eq);
+                        eqf.nnf_impl(env, polarity)
                     }
-                } else {
-                    // otherwise, we translate it into a boolean formula
-                    match ts.len() {
-                        1 => ts[0].nnf_impl(env, polarity), // if there is only one term, there is not need for comparison
-                        2 => {
-                            // if there are two terms, then these two must be unequal.
-                            let eq = env.arena.eq(ts[0].clone(), ts[1].clone());
-                            let eqf = env.arena.not(eq);
-                            eqf.nnf_impl(env, polarity)
+                    _ => {
+                        // If the terms are booleans, then more than two terms cannot be distinct
+                        if bs == s {
+                            env.arena.get_false().nnf_impl(env, polarity)
+                        } else {
+                            // Otherwise, we treat the whole Distinct term as atomic
+                            if polarity {
+                                self.clone()
+                            } else {
+                                env.arena.not(self.clone())
+                            }
                         }
-                        _ => env.arena.get_false().nnf_impl(env, polarity), // more than two distinct booleans are not possible.
                     }
                 }
             }


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

In the function `nnf_impl()` in `src/ast/cnf.rs`, the NNF algorithm does a bit of analysis on the `DISTINCT` keyword to reduce the formula even further. In particular, a `DISTINCT` clause with a single element is always true, and a `DISTINCT` clause on three or more booleans is always false.

This PR extends this analysis to more cases. A `DISTINCT` clause on two elements now always compares equality.

------------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
