### PR TITLE
add `Rejected` to `Sig`

### DIFF
--- a/src/raw/alg.rs
+++ b/src/raw/alg.rs
@@ -594,6 +594,11 @@ pub enum Sig<Str, So> {
     /// It is a special case, because concat is an associative operation, which requires accumulation
     /// of bv lengths as well
     BvConcat,
+    /// A placeholder signature for rejected symbol
+    ///
+    /// It is useful when a symbol is meant to be rejected for various reasons (e.g. unsupported functions),
+    /// but we want the symbols to be presented as rejected ones, not just absent.
+    Rejected,
 }
 
 impl<Str, So> Sig<Str, So> {
@@ -1287,6 +1292,7 @@ where
                 write!(f, "(=> {} ...[>= {} times] {} {})", inp, n, inp, o)
             }
             Sig::BvConcat => "(=> (_ BitVec l1) ... (_ BitVec ln) (_ BitVec (+ l1 ... ln)))".fmt(f),
+            Sig::Rejected => "REJECTED".fmt(f),
         }
     }
 }

--- a/src/raw/tc/app.rs
+++ b/src/raw/tc/app.rs
@@ -221,6 +221,9 @@ where
                         "TC: {qid}{meta_string} has a signature of a bit vector function, which cannot be used as a variable!"
                     ))
                 }
+                Sig::Rejected => Err(format!(
+                    "TC: {qid}{meta_string} is a rejected/unsupported symbol!"
+                )),
             }
         }
         Some((l, s)) => {
@@ -674,6 +677,7 @@ where
             // passing all tests
             Ok(env.arena.app(f.clone(), new_args, Some(out_sort)))
         }
+        Sig::Rejected => Err(format!("TC: {f}{f_meta} is a rejected/unsupported symbol!")),
     }
 }
 


### PR DESCRIPTION
A rejected case explicitly flags an unsupported/rejected symbol for reporting purposes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
