### PR TITLE
Update yaspar dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ none = []
 regression = ["all", "cvc5"]
 
 [dependencies]
-yaspar = "2.7"
+yaspar = "2.7.1"
 sat-interface = { version = "0.1", optional = true }
 cvc5 = { version = "0.4", optional = true }
 dashu = { version = "0.4.2", features = ["serde", "num-traits", "num-order"] }


### PR DESCRIPTION
Updated yaspar dependency version from 2.7 to 2.7.1.

This does not compile with Yaspar 2.7.0.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
