### PR TITLE
fix CI issues

### DIFF
--- a/.github/actions/setup-cvc5/action.yaml
+++ b/.github/actions/setup-cvc5/action.yaml
@@ -46,6 +46,12 @@ runs:
         git clone --depth 1 --branch "cvc5-$cvc5_ver" \
           https://github.com/cvc5/cvc5.git cvc5-built
         cd cvc5-built
+        # On macOS, Apple Clang errors on a deprecated literal operator in a GMP
+        # header used by LibPoly; patch cvc5's FindPoly.cmake to keep it a warning.
+        # See https://github.com/cvc5/cvc5/pull/12585
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          git apply "${{ github.action_path }}/cvc5-poly-literal-operator.patch"
+        fi
         ./configure.sh --static --auto-download \
           --prefix="$(pwd)/build/install" -DBUILD_GMP=1
         cd build && make -j$(nproc 2>/dev/null || sysctl -n hw.ncpu)

--- a/.github/actions/setup-cvc5/cvc5-poly-literal-operator.patch
+++ b/.github/actions/setup-cvc5/cvc5-poly-literal-operator.patch
@@ -1,0 +1,20 @@
+--- a/cmake/FindPoly.cmake
++++ b/cmake/FindPoly.cmake
+@@ -156,12 +156,14 @@
+       "${DEPS_BASE}/lib/libpicpolyxx${CMAKE_STATIC_LIBRARY_SUFFIX}")
+   endif()
+ 
+-  # Disable a warning triggered by the Emscripten compiler due to code in
+-  # a GMP header used by LibPoly.
++  # Disable a warning triggered by compilers (Emscripten, Apple Clang, etc.)
++  # due to deprecated literal operator syntax in a GMP header used by LibPoly.
+   set(POLY_CXX_FLAGS "")
+-  if(NOT(WASM STREQUAL "OFF"))
++  check_cxx_compiler_flag(-Wno-error=deprecated-literal-operator HAVE_CXX_FLAGWno_error_deprecated_literal_operator)
++  if(HAVE_CXX_FLAGWno_error_deprecated_literal_operator)
+     set(POLY_CXX_FLAGS -DCMAKE_CXX_FLAGS=-Wno-error=deprecated-literal-operator)
+   endif()
++
+   # We pass the full path of GMP to LibPoly, s.t. we can ensure that LibPoly is
+   # able to find the correct version of GMP if we built it locally. This is
+   # primarily important for cross-compiling cvc5, because LibPoly's search

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["SMT", "solver", "logic"]
 categories = ["science"]
 homepage = "https://github.com/yaspar-org/yaspar-ir"
 repository = "https://github.com/yaspar-org/yaspar-ir"
-exclude = ["tests/resources", "tests/regression.rs"]
+exclude = ["tests/resources", "tests/regression.rs", ".github"]
 
 [features]
 default = ["none"]
@@ -27,7 +27,7 @@ none = []
 regression = ["all", "cvc5"]
 
 [dependencies]
-yaspar = "2.7"
+yaspar = "2.7.1"
 sat-interface = { version = "0.1", optional = true }
 cvc5 = { version = "0.4", optional = true }
 dashu = { version = "0.4.2", features = ["serde", "num-traits", "num-order"] }


### PR DESCRIPTION
cvc5 doesn't build on Mac due to C++ dependencies. We manually apply a patch here to overcome the problem.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
