### PR TITLE
generalize API

### DIFF
--- a/src/ast/ctx/mod.rs
+++ b/src/ast/ctx/mod.rs
@@ -311,7 +311,7 @@ impl Context {
     }
 
     /// Remove a sort from the sort table
-    pub fn remove_sort<S>(&mut self, sort: &S)
+    pub fn remove_sort<S>(&mut self, sort: S)
     where
         S: AllocatableString<Arena>,
     {
@@ -472,7 +472,7 @@ impl Context {
     }
 
     /// Remove a symbol from the symbol table
-    pub fn remove_symbol<S>(&mut self, symbol: &S)
+    pub fn remove_symbol<S>(&mut self, symbol: S)
     where
         S: AllocatableString<Arena>,
     {


### PR DESCRIPTION
&S is automatically AllocatableString if S is. Removing & monotonically allows more types.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
