### PR TITLE
fix: evict stale sort_cache entries after mutual datatype construction

### DIFF
--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -2487,7 +2487,15 @@ where
             env.dt_sorts.insert(def.name.clone(), us);
         }
         let result = Self::build_dt_decls(env, defs);
+        // Evict stale sort_cache entries that were cached against unresolved
+        // placeholder sorts during datatype construction. Without this,
+        // later sort lookups hit the cache and return the unresolved sort
+        // object instead of the resolved one, causing sort identity mismatches.
+        let stale: Vec<CSort<'tm>> = env.dt_sorts.values().cloned().collect();
         env.dt_sorts.clear();
+        for cs in stale {
+            env.sort_cache.remove_by_right(&cs);
+        }
         let decls = result?;
         if decls.len() == 1 {
             let cs = env.tm.mk_dt_sort(&decls[0]);

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -2673,3 +2673,26 @@ fn back_from_cvc5_api_const_array() {
         tm.mk_const_array(arr, zero)
     });
 }
+
+// ── Mutual datatype sort cache eviction tests ───────────────
+
+/// Mutually-declared datatypes: a sort used as a field type in a sibling
+/// datatype must resolve to the *finalized* sort after declaration, not to
+/// the unresolved placeholder that was in dt_sorts during construction.
+/// Without the stale sort_cache eviction fix this panics with a sort
+/// identity mismatch ("argument type is not the type of the function's
+/// argument type").
+#[test]
+fn mutual_datatypes_sort_cache_eviction() {
+    run_script(
+        "(set-logic ALL)
+         (declare-datatypes ((A 0) (B 0))
+           (((mkA (getB B)) (baseA))
+            ((mkB (getA A)))))
+         (declare-const a A)
+         (declare-const b B)
+         (assert (= a (mkA b)))
+         (assert (= b (mkB a)))
+         (check-sat)",
+    );
+}


### PR DESCRIPTION
During translate_declare_datatypes, unresolved placeholder sorts are registered in dt_sorts so sibling datatypes can reference each other. When Sort::to_cvc5 resolves these references, it caches the unresolved sort in sort_cache. After construction completes, dt_sorts is cleared and resolved sorts are stored—but sort_cache retains the stale unresolved entries. Subsequent lookups of those sorts hit the cache and return the unresolved placeholder, causing cvc5 to reject well-typed terms with "argument type is not the type of the function's argument type".

Fix: after clearing dt_sorts, remove the corresponding stale entries from sort_cache by right-value so later lookups re-resolve against the finalized sorts.

There is a new test case included for this bug. This test (mutual_datatypes_sort_cache_eviction in tests/cvc5.rs) exercises the bug because:
  1. A and B are mutually declared — A has a field of type B and vice versa
  2. During construction, translating A's field type B caches the unresolved B placeholder in sort_cache
  3. After construction, (declare-const b B) hits sort_cache, gets the stale unresolved sort
  4. (assert (= a (mkA b))) then passes b (unresolved sort) to mkA (which expects resolved B) — sort mismatch

You can run with `cargo test --features cvc5-dynamic --test cvc5 mutual_datatypes_sort_cache_eviction` once you have cvc5 available locally