### PR TITLE
Fix ConvertFromCvc5 for negative integer and rational model values

### DIFF
--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -91,7 +91,7 @@ use crate::traits::{AllocatableString, Contains, HasMutRef, Repr};
 use crate::untyped::UntypedAst;
 use bimap::BiHashMap;
 pub use cvc5::{Kind, ProofComponent, Solver, TermManager};
-use dashu::integer::UBig;
+use dashu::integer::{IBig, Sign, UBig};
 use std::collections::{HashMap, HashSet};
 use yaspar::ast::Keyword;
 use yaspar::{binary_to_string, hex_to_string};
@@ -602,6 +602,23 @@ where
     }
 }
 
+/// Allocate an integer term for a possibly-negative `IBig`.
+///
+/// A `Numeral` is non-negative, so a negative value becomes a unary-minus
+/// application `(- mag)`, matching [`CheckedApi::integer`](crate::ast::CheckedApi::integer).
+fn signed_int_term(rf: &mut Context, value: IBig, sort: Sort) -> Term {
+    let (sign, mag) = value.into_parts();
+    let num = rf.allocate_term(ATerm::Constant(Constant::Numeral(mag), Some(sort.clone())));
+    match sign {
+        Sign::Negative => {
+            let sym = rf.allocate_symbol(SUB);
+            let qid = QualifiedIdentifier::simple(sym);
+            rf.app(qid, vec![num], Some(sort))
+        }
+        Sign::Positive => num,
+    }
+}
+
 fn translate_term_from_cvc5<'tm, Ctx>(ct: &CTerm<'tm>, fenv: &mut Cvc5Env<'tm, Ctx>) -> Res<Term>
 where
     Ctx: HasMutRef<Context>,
@@ -616,14 +633,12 @@ where
     }
     if ct.is_integer_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
-        let n: UBig = ct
+        // cvc5 gives a negative value as a signed string (e.g. "-5"), so parse signed.
+        let n: IBig = ct
             .integer_value()
             .parse()
             .map_err(|e| format!("Big integer parse error: {e}"))?;
-        return Ok(fenv
-            .ctx
-            .ref_mut()
-            .allocate_term(ATerm::Constant(Constant::Numeral(n), Some(sort))));
+        return Ok(signed_int_term(&mut fenv.ctx.ref_mut(), n, sort));
     }
     if ct.is_real_value() {
         let sort = ct.sort().conv_from_cvc5(fenv)?;
@@ -640,11 +655,13 @@ where
                 let denom = rf.allocate_term(ATerm::Constant(d, Some(sort.clone())));
                 (numer, denom)
             } else {
-                let num: UBig = num_s.parse().map_err(|e| format!("{e}"))?;
+                // cvc5 normalizes a rational's sign onto the numerator (even "5/(-2)"
+                // comes back as "-5/2"), so only the numerator can be negative; parsing
+                // the denominator as `UBig` enforces that it stays non-negative.
+                let num: IBig = num_s.parse().map_err(|e| format!("{e}"))?;
                 let den: UBig = den_s.parse().map_err(|e| format!("{e}"))?;
                 let int = rf.int_sort();
-                let numer =
-                    rf.allocate_term(ATerm::Constant(Constant::Numeral(num), Some(int.clone())));
+                let numer = signed_int_term(&mut rf, num, int.clone());
                 let denom = rf.allocate_term(ATerm::Constant(Constant::Numeral(den), Some(int)));
                 (numer, denom)
             };

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -2696,3 +2696,71 @@ fn mutual_datatypes_sort_cache_eviction() {
          (check-sat)",
     );
 }
+
+// ── Negative numeric model values (regression for the `UBig` parse bug) ───────
+//
+// cvc5 returns a negative integer's value as the signed string "-5", and a
+// rational with negative numerator as "-3/4". `conv_from_cvc5` previously parsed
+// these into `UBig`, which errored ("Big integer parse error: invalid digit").
+// They must round-trip back to the unary-minus term form `(- n)`.
+
+#[test]
+fn get_value_negative_integer() {
+    with_script_results(
+        "(set-logic QF_LIA)
+         (declare-const x Int)
+         (assert (= x (- 5)))
+         (check-sat)
+         (get-value (x))",
+        &[("produce-models", "true")],
+        |results| match results.last().unwrap() {
+            CommandResult::GetValue(vals) => {
+                assert_eq!(vals.len(), 1);
+                assert_eq!(vals[0].to_string(), "(- 5)");
+            }
+            other => panic!("expected GetValue, got {other:?}"),
+        },
+    );
+}
+
+#[test]
+fn get_value_negative_integer_nested() {
+    // A negative integer nested inside a larger value must also convert, since
+    // `conv_from_cvc5` recurses. Here the value of `(+ x 0)` is the negative model.
+    with_script_results(
+        "(set-logic QF_LIA)
+         (declare-const x Int)
+         (assert (= x (- 42)))
+         (check-sat)
+         (get-value ((+ x 1)))",
+        &[("produce-models", "true")],
+        |results| match results.last().unwrap() {
+            CommandResult::GetValue(vals) => {
+                assert_eq!(vals.len(), 1);
+                assert_eq!(vals[0].to_string(), "(- 41)");
+            }
+            other => panic!("expected GetValue, got {other:?}"),
+        },
+    );
+}
+
+#[test]
+fn get_value_negative_rational_pure_real() {
+    // Pure-`Real` logic (no Int theory) exercises the rational branch that also
+    // parsed into `UBig`; a negative numerator must round-trip.
+    with_script_results(
+        "(set-logic QF_LRA)
+         (declare-const x Real)
+         (assert (= x (- (/ 3.0 4.0))))
+         (check-sat)
+         (get-value (x))",
+        &[("produce-models", "true")],
+        |results| match results.last().unwrap() {
+            CommandResult::GetValue(vals) => {
+                assert_eq!(vals.len(), 1);
+                assert_eq!(vals[0].to_string(), "(/ (- 3) 4)");
+            }
+            other => panic!("expected GetValue, got {other:?}"),
+        },
+    );
+}


### PR DESCRIPTION
## Summary

`ConvertFromCvc5` for `CTerm` parsed cvc5's signed value strings (`"-5"`, `"-3/4"`) into `UBig`, failing with `Big integer parse error: invalid digit`. This made `get-value` unusable for any model containing a negative integer, including nested ones (the converter recurses).

This parses signed (`IBig`) and reconstructs negatives as the unary-minus form `(- mag)` via a new `signed_int_term` helper, matching what the parser and `CheckedApi::integer` produce. Two sites: the integer arm and the pure-`Real` rational numerator.

## Tests

Adds regression tests for a negative integer, a nested negative integer, and a negative pure-`Real` rational. Full cvc5 suite passes locally.

Fixes #108