### PR TITLE
remove deprecated interfaces

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -60,8 +60,7 @@ pub use crate::untyped as u;
 pub use boilerplates::TypedBuilder;
 pub use gsubst::{GlobalSubst, GlobalSubstituter, GlobalSubstituterInner};
 pub use mono::{Monomorphization, find_sort_subst_from_datatype_dec};
-#[allow(deprecated)]
-pub use subst::{Substitute, SubstituteV2, Substitution, SubstitutionV2};
+pub use subst::{Substitute, Substitution};
 
 pub use crate::ast::letelim::{LetElim, LetEliminator, LetEliminatorInner};
 use crate::traits::MetaData;

--- a/src/ast/ctx/mod.rs
+++ b/src/ast/ctx/mod.rs
@@ -574,12 +574,6 @@ impl Context {
         self.frame.sorts.get(name)
     }
 
-    /// c.f. [Self::defined_symbols]
-    #[deprecated = "this function is to be removed in 2.7.4 due to its bad naming; use defined_symbols"]
-    pub fn all_defined_symbols(&self) -> HashSet<Str> {
-        self.defined_symbols()
-    }
-
     /// Get all the symbols with a definition body
     ///
     /// This function is different from [Self::user_defined_symbols] in that it only returns the symbols

--- a/src/ast/gsubst.rs
+++ b/src/ast/gsubst.rs
@@ -9,10 +9,10 @@
 
 use crate::allocator::{SortAllocator, TermAllocator};
 use crate::ast::alg::VarBinding;
-use crate::ast::subst::SubstituteV2;
+use crate::ast::subst::Substitute;
 use crate::ast::{
     Arena, Attribute, Constant, Context, FetchSort, FunctionDef, HasArena, Local, Memoize,
-    Monomorphization, Pattern, PatternArm, QualifiedIdentifier, Sort, Str, SubstitutionV2, Term,
+    Monomorphization, Pattern, PatternArm, QualifiedIdentifier, Sort, Str, Substitution, Term,
     TypedBuilder,
 };
 use crate::ast::{TermRecursor, TypedTermRecursor};
@@ -285,7 +285,7 @@ impl TermRecursor<Str, Sort, Term> for GlobalSubstituterInner<'_> {
             // The cache was just populated
             let def = self.global_def_cache.get(sym).unwrap();
             let sorts: Vec<Sort> = recs.iter().map(|t| t.get_sort(&mut self.inner)).collect();
-            let subst = SubstitutionV2::new(def.vars.iter().map(|v| v.clone().into()).zip(recs));
+            let subst = Substitution::new(def.vars.iter().map(|v| v.clone().into()).zip(recs));
             if def.sort_params.is_empty() {
                 Ok(def.body.subst(&subst, &mut self.inner))
             } else {

--- a/src/ast/subst.rs
+++ b/src/ast/subst.rs
@@ -1,24 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// The legacy `Substitution` / `Substitute` API is deprecated but still implemented here.
-#![allow(deprecated)]
-
 //! Local substitution of variables in terms.
 //!
-//! This module provides [`SubstitutionV2`], a mapping from local variable IDs to replacement
-//! terms, and the [`SubstituteV2`] trait for applying substitutions. The substitution operation
+//! This module provides [`Substitution`], a mapping from local variable IDs to replacement
+//! terms, and the [`Substitute`] trait for applying substitutions. The substitution operation
 //! correctly handles variable shadowing in binders (`let`, `forall`, `exists`, `match`):
 //! a substitution is suspended inside a scope that re-binds the same variable.
-//!
-//! The legacy [`Substitution`] / [`Substitute`] API (name-based) is deprecated and will be
-//! removed in 2.7.4. Prefer [`SubstitutionV2`] / [`SubstituteV2`] (ID-based) for new code.
 //!
 //! # Example
 //!
 //! ```rust
 //! use yaspar_ir::ast::{CheckedApi, Context, ScopedSortApi, Typecheck};
-//! use yaspar_ir::ast::subst::{SubstitutionV2, SubstituteV2};
+//! use yaspar_ir::ast::subst::{Substitution, Substitute};
 //! use yaspar_ir::untyped::UntypedAst;
 //!
 //! let mut context = Context::new();
@@ -28,7 +22,7 @@
 //! let term = UntypedAst.parse_term_str("(+ x y)").unwrap().type_check(&mut q).unwrap();
 //! let one = q.numeral(1u8.into()).unwrap();
 //! let loc = q.get_direct_bindings()[0].clone().into();
-//! let subst = SubstitutionV2::new([(loc, one)]);
+//! let subst = Substitution::new([(loc, one)]);
 //! let result = term.subst(&subst, &mut q);
 //! assert_eq!(result.to_string(), "(+ 1 y)");
 //! ```
@@ -38,270 +32,29 @@
 use crate::allocator::{LocalVarAllocator, TermAllocator};
 use crate::ast::alg::VarBinding;
 use crate::ast::{
-    ATerm, Arena, Attribute, Constant, HasArena, HasArenaAlt, Local, Memoize, Pattern, PatternArm,
-    QualifiedIdentifier, Sort, Str, Term, TermRecursor, TypedBuilder, TypedTermRecursor,
+    Attribute, Constant, HasArena, Local, Memoize, Pattern, PatternArm, QualifiedIdentifier, Sort,
+    Str, Term, TermRecursor, TypedBuilder, TypedTermRecursor,
 };
-use crate::containers::{Mapping, MemLinkedList};
+use crate::containers::Mapping;
 use crate::raw::alg::rec::Bottom;
-use crate::traits::{AllocatableString, Repr};
 use delegate::delegate;
 use std::collections::HashMap;
 use yaspar::ast::Keyword;
 
-/// A mapping from variable names to replacement terms.
+/// A mapping from local variable IDs to replacement terms.
 ///
-/// Create with [`Substitution::new`] (from name–term pairs) or [`Substitution::empty`].
+/// Create with [`Substitution::new`] (from `Local`–term pairs) or [`Substitution::empty`].
 /// Apply to a term via the [`Substitute`] trait.
-#[deprecated = "this type is to be replaced in 2.7.4"]
-pub struct Substitution(HashMap<Str, Option<Term>>);
-
-impl Substitution {
-    pub fn empty() -> Substitution {
-        Substitution(HashMap::new())
-    }
-
-    pub fn new_str(bindings: impl IntoIterator<Item = (Str, Term)>) -> Substitution {
-        let map = bindings.into_iter().map(|(s, t)| (s, Some(t))).collect();
-        Substitution(map)
-    }
-
-    pub fn new<S, E>(bindings: impl IntoIterator<Item = (S, Term)>, env: &mut E) -> Substitution
-    where
-        S: AllocatableString<Arena>,
-        E: HasArena,
-    {
-        Self::new_str(
-            bindings
-                .into_iter()
-                .map(|(s, t)| (s.allocate(env.arena()), t)),
-        )
-    }
-
-    /// Push one more binding to the substitution
-    ///
-    /// c.f. [Self::extend]
-    pub fn push(&mut self, name: Str, term: Term) {
-        self.0.insert(name, Some(term));
-    }
-
-    /// Push multiple bindings to the substitution
-    ///
-    /// c.f. [Self::push]
-    pub fn extend(&mut self, bindings: impl IntoIterator<Item = (Str, Term)>) {
-        for (name, term) in bindings {
-            self.0.insert(name, Some(term));
-        }
-    }
-}
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct Substitution(HashMap<usize, Term>);
 
 impl Default for Substitution {
-    fn default() -> Substitution {
+    fn default() -> Self {
         Substitution::empty()
     }
 }
 
-/// Apply a substitution to `Self`.
-///
-/// Note that it is the caller's responsibility to maintain well-sortedness invariance.
-#[deprecated = "this trait is to be replaced in 2.7.4"]
-pub trait Substitute<E> {
-    fn subst(&self, subst: &Substitution, env: &mut E) -> Self;
-}
-
-/// A stack of substitutions to handle shadowing
-type SubstList<'a> = MemLinkedList<'a, Substitution>;
-
-impl SubstList<'_> {
-    fn lookup(&self, x: &Str) -> Option<Term> {
-        match self {
-            SubstList::Nil => None,
-            SubstList::Cons { car, cdr } => {
-                if let Some(t) = car.0.get(x) {
-                    t.clone()
-                } else {
-                    cdr.lookup(x)
-                }
-            }
-        }
-    }
-}
-
-trait SubstituteImpl<E> {
-    fn subst_impl(&self, substs: &SubstList, env: &mut E) -> Self;
-}
-
-impl<E, X> Substitute<E> for X
-where
-    E: HasArenaAlt,
-    X: SubstituteImpl<E>,
-{
-    fn subst(&self, subst: &Substitution, env: &mut E) -> Self {
-        self.subst_impl(
-            &SubstList::Cons {
-                car: subst,
-                cdr: &SubstList::Nil,
-            },
-            env,
-        )
-    }
-}
-
-impl<E, T> SubstituteImpl<E> for Vec<T>
-where
-    E: HasArenaAlt,
-    T: SubstituteImpl<E>,
-{
-    fn subst_impl(&self, substs: &SubstList, env: &mut E) -> Self {
-        self.iter().map(|a| a.subst_impl(substs, env)).collect()
-    }
-}
-
-impl<E> SubstituteImpl<E> for Attribute
-where
-    E: HasArenaAlt,
-{
-    fn subst_impl(&self, substs: &SubstList, env: &mut E) -> Self {
-        match self {
-            Attribute::Pattern(t) => Attribute::Pattern(t.subst_impl(substs, env)),
-            _ => self.clone(),
-        }
-    }
-}
-
-fn subst_binder_shadow<V, E>(
-    vars: &[V],
-    body: &Term,
-    substs: &SubstList,
-    env: &mut E,
-    f: impl Fn(&V) -> Str,
-) -> Term
-where
-    E: HasArenaAlt,
-{
-    let shadow = vars.iter().map(|v| (f(v), None)).collect();
-    let subst = Substitution(shadow);
-    body.subst_impl(
-        &SubstList::Cons {
-            car: &subst,
-            cdr: substs,
-        },
-        env,
-    )
-}
-
-impl<E> SubstituteImpl<E> for Term
-where
-    E: HasArenaAlt,
-{
-    fn subst_impl(&self, substs: &SubstList, env: &mut E) -> Self {
-        match self.repr() {
-            ATerm::Constant(_, _) | ATerm::Global(_, _) => self.clone(),
-            ATerm::Local(var) => {
-                if let Some(t) = substs.lookup(&var.symbol) {
-                    t
-                } else {
-                    self.clone()
-                }
-            }
-            ATerm::App(f, args, s) => {
-                let nargs = args.subst_impl(substs, env);
-                env.arena_alt().app(f.clone(), nargs, s.clone())
-            }
-            ATerm::Let(bindings, body) => {
-                let nbindings = bindings
-                    .iter()
-                    .map(|b| VarBinding(b.0.clone(), b.1, b.2.subst_impl(substs, env)))
-                    .collect();
-                let nbody = subst_binder_shadow(bindings, body, substs, env, |v| v.0.clone());
-                env.arena_alt().let_term(nbindings, nbody)
-            }
-            ATerm::Exists(vars, body) => {
-                let nbody = subst_binder_shadow(vars, body, substs, env, |v| v.0.clone());
-                env.arena_alt().exists(vars.clone(), nbody)
-            }
-            ATerm::Forall(vars, body) => {
-                let nbody = subst_binder_shadow(vars, body, substs, env, |v| v.0.clone());
-                env.arena_alt().forall(vars.clone(), nbody)
-            }
-            ATerm::Matching(t, cases) => {
-                let nt = t.subst_impl(substs, env);
-                let ncases = cases
-                    .iter()
-                    .map(|c| {
-                        let nbody = subst_binder_shadow(
-                            &c.pattern.variables(),
-                            &c.body,
-                            substs,
-                            env,
-                            |v| Str::clone(v),
-                        );
-                        PatternArm {
-                            pattern: c.pattern.clone(),
-                            body: nbody,
-                        }
-                    })
-                    .collect();
-                env.arena_alt().matching(nt, ncases)
-            }
-            ATerm::Annotated(t, annos) => {
-                let nt = t.subst_impl(substs, env);
-                let nannos = annos.subst_impl(substs, env);
-                env.arena_alt().annotated(nt, nannos)
-            }
-            ATerm::Eq(a, b) => {
-                let na = a.subst_impl(substs, env);
-                let nb = b.subst_impl(substs, env);
-                env.arena_alt().eq(na, nb)
-            }
-            ATerm::Distinct(ts) => {
-                let nts = ts.subst_impl(substs, env);
-                env.arena_alt().distinct(nts)
-            }
-            ATerm::And(ts) => {
-                let nts = ts.subst_impl(substs, env);
-                env.arena_alt().and(nts)
-            }
-            ATerm::Or(ts) => {
-                let nts = ts.subst_impl(substs, env);
-                env.arena_alt().or(nts)
-            }
-            ATerm::Xor(ts) => {
-                let nts = ts.subst_impl(substs, env);
-                env.arena_alt().xor(nts)
-            }
-            ATerm::Implies(ts, concl) => {
-                let nts = ts.subst_impl(substs, env);
-                let concl = concl.subst_impl(substs, env);
-                env.arena_alt().implies(nts, concl)
-            }
-            ATerm::Not(t) => {
-                let nt = t.subst_impl(substs, env);
-                env.arena_alt().not(nt)
-            }
-            ATerm::Ite(c, t, e) => {
-                let nc = c.subst_impl(substs, env);
-                let nt = t.subst_impl(substs, env);
-                let ne = e.subst_impl(substs, env);
-                env.arena_alt().ite(nc, nt, ne)
-            }
-        }
-    }
-}
-
-/// A mapping from local variable IDs to replacement terms.
-///
-/// Create with [`SubstitutionV2::new`] (from `Local`–term pairs) or [`SubstitutionV2::empty`].
-/// Apply to a term via the [`SubstituteV2`] trait.
-#[derive(Clone, Debug)]
-pub struct SubstitutionV2(HashMap<usize, Term>);
-
-impl Default for SubstitutionV2 {
-    fn default() -> Self {
-        SubstitutionV2::empty()
-    }
-}
-
-impl SubstitutionV2 {
+impl Substitution {
     /// Create an empty substitution.
     pub fn empty() -> Self {
         Self(HashMap::new())
@@ -310,7 +63,7 @@ impl SubstitutionV2 {
     /// Create a substitution from an iterator of `(Local, Term)` pairs.
     pub fn new(bindings: impl IntoIterator<Item = (Local, Term)>) -> Self {
         let map = bindings.into_iter().map(|(l, t)| (l.id, t)).collect();
-        SubstitutionV2(map)
+        Substitution(map)
     }
 
     /// Push one more binding to the substitution
@@ -340,36 +93,57 @@ impl SubstitutionV2 {
     }
 }
 
+/// A backport support for using [SubstitutionV2]
+pub type SubstitutionV2 = Substitution;
+
 /// Apply a substitution to `Self`.
 ///
 /// Note that it is the caller's responsibility to maintain well-sortedness invariance.
-pub trait SubstituteV2<E> {
+pub trait Substitute<E> {
     /// The type produced by the substitution.
     type Out;
 
     /// Apply the substitution, returning a new value with locals replaced.
-    fn subst(&self, subst: &SubstitutionV2, env: &mut E) -> Self::Out;
+    fn subst(&self, subst: &Substitution, env: &mut E) -> Self::Out;
 }
 
-impl<E> SubstituteV2<E> for [Term]
+/// A backport support for [SubstituteV2]
+pub trait SubstituteV2<E> {
+    type Out;
+
+    fn subst(&self, subst: &Substitution, env: &mut E) -> Self::Out;
+}
+
+impl<E, X> SubstituteV2<E> for X
+where
+    X: Substitute<E>,
+{
+    type Out = <X as Substitute<E>>::Out;
+
+    fn subst(&self, subst: &Substitution, env: &mut E) -> Self::Out {
+        Substitute::subst(self, subst, env)
+    }
+}
+
+impl<E> Substitute<E> for [Term]
 where
     E: HasArena,
 {
     type Out = Vec<Term>;
 
-    fn subst(&self, subst: &SubstitutionV2, env: &mut E) -> Self::Out {
+    fn subst(&self, subst: &Substitution, env: &mut E) -> Self::Out {
         let mut s = Substituter::create(env, subst);
         self.iter().map(|t| s.recurse_on_term_no_err(t)).collect()
     }
 }
 
-impl<E> SubstituteV2<E> for Term
+impl<E> Substitute<E> for Term
 where
     E: HasArena,
 {
     type Out = Self;
 
-    fn subst(&self, subst: &SubstitutionV2, env: &mut E) -> Self::Out {
+    fn subst(&self, subst: &Substitution, env: &mut E) -> Self::Out {
         Substituter::create(env, subst).recurse_on_term_no_err(self)
     }
 }
@@ -382,26 +156,26 @@ where
     E: HasArena,
 {
     /// Create a new memoized substituter backed by the given arena and substitution.
-    pub fn create(env: &'a mut E, subst: &'a SubstitutionV2) -> Self {
+    pub fn create(env: &'a mut E, subst: &'a Substitution) -> Self {
         Memoize::new(SubstituterInner::new(env, subst))
     }
 }
 
 /// Stack-safe local substitution using [`TermRecursor`].
 ///
-/// Replaces local variables by ID according to a [`SubstitutionV2`]. Binders (`let`, `forall`,
+/// Replaces local variables by ID according to a [`Substitution`]. Binders (`let`, `forall`,
 /// `exists`, `match`) shadow substitutions for re-bound variables.
 pub struct SubstituterInner<'a, E> {
     inner: TypedBuilder<'a, E>,
     /// The base substitution (local id → replacement term).
-    subst: &'a SubstitutionV2,
+    subst: &'a Substitution,
     /// Shadow stack: each frame maps a local variable id to a fresh id, blocking substitution in scoped bodies.
     shadows: Vec<HashMap<usize, usize>>,
 }
 
 impl<'a, E: HasArena> SubstituterInner<'a, E> {
     /// Create a new substituter backed by the given arena and substitution.
-    pub fn new(arena: &'a mut E, subst: &'a SubstitutionV2) -> Self {
+    pub fn new(arena: &'a mut E, subst: &'a Substitution) -> Self {
         Self {
             inner: TypedBuilder::new(arena),
             subst,

--- a/tests/substitutions.rs
+++ b/tests/substitutions.rs
@@ -4,7 +4,7 @@
 use dashu::integer::UBig;
 use yaspar_ir::ast::{
     CheckedApi, Context, GlobalSubst, LetElim, Local, LocalVarAllocator, ObjectAllocatorExt,
-    StrAllocator, SubstituteV2, SubstitutionV2, Typecheck,
+    StrAllocator, Substitute, Substitution, Typecheck,
 };
 use yaspar_ir::untyped::UntypedAst;
 
@@ -31,7 +31,7 @@ fn test_substitutions() {
         .unwrap()
         .type_check(&mut q_ctx)
         .unwrap();
-    let mut subst = SubstitutionV2::new([(x_local, plus)]);
+    let mut subst = Substitution::new([(x_local, plus)]);
     let z_sym = q_ctx.allocate_symbol("z");
     let z_id = q_ctx.new_local(); // a non-existent local id
     let loc = Local {
@@ -80,7 +80,7 @@ fn test_substitutions_shadow() {
         .unwrap()
         .type_check(&mut q_ctx)
         .unwrap();
-    let subst = SubstitutionV2::new([(x_local, plus)]);
+    let subst = Substitution::new([(x_local, plus)]);
     let t = UntypedAst
         .parse_term_str("(forall ((x Int)) (= x 10))")
         .unwrap()


### PR DESCRIPTION
Substitution and Substitute are updated to V2. We keep V2 as an alias.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
