### PR TITLE
Handle :no-pattern attribute from the parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ no-pattern = ["yaspar/no-pattern"]
 regression = ["all", "cvc5"]
 
 [dependencies]
-yaspar = "2.7.1"
+yaspar = "2.7.2"
 sat-interface = { version = "0.1", optional = true }
 cvc5 = { version = "0.4", optional = true }
 dashu = { version = "0.4.2", features = ["serde", "num-traits", "num-order"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,7 @@ cvc5-dynamic = ["cvc5-dep"]
 finite-set = []
 cache = []
 none = []
-# Enable parsing of the non-standard `:no-pattern <term>` quantifier attribute
-# (an anti-trigger hint emitted by Dafny/Boogie). Forwards to yaspar's grammar
-# gate of the same name. Off by default so the parser stays strictly SMT-LIB
-# 2.7 conformant.
+# Parse the non-standard `:no-pattern` attribute; forwards to `yaspar/no-pattern`.
 no-pattern = ["yaspar/no-pattern"]
 regression = ["all", "cvc5"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["tests/resources", "tests/regression.rs", ".github"]
 
 [features]
 default = ["none"]
-all = ["cnf", "implicant-generation", "finite-set"]
+all = ["cnf", "implicant-generation", "finite-set", "no-pattern"]
 cnf = ["dep:sat-interface", "cache"]
 implicant-generation = ["cnf"]
 cvc5-parser = ["cvc5?/parser"]
@@ -24,6 +24,11 @@ cvc5-dynamic = ["cvc5-dep"]
 finite-set = []
 cache = []
 none = []
+# Enable parsing of the non-standard `:no-pattern <term>` quantifier attribute
+# (an anti-trigger hint emitted by Dafny/Boogie). Forwards to yaspar's grammar
+# gate of the same name. Off by default so the parser stays strictly SMT-LIB
+# 2.7 conformant.
+no-pattern = ["yaspar/no-pattern"]
 regression = ["all", "cvc5"]
 
 [dependencies]

--- a/src/ast/boilerplates.rs
+++ b/src/ast/boilerplates.rs
@@ -257,8 +257,8 @@ where
     }
 
     #[cfg(feature = "no-pattern")]
-    fn on_attribute_no_pattern(&mut self, _: &[Term], recs: Vec<Term>) -> Result<Attribute, Bottom> {
-        Ok(Attribute::NoPattern(recs))
+    fn on_attribute_no_pattern(&mut self, _: &Term, rec: Term) -> Result<Attribute, Bottom> {
+        Ok(Attribute::NoPattern(rec))
     }
 
     fn on_eq(&mut self, _: &Term, _: &Term, _: &Term, a: Term, b: Term) -> Result<Term, Bottom> {

--- a/src/ast/boilerplates.rs
+++ b/src/ast/boilerplates.rs
@@ -256,6 +256,11 @@ where
         Ok(Attribute::Pattern(recs))
     }
 
+    #[cfg(feature = "no-pattern")]
+    fn on_attribute_no_pattern(&mut self, _: &[Term], recs: Vec<Term>) -> Result<Attribute, Bottom> {
+        Ok(Attribute::NoPattern(recs))
+    }
+
     fn on_eq(&mut self, _: &Term, _: &Term, _: &Term, a: Term, b: Term) -> Result<Term, Bottom> {
         Ok(self.arena.arena().eq(a, b))
     }

--- a/src/ast/fv.rs
+++ b/src/ast/fv.rs
@@ -245,8 +245,8 @@ impl TermRecursor<Str, Sort, Term> for FreeLocalVariableFinder {
     #[cfg(feature = "no-pattern")]
     fn on_attribute_no_pattern(
         &mut self,
-        _patterns: &[Term],
-        _patterns_rec: Vec<Self::Out>,
+        _pattern: &Term,
+        _pattern_rec: Self::Out,
     ) -> Result<Self::Attr, Self::Err> {
         Ok(())
     }

--- a/src/ast/fv.rs
+++ b/src/ast/fv.rs
@@ -242,6 +242,15 @@ impl TermRecursor<Str, Sort, Term> for FreeLocalVariableFinder {
         Ok(())
     }
 
+    #[cfg(feature = "no-pattern")]
+    fn on_attribute_no_pattern(
+        &mut self,
+        _patterns: &[Term],
+        _patterns_rec: Vec<Self::Out>,
+    ) -> Result<Self::Attr, Self::Err> {
+        Ok(())
+    }
+
     fn on_eq(
         &mut self,
         _current: &Term,

--- a/src/ast/gsubst.rs
+++ b/src/ast/gsubst.rs
@@ -247,6 +247,8 @@ impl TermRecursor<Str, Sort, Term> for GlobalSubstituterInner<'_> {
             fn on_attribute_symbol(&mut self, keyword: &Keyword, symbol: &Str) -> Result<Attribute, Bottom>;
             fn on_attribute_named(&mut self, name: &Str) -> Result<Attribute, Bottom>;
             fn on_attribute_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
+            #[cfg(feature = "no-pattern")]
+            fn on_attribute_no_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
             fn on_eq(&mut self, current: &Term, a: &Term, b: &Term, a_rec: Term, b_rec: Term) -> Result<Term, Bottom>;
             fn on_distinct(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;
             fn on_and(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;

--- a/src/ast/gsubst.rs
+++ b/src/ast/gsubst.rs
@@ -248,7 +248,7 @@ impl TermRecursor<Str, Sort, Term> for GlobalSubstituterInner<'_> {
             fn on_attribute_named(&mut self, name: &Str) -> Result<Attribute, Bottom>;
             fn on_attribute_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
             #[cfg(feature = "no-pattern")]
-            fn on_attribute_no_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
+            fn on_attribute_no_pattern(&mut self, pattern: &Term, pattern_rec: Term) -> Result<Attribute, Bottom>;
             fn on_eq(&mut self, current: &Term, a: &Term, b: &Term, a_rec: Term, b_rec: Term) -> Result<Term, Bottom>;
             fn on_distinct(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;
             fn on_and(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;

--- a/src/ast/letelim.rs
+++ b/src/ast/letelim.rs
@@ -105,6 +105,8 @@ impl<E: HasArena> TermRecursor<Str, Sort, Term> for LetEliminatorInner<'_, E> {
             fn on_attribute_symbol(&mut self, keyword: &Keyword, symbol: &Str) -> Result<Attribute, Bottom>;
             fn on_attribute_named(&mut self, name: &Str) -> Result<Attribute, Bottom>;
             fn on_attribute_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
+            #[cfg(feature = "no-pattern")]
+            fn on_attribute_no_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
             fn on_eq(&mut self, current: &Term, a: &Term, b: &Term, a_rec: Term, b_rec: Term) -> Result<Term, Bottom>;
             fn on_distinct(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;
             fn on_and(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;

--- a/src/ast/letelim.rs
+++ b/src/ast/letelim.rs
@@ -106,7 +106,7 @@ impl<E: HasArena> TermRecursor<Str, Sort, Term> for LetEliminatorInner<'_, E> {
             fn on_attribute_named(&mut self, name: &Str) -> Result<Attribute, Bottom>;
             fn on_attribute_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
             #[cfg(feature = "no-pattern")]
-            fn on_attribute_no_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
+            fn on_attribute_no_pattern(&mut self, pattern: &Term, pattern_rec: Term) -> Result<Attribute, Bottom>;
             fn on_eq(&mut self, current: &Term, a: &Term, b: &Term, a_rec: Term, b_rec: Term) -> Result<Term, Bottom>;
             fn on_distinct(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;
             fn on_and(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;

--- a/src/ast/mono.rs
+++ b/src/ast/mono.rs
@@ -226,7 +226,7 @@ impl<E: HasArena> TermRecursor<Str, Sort, Term> for MonomorphizerInner<'_, E> {
             fn on_attribute_named(&mut self, name: &Str) -> Result<Attribute, Bottom>;
             fn on_attribute_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
             #[cfg(feature = "no-pattern")]
-            fn on_attribute_no_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
+            fn on_attribute_no_pattern(&mut self, pattern: &Term, pattern_rec: Term) -> Result<Attribute, Bottom>;
             fn on_eq(&mut self, current: &Term, a: &Term, b: &Term, a_rec: Term, b_rec: Term) -> Result<Term, Bottom>;
             fn on_distinct(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;
             fn on_and(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;

--- a/src/ast/mono.rs
+++ b/src/ast/mono.rs
@@ -225,6 +225,8 @@ impl<E: HasArena> TermRecursor<Str, Sort, Term> for MonomorphizerInner<'_, E> {
             fn on_attribute_symbol(&mut self, keyword: &Keyword, symbol: &Str) -> Result<Attribute, Bottom>;
             fn on_attribute_named(&mut self, name: &Str) -> Result<Attribute, Bottom>;
             fn on_attribute_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
+            #[cfg(feature = "no-pattern")]
+            fn on_attribute_no_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
             fn on_eq(&mut self, current: &Term, a: &Term, b: &Term, a_rec: Term, b_rec: Term) -> Result<Term, Bottom>;
             fn on_distinct(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;
             fn on_and(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;

--- a/src/ast/subst.rs
+++ b/src/ast/subst.rs
@@ -208,6 +208,8 @@ impl<E: HasArena> TermRecursor<Str, Sort, Term> for SubstituterInner<'_, E> {
             fn on_attribute_symbol(&mut self, keyword: &Keyword, symbol: &Str) -> Result<Attribute, Bottom>;
             fn on_attribute_named(&mut self, name: &Str) -> Result<Attribute, Bottom>;
             fn on_attribute_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
+            #[cfg(feature = "no-pattern")]
+            fn on_attribute_no_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
             fn on_eq(&mut self, current: &Term, a: &Term, b: &Term, a_rec: Term, b_rec: Term) -> Result<Term, Bottom>;
             fn on_distinct(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;
             fn on_and(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;

--- a/src/ast/subst.rs
+++ b/src/ast/subst.rs
@@ -209,7 +209,7 @@ impl<E: HasArena> TermRecursor<Str, Sort, Term> for SubstituterInner<'_, E> {
             fn on_attribute_named(&mut self, name: &Str) -> Result<Attribute, Bottom>;
             fn on_attribute_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
             #[cfg(feature = "no-pattern")]
-            fn on_attribute_no_pattern(&mut self, patterns: &[Term], patterns_rec: Vec<Term>) -> Result<Attribute, Bottom>;
+            fn on_attribute_no_pattern(&mut self, pattern: &Term, pattern_rec: Term) -> Result<Attribute, Bottom>;
             fn on_eq(&mut self, current: &Term, a: &Term, b: &Term, a_rec: Term, b_rec: Term) -> Result<Term, Bottom>;
             fn on_distinct(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;
             fn on_and(&mut self, current: &Term, ts: &[Term], ts_rec: Vec<Term>) -> Result<Term, Bottom>;

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -188,7 +188,7 @@ pub struct WithPattern<'tm> {
 /// Pattern / anti-pattern groups collected from a term's annotations, produced
 /// by the `on_attribute_*` callbacks and merged in `on_annotated`.
 #[derive(Default)]
-struct PatternAttrs<'tm> {
+pub struct PatternAttrs<'tm> {
     /// `:pattern` groups; each becomes an `INST_PATTERN`.
     patterns: Vec<Vec<CTerm<'tm>>>,
     /// `:no-pattern` terms; each becomes an `INST_NO_PATTERN`.
@@ -2175,6 +2175,8 @@ impl<'tm, Ctx> Cvc5Env<'tm, Ctx> {
         // Build INST_PATTERN_LIST from :pattern (and :no-pattern) annotations.
         // The list holds INST_PATTERN entries and, for anti-triggers,
         // INST_NO_PATTERN entries.
+        // `mut` is used only under `no-pattern` (to push INST_NO_PATTERN entries).
+        #[cfg_attr(not(feature = "no-pattern"), allow(unused_mut))]
         let mut pats: Vec<CTerm<'tm>> = t_rec
             .patterns
             .iter()

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -180,6 +180,20 @@ pub struct WithPattern<'tm> {
     ///
     /// Multiple `:pattern`s are maintained.
     patterns: Vec<Vec<CTerm<'tm>>>,
+    /// Terms collected from `:no-pattern` annotations (each an anti-trigger).
+    #[cfg(feature = "no-pattern")]
+    no_patterns: Vec<CTerm<'tm>>,
+}
+
+/// Pattern / anti-pattern groups collected from a term's annotations, produced
+/// by the `on_attribute_*` callbacks and merged in `on_annotated`.
+#[derive(Default)]
+struct PatternAttrs<'tm> {
+    /// `:pattern` groups; each becomes an `INST_PATTERN`.
+    patterns: Vec<Vec<CTerm<'tm>>>,
+    /// `:no-pattern` terms; each becomes an `INST_NO_PATTERN`.
+    #[cfg(feature = "no-pattern")]
+    no_patterns: Vec<CTerm<'tm>>,
 }
 
 impl<'tm> From<WithPattern<'tm>> for CTerm<'tm> {
@@ -193,6 +207,8 @@ impl<'tm> From<CTerm<'tm>> for WithPattern<'tm> {
         WithPattern {
             term: value,
             patterns: vec![],
+            #[cfg(feature = "no-pattern")]
+            no_patterns: vec![],
         }
     }
 }
@@ -805,6 +821,8 @@ where
                 let probe = WithPattern {
                     term: body_ct.clone(),
                     patterns: cvc5_patterns.clone(),
+                    #[cfg(feature = "no-pattern")]
+                    no_patterns: vec![],
                 };
                 if let Some(cached) = fenv.term_cache.get_by_right(&probe) {
                     break 'inner Ok(cached.clone());
@@ -1544,7 +1562,7 @@ fn to_term_vec(terms: Vec<WithPattern>) -> Vec<CTerm> {
 
 impl<'tm, Ctx> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm, Ctx> {
     type Out = WithPattern<'tm>;
-    type Attr = Vec<Vec<CTerm<'tm>>>;
+    type Attr = PatternAttrs<'tm>;
     type Binding = (usize, WithPattern<'tm>);
     type Pattern = ();
     type Arm = CTerm<'tm>;
@@ -1818,54 +1836,63 @@ impl<'tm, Ctx> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm, Ctx> {
         _t: &Term,
         _anns: &[Attribute],
         t_rec: WithPattern<'tm>,
-        anns_rec: Vec<Vec<Vec<CTerm<'tm>>>>,
+        anns_rec: Vec<PatternAttrs<'tm>>,
     ) -> Res<WithPattern<'tm>> {
-        // do not handle other annotations
         let mut pats = t_rec.patterns;
-        anns_rec.into_iter().for_each(|ps| pats.extend(ps));
+        #[cfg(feature = "no-pattern")]
+        let mut no_pats = t_rec.no_patterns;
+        for a in anns_rec {
+            pats.extend(a.patterns);
+            #[cfg(feature = "no-pattern")]
+            no_pats.extend(a.no_patterns);
+        }
         Ok(WithPattern {
             term: t_rec.term,
             patterns: pats,
+            #[cfg(feature = "no-pattern")]
+            no_patterns: no_pats,
         })
     }
-    fn on_attribute_keyword(&mut self, _keyword: &Keyword) -> Res<Vec<Vec<CTerm<'tm>>>> {
-        Ok(vec![])
+    fn on_attribute_keyword(&mut self, _keyword: &Keyword) -> Res<PatternAttrs<'tm>> {
+        Ok(PatternAttrs::default())
     }
     fn on_attribute_constant(
         &mut self,
         _keyword: &Keyword,
         _constant: &Constant,
-    ) -> Res<Vec<Vec<CTerm<'tm>>>> {
-        Ok(vec![])
+    ) -> Res<PatternAttrs<'tm>> {
+        Ok(PatternAttrs::default())
     }
-    fn on_attribute_symbol(
-        &mut self,
-        _keyword: &Keyword,
-        _symbol: &Str,
-    ) -> Res<Vec<Vec<CTerm<'tm>>>> {
-        Ok(vec![])
+    fn on_attribute_symbol(&mut self, _keyword: &Keyword, _symbol: &Str) -> Res<PatternAttrs<'tm>> {
+        Ok(PatternAttrs::default())
     }
-    fn on_attribute_named(&mut self, _name: &Str) -> Res<Vec<Vec<CTerm<'tm>>>> {
-        Ok(vec![])
+    fn on_attribute_named(&mut self, _name: &Str) -> Res<PatternAttrs<'tm>> {
+        Ok(PatternAttrs::default())
     }
 
     fn on_attribute_pattern(
         &mut self,
         _patterns: &[Term],
         patterns_rec: Vec<WithPattern<'tm>>,
-    ) -> Res<Vec<Vec<CTerm<'tm>>>> {
-        Ok(vec![to_term_vec(patterns_rec)])
+    ) -> Res<PatternAttrs<'tm>> {
+        Ok(PatternAttrs {
+            patterns: vec![to_term_vec(patterns_rec)],
+            ..Default::default()
+        })
     }
 
     #[cfg(feature = "no-pattern")]
     fn on_attribute_no_pattern(
         &mut self,
-        _patterns: &[Term],
-        patterns_rec: Vec<WithPattern<'tm>>,
-    ) -> Res<Vec<Vec<CTerm<'tm>>>> {
-        // `:no-pattern` is an anti-trigger hint; treat it as a (non-triggering)
-        // pattern group for cvc5's purposes.
-        Ok(vec![to_term_vec(patterns_rec)])
+        _pattern: &Term,
+        pattern_rec: WithPattern<'tm>,
+    ) -> Res<PatternAttrs<'tm>> {
+        // Preserve the anti-trigger term; emitted as an INST_NO_PATTERN on the
+        // quantifier in `translate_quantifier_body`.
+        Ok(PatternAttrs {
+            no_patterns: vec![pattern_rec.term],
+            ..Default::default()
+        })
     }
 
     fn on_eq(
@@ -2145,19 +2172,28 @@ impl<'tm, Ctx> Cvc5Env<'tm, Ctx> {
         // Peel off annotations from the body to extract :pattern triggers
         let cbody = t_rec.term;
 
-        // Build INST_PATTERN_LIST from :pattern annotations
-        if !t_rec.patterns.is_empty() {
-            let pats = t_rec
-                .patterns
-                .iter()
-                .filter_map(|ts| {
-                    if ts.is_empty() {
-                        None
-                    } else {
-                        Some(self.tm.mk_term(Kind::InstPattern, ts))
-                    }
-                })
-                .collect::<Vec<_>>();
+        // Build INST_PATTERN_LIST from :pattern (and :no-pattern) annotations.
+        // The list holds INST_PATTERN entries and, for anti-triggers,
+        // INST_NO_PATTERN entries.
+        let mut pats: Vec<CTerm<'tm>> = t_rec
+            .patterns
+            .iter()
+            .filter_map(|ts| {
+                if ts.is_empty() {
+                    None
+                } else {
+                    Some(self.tm.mk_term(Kind::InstPattern, ts))
+                }
+            })
+            .collect();
+        #[cfg(feature = "no-pattern")]
+        for t in &t_rec.no_patterns {
+            pats.push(
+                self.tm
+                    .mk_term(Kind::InstNoPattern, std::slice::from_ref(t)),
+            );
+        }
+        if !pats.is_empty() {
             let plist = self.tm.mk_term(Kind::InstPatternList, &pats);
             return Ok(self.tm.mk_term(kind, &[bvl, cbody, plist]).into());
         }

--- a/src/cvc5.rs
+++ b/src/cvc5.rs
@@ -1857,6 +1857,17 @@ impl<'tm, Ctx> TermRecursor<Str, Sort, Term> for Cvc5Env<'tm, Ctx> {
         Ok(vec![to_term_vec(patterns_rec)])
     }
 
+    #[cfg(feature = "no-pattern")]
+    fn on_attribute_no_pattern(
+        &mut self,
+        _patterns: &[Term],
+        patterns_rec: Vec<WithPattern<'tm>>,
+    ) -> Res<Vec<Vec<CTerm<'tm>>>> {
+        // `:no-pattern` is an anti-trigger hint; treat it as a (non-triggering)
+        // pattern group for cvc5's purposes.
+        Ok(vec![to_term_vec(patterns_rec)])
+    }
+
     fn on_eq(
         &mut self,
         _current: &Term,

--- a/src/raw/alg.rs
+++ b/src/raw/alg.rs
@@ -348,6 +348,14 @@ pub enum Attribute<Str, T> {
     Named(Str),
     /// Special attribute :pattern (term+)
     Pattern(Vec<T>),
+    /// Special attribute :no-pattern (single term). An *anti*-trigger hint: the
+    /// term must NOT be used as an e-matching trigger. Stored as a `Vec` (of
+    /// length one) so it reuses the same sub-term recursion machinery as
+    /// `Pattern`; the term is preserved so consumers (e.g. trigger inference)
+    /// can honor the exclusion. Gated behind the `no-pattern` feature, which
+    /// forwards to `yaspar/no-pattern`; only produced when it is enabled.
+    #[cfg(feature = "no-pattern")]
+    NoPattern(Vec<T>),
 }
 
 /// Represent sorts in SMTLib
@@ -803,6 +811,8 @@ impl<Str, So, T> Term<Str, So, T> {
             Term::Annotated(t, annos) => {
                 Box::new(std::iter::once(t).chain(annos.iter().flat_map(|a| match a {
                     Attribute::Pattern(ts) => ts.iter(),
+                    #[cfg(feature = "no-pattern")]
+                    Attribute::NoPattern(ts) => ts.iter(),
                     _ => [].iter(),
                 })))
             }
@@ -1151,6 +1161,12 @@ where
             Attribute::Pattern(ts) => {
                 ":pattern ".fmt(f)?;
                 fmt_vec_paren(f, ts)
+            }
+            #[cfg(feature = "no-pattern")]
+            Attribute::NoPattern(ts) => {
+                // `:no-pattern` takes a single term value (not a list).
+                ":no-pattern ".fmt(f)?;
+                fmt_vec(f, ts)
             }
         }
     }

--- a/src/raw/alg.rs
+++ b/src/raw/alg.rs
@@ -348,11 +348,11 @@ pub enum Attribute<Str, T> {
     Named(Str),
     /// Special attribute :pattern (term+)
     Pattern(Vec<T>),
-    /// Special attribute `:no-pattern` — an *anti*-trigger hint whose term must
-    /// not be used as an e-matching trigger. A length-1 `Vec` so it reuses
-    /// `Pattern`'s sub-term recursion. Behind the `no-pattern` feature.
+    /// Special attribute `:no-pattern` — an *anti*-trigger hint whose (single)
+    /// term must not be used as an e-matching trigger. Behind the `no-pattern`
+    /// feature.
     #[cfg(feature = "no-pattern")]
-    NoPattern(Vec<T>),
+    NoPattern(T),
 }
 
 /// Represent sorts in SMTLib
@@ -809,7 +809,7 @@ impl<Str, So, T> Term<Str, So, T> {
                 Box::new(std::iter::once(t).chain(annos.iter().flat_map(|a| match a {
                     Attribute::Pattern(ts) => ts.iter(),
                     #[cfg(feature = "no-pattern")]
-                    Attribute::NoPattern(ts) => ts.iter(),
+                    Attribute::NoPattern(t) => std::slice::from_ref(t).iter(),
                     _ => [].iter(),
                 })))
             }
@@ -1160,11 +1160,7 @@ where
                 fmt_vec_paren(f, ts)
             }
             #[cfg(feature = "no-pattern")]
-            Attribute::NoPattern(ts) => {
-                // `:no-pattern` takes a single term value (not a list).
-                ":no-pattern ".fmt(f)?;
-                fmt_vec(f, ts)
-            }
+            Attribute::NoPattern(t) => write!(f, ":no-pattern {t}"),
         }
     }
 }

--- a/src/raw/alg.rs
+++ b/src/raw/alg.rs
@@ -348,12 +348,9 @@ pub enum Attribute<Str, T> {
     Named(Str),
     /// Special attribute :pattern (term+)
     Pattern(Vec<T>),
-    /// Special attribute :no-pattern (single term). An *anti*-trigger hint: the
-    /// term must NOT be used as an e-matching trigger. Stored as a `Vec` (of
-    /// length one) so it reuses the same sub-term recursion machinery as
-    /// `Pattern`; the term is preserved so consumers (e.g. trigger inference)
-    /// can honor the exclusion. Gated behind the `no-pattern` feature, which
-    /// forwards to `yaspar/no-pattern`; only produced when it is enabled.
+    /// Special attribute `:no-pattern` — an *anti*-trigger hint whose term must
+    /// not be used as an e-matching trigger. A length-1 `Vec` so it reuses
+    /// `Pattern`'s sub-term recursion. Behind the `no-pattern` feature.
     #[cfg(feature = "no-pattern")]
     NoPattern(Vec<T>),
 }

--- a/src/raw/alg/rec.rs
+++ b/src/raw/alg/rec.rs
@@ -323,6 +323,14 @@ pub trait TermRecursor<Str, So, T> {
         patterns: &[T],
         patterns_rec: Vec<Self::Out>,
     ) -> Result<Self::Attr, Self::Err>;
+    /// Called for a `:no-pattern` attribute after its sub-term(s) have been
+    /// recursed. Only present under the `no-pattern` feature.
+    #[cfg(feature = "no-pattern")]
+    fn on_attribute_no_pattern(
+        &mut self,
+        patterns: &[T],
+        patterns_rec: Vec<Self::Out>,
+    ) -> Result<Self::Attr, Self::Err>;
 
     // --- Binary / n-ary connectives ---
 
@@ -569,6 +577,14 @@ where
                         break;
                     }
                 }
+                #[cfg(feature = "no-pattern")]
+                Attribute::NoPattern(ts) => {
+                    if ts.is_empty() {
+                        anns_rec.push(recursor.on_attribute_no_pattern(ts, vec![])?);
+                    } else {
+                        break;
+                    }
+                }
                 Attribute::Keyword(k) => anns_rec.push(recursor.on_attribute_keyword(k)?),
                 Attribute::Constant(k, c) => anns_rec.push(recursor.on_attribute_constant(k, c)?),
                 Attribute::Symbol(k, s) => anns_rec.push(recursor.on_attribute_symbol(k, s)?),
@@ -765,12 +781,25 @@ where
                     mut cur_pattern_rec,
                 } => {
                     cur_pattern_rec.push(result);
-                    let pat_ts = match &anns[anns_rec.len()] {
-                        Attribute::Pattern(ts) => ts,
+                    let (pat_ts, is_no_pattern) = match &anns[anns_rec.len()] {
+                        Attribute::Pattern(ts) => (ts, false),
+                        #[cfg(feature = "no-pattern")]
+                        Attribute::NoPattern(ts) => (ts, true),
                         _ => unreachable!(),
                     };
+                    // `is_no_pattern` is always `false` unless the `no-pattern`
+                    // feature is enabled (the only arm that sets it is gated).
+                    let _ = is_no_pattern;
                     if cur_pattern_rec.len() >= pat_ts.len() {
-                        anns_rec.push(recursor.on_attribute_pattern(pat_ts, cur_pattern_rec)?);
+                        #[cfg(feature = "no-pattern")]
+                        let attr = if is_no_pattern {
+                            recursor.on_attribute_no_pattern(pat_ts, cur_pattern_rec)?
+                        } else {
+                            recursor.on_attribute_pattern(pat_ts, cur_pattern_rec)?
+                        };
+                        #[cfg(not(feature = "no-pattern"))]
+                        let attr = recursor.on_attribute_pattern(pat_ts, cur_pattern_rec)?;
+                        anns_rec.push(attr);
                         cur_pattern_rec = vec![];
                         Self::advance_attributes_until_pattern(recursor, anns, &mut anns_rec)?;
                         if anns_rec.len() >= anns.len() {
@@ -954,6 +983,8 @@ where
                 ..
             } => match &anns[anns_rec.len()] {
                 Attribute::Pattern(ts) => Ok(&ts[cur_pattern_rec.len()]),
+                #[cfg(feature = "no-pattern")]
+                Attribute::NoPattern(ts) => Ok(&ts[cur_pattern_rec.len()]),
                 _ => unreachable!(),
             },
             Frame::Nary { ts, rec, .. } => Ok(&ts[rec.len()]),

--- a/src/raw/alg/rec.rs
+++ b/src/raw/alg/rec.rs
@@ -323,13 +323,13 @@ pub trait TermRecursor<Str, So, T> {
         patterns: &[T],
         patterns_rec: Vec<Self::Out>,
     ) -> Result<Self::Attr, Self::Err>;
-    /// Called for a `:no-pattern` attribute after its sub-term(s) have been
-    /// recursed. Only present under the `no-pattern` feature.
+    /// Called for a `:no-pattern` attribute after its (single) sub-term has
+    /// been recursed. Only present under the `no-pattern` feature.
     #[cfg(feature = "no-pattern")]
     fn on_attribute_no_pattern(
         &mut self,
-        patterns: &[T],
-        patterns_rec: Vec<Self::Out>,
+        pattern: &T,
+        pattern_rec: Self::Out,
     ) -> Result<Self::Attr, Self::Err>;
 
     // --- Binary / n-ary connectives ---
@@ -578,13 +578,8 @@ where
                     }
                 }
                 #[cfg(feature = "no-pattern")]
-                Attribute::NoPattern(ts) => {
-                    if ts.is_empty() {
-                        anns_rec.push(recursor.on_attribute_no_pattern(ts, vec![])?);
-                    } else {
-                        break;
-                    }
-                }
+                // `:no-pattern` always carries exactly one term: break to recurse it.
+                Attribute::NoPattern(_) => break,
                 Attribute::Keyword(k) => anns_rec.push(recursor.on_attribute_keyword(k)?),
                 Attribute::Constant(k, c) => anns_rec.push(recursor.on_attribute_constant(k, c)?),
                 Attribute::Symbol(k, s) => anns_rec.push(recursor.on_attribute_symbol(k, s)?),
@@ -781,17 +776,22 @@ where
                     mut cur_pattern_rec,
                 } => {
                     cur_pattern_rec.push(result);
-                    let (pat_ts, is_no_pattern) = match &anns[anns_rec.len()] {
-                        Attribute::Pattern(ts) => (ts, false),
+                    // `:no-pattern` has a single sub-term, viewed as a 1-elem
+                    // slice so it shares the pattern loop below.
+                    let (pat_ts, is_no_pattern): (&[T], bool) = match &anns[anns_rec.len()] {
+                        Attribute::Pattern(ts) => (ts.as_slice(), false),
                         #[cfg(feature = "no-pattern")]
-                        Attribute::NoPattern(ts) => (ts, true),
+                        Attribute::NoPattern(t) => (std::slice::from_ref(t), true),
                         _ => unreachable!(),
                     };
                     let _ = is_no_pattern; // only read under `no-pattern`
                     if cur_pattern_rec.len() >= pat_ts.len() {
                         #[cfg(feature = "no-pattern")]
                         let attr = if is_no_pattern {
-                            recursor.on_attribute_no_pattern(pat_ts, cur_pattern_rec)?
+                            recursor.on_attribute_no_pattern(
+                                &pat_ts[0],
+                                cur_pattern_rec.into_iter().next().unwrap(),
+                            )?
                         } else {
                             recursor.on_attribute_pattern(pat_ts, cur_pattern_rec)?
                         };
@@ -982,7 +982,7 @@ where
             } => match &anns[anns_rec.len()] {
                 Attribute::Pattern(ts) => Ok(&ts[cur_pattern_rec.len()]),
                 #[cfg(feature = "no-pattern")]
-                Attribute::NoPattern(ts) => Ok(&ts[cur_pattern_rec.len()]),
+                Attribute::NoPattern(t) => Ok(t),
                 _ => unreachable!(),
             },
             Frame::Nary { ts, rec, .. } => Ok(&ts[rec.len()]),

--- a/src/raw/alg/rec.rs
+++ b/src/raw/alg/rec.rs
@@ -787,9 +787,7 @@ where
                         Attribute::NoPattern(ts) => (ts, true),
                         _ => unreachable!(),
                     };
-                    // `is_no_pattern` is always `false` unless the `no-pattern`
-                    // feature is enabled (the only arm that sets it is gated).
-                    let _ = is_no_pattern;
+                    let _ = is_no_pattern; // only read under `no-pattern`
                     if cur_pattern_rec.len() >= pat_ts.len() {
                         #[cfg(feature = "no-pattern")]
                         let attr = if is_no_pattern {

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -159,6 +159,8 @@ where
             fn on_attribute_symbol(&mut self, keyword: &Keyword, symbol: &Str) -> Result<Self::Attr, Self::Err>;
             fn on_attribute_named(&mut self, name: &Str) -> Result<Self::Attr, Self::Err>;
             fn on_attribute_pattern(&mut self, patterns: &[T], patterns_rec: Vec<Self::Out>) -> Result<Self::Attr, Self::Err>;
+            #[cfg(feature = "no-pattern")]
+            fn on_attribute_no_pattern(&mut self, patterns: &[T], patterns_rec: Vec<Self::Out>) -> Result<Self::Attr, Self::Err>;
             fn on_let_binding(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, binding_idx: usize, binding_rec: Self::Out) -> Result<Self::Binding, Self::Err>;
             fn setup_let_scope(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: &[Self::Binding]) -> Result<(), Self::Err>;
             fn cleanup_let_scope_on_error(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: Vec<Self::Binding>);
@@ -405,6 +407,8 @@ where
             fn on_attribute_symbol(&mut self, keyword: &Keyword, symbol: &Str) -> Result<Self::Attr, Self::Err>;
             fn on_attribute_named(&mut self, name: &Str) -> Result<Self::Attr, Self::Err>;
             fn on_attribute_pattern(&mut self, patterns: &[T], patterns_rec: Vec<Self::Out>) -> Result<Self::Attr, Self::Err>;
+            #[cfg(feature = "no-pattern")]
+            fn on_attribute_no_pattern(&mut self, patterns: &[T], patterns_rec: Vec<Self::Out>) -> Result<Self::Attr, Self::Err>;
             fn on_let_binding(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, binding_idx: usize, binding_rec: Self::Out) -> Result<Self::Binding, Self::Err>;
             fn setup_let_scope(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: &[Self::Binding]) -> Result<(), Self::Err>;
             fn cleanup_let_scope_on_error(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: Vec<Self::Binding>);

--- a/src/raw/alg/rec_memo.rs
+++ b/src/raw/alg/rec_memo.rs
@@ -160,7 +160,7 @@ where
             fn on_attribute_named(&mut self, name: &Str) -> Result<Self::Attr, Self::Err>;
             fn on_attribute_pattern(&mut self, patterns: &[T], patterns_rec: Vec<Self::Out>) -> Result<Self::Attr, Self::Err>;
             #[cfg(feature = "no-pattern")]
-            fn on_attribute_no_pattern(&mut self, patterns: &[T], patterns_rec: Vec<Self::Out>) -> Result<Self::Attr, Self::Err>;
+            fn on_attribute_no_pattern(&mut self, pattern: &T, pattern_rec: Self::Out) -> Result<Self::Attr, Self::Err>;
             fn on_let_binding(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, binding_idx: usize, binding_rec: Self::Out) -> Result<Self::Binding, Self::Err>;
             fn setup_let_scope(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: &[Self::Binding]) -> Result<(), Self::Err>;
             fn cleanup_let_scope_on_error(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: Vec<Self::Binding>);
@@ -408,7 +408,7 @@ where
             fn on_attribute_named(&mut self, name: &Str) -> Result<Self::Attr, Self::Err>;
             fn on_attribute_pattern(&mut self, patterns: &[T], patterns_rec: Vec<Self::Out>) -> Result<Self::Attr, Self::Err>;
             #[cfg(feature = "no-pattern")]
-            fn on_attribute_no_pattern(&mut self, patterns: &[T], patterns_rec: Vec<Self::Out>) -> Result<Self::Attr, Self::Err>;
+            fn on_attribute_no_pattern(&mut self, pattern: &T, pattern_rec: Self::Out) -> Result<Self::Attr, Self::Err>;
             fn on_let_binding(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, binding_idx: usize, binding_rec: Self::Out) -> Result<Self::Binding, Self::Err>;
             fn setup_let_scope(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: &[Self::Binding]) -> Result<(), Self::Err>;
             fn cleanup_let_scope_on_error(&mut self, current: &T, vs: &[VarBinding<Str, T>], body: &T, vs_rec: Vec<Self::Binding>);

--- a/src/raw/tc.rs
+++ b/src/raw/tc.rs
@@ -1037,6 +1037,15 @@ where
         Ok(Attribute::Pattern(patterns_rec))
     }
 
+    #[cfg(feature = "no-pattern")]
+    fn on_attribute_no_pattern(
+        &mut self,
+        _patterns: &[T],
+        patterns_rec: Vec<Self::Out>,
+    ) -> Result<Self::Attr, Self::Err> {
+        Ok(Attribute::NoPattern(patterns_rec))
+    }
+
     fn on_eq(
         &mut self,
         _current: &T,
@@ -1191,6 +1200,12 @@ where
             )),
             alg::Attribute::Named(s) => Ok(Attribute::Named(env.arena.allocate_symbol(s.inner()))),
             alg::Attribute::Pattern(ts) => Ok(Attribute::Pattern(
+                ts.iter()
+                    .map(|t| t.type_check(env))
+                    .collect::<TC<Vec<_>>>()?,
+            )),
+            #[cfg(feature = "no-pattern")]
+            alg::Attribute::NoPattern(ts) => Ok(Attribute::NoPattern(
                 ts.iter()
                     .map(|t| t.type_check(env))
                     .collect::<TC<Vec<_>>>()?,

--- a/src/raw/tc.rs
+++ b/src/raw/tc.rs
@@ -1040,10 +1040,10 @@ where
     #[cfg(feature = "no-pattern")]
     fn on_attribute_no_pattern(
         &mut self,
-        _patterns: &[T],
-        patterns_rec: Vec<Self::Out>,
+        _pattern: &T,
+        pattern_rec: Self::Out,
     ) -> Result<Self::Attr, Self::Err> {
-        Ok(Attribute::NoPattern(patterns_rec))
+        Ok(Attribute::NoPattern(pattern_rec))
     }
 
     fn on_eq(
@@ -1205,11 +1205,7 @@ where
                     .collect::<TC<Vec<_>>>()?,
             )),
             #[cfg(feature = "no-pattern")]
-            alg::Attribute::NoPattern(ts) => Ok(Attribute::NoPattern(
-                ts.iter()
-                    .map(|t| t.type_check(env))
-                    .collect::<TC<Vec<_>>>()?,
-            )),
+            alg::Attribute::NoPattern(t) => Ok(Attribute::NoPattern(t.type_check(env)?)),
         }
     }
 }

--- a/src/untyped/instance.rs
+++ b/src/untyped/instance.rs
@@ -257,10 +257,7 @@ impl ActionOnAttribute for UntypedAst {
         _range: Range,
         term: Self::Term,
     ) -> ParsingResult<Self::Attribute> {
-        // `:no-pattern <term>` is an *anti*-trigger hint: it names a term that
-        // must NOT be used as an e-matching trigger. We preserve the term (as a
-        // single-element vector, mirroring `Pattern`) so consumers such as
-        // trigger inference can honor the exclusion.
+        // Length-1 vec, mirroring `Pattern`; see `Attribute::NoPattern`.
         Ok(Attribute::NoPattern(vec![term]))
     }
 }

--- a/src/untyped/instance.rs
+++ b/src/untyped/instance.rs
@@ -250,6 +250,19 @@ impl ActionOnAttribute for UntypedAst {
     ) -> ParsingResult<Self::Attribute> {
         Ok(Attribute::Pattern(patterns))
     }
+
+    #[cfg(feature = "no-pattern")]
+    fn on_attribute_no_pattern(
+        &mut self,
+        _range: Range,
+        term: Self::Term,
+    ) -> ParsingResult<Self::Attribute> {
+        // `:no-pattern <term>` is an *anti*-trigger hint: it names a term that
+        // must NOT be used as an e-matching trigger. We preserve the term (as a
+        // single-element vector, mirroring `Pattern`) so consumers such as
+        // trigger inference can honor the exclusion.
+        Ok(Attribute::NoPattern(vec![term]))
+    }
 }
 
 impl ActionOnSort for UntypedAst {

--- a/src/untyped/instance.rs
+++ b/src/untyped/instance.rs
@@ -257,8 +257,7 @@ impl ActionOnAttribute for UntypedAst {
         _range: Range,
         term: Self::Term,
     ) -> ParsingResult<Self::Attribute> {
-        // Length-1 vec, mirroring `Pattern`; see `Attribute::NoPattern`.
-        Ok(Attribute::NoPattern(vec![term]))
+        Ok(Attribute::NoPattern(term))
     }
 }
 

--- a/tests/no_pattern.rs
+++ b/tests/no_pattern.rs
@@ -38,9 +38,7 @@ fn parses_no_pattern_attribute() {
 #[test]
 fn no_pattern_term_is_preserved() {
     let cmds = UntypedAst
-        .parse_script_str(
-            "(assert (forall ((x Int)) (! (p x) :no-pattern (f x))))",
-        )
+        .parse_script_str("(assert (forall ((x Int)) (! (p x) :no-pattern (f x))))")
         .expect("parse");
     let printed = format!("{}", cmds[0]);
     assert!(

--- a/tests/no_pattern.rs
+++ b/tests/no_pattern.rs
@@ -1,0 +1,54 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression tests for the `no-pattern` feature: parsing the non-standard
+//! `:no-pattern <term>` quantifier attribute emitted by Dafny/Boogie.
+//!
+//! These tests only run when the `no-pattern` feature is enabled (the attribute
+//! is not part of the SMT-LIB 2.7 grammar otherwise). See issue #122.
+
+#![cfg(feature = "no-pattern")]
+
+use yaspar_ir::ast::{Context, Typecheck};
+use yaspar_ir::untyped::UntypedAst;
+
+/// A quantifier carrying both `:pattern` and `:no-pattern` (the Dafny/Boogie
+/// shape) parses and type-checks.
+#[test]
+fn parses_no_pattern_attribute() {
+    let mut ctx = Context::new();
+    let cmds = UntypedAst
+        .parse_script_str(
+            r#"
+        (set-logic ALL)
+        (declare-fun p (Int) Bool)
+        (declare-fun f (Int) Int)
+        (assert (forall ((x Int))
+            (! (p (f x)) :pattern ((p (f x))) :no-pattern (f x))))
+    "#,
+        )
+        .expect("script with :no-pattern should parse")
+        .type_check(&mut ctx)
+        .expect("script with :no-pattern should type-check");
+    assert_eq!(cmds.len(), 4);
+}
+
+/// The `:no-pattern` term is preserved (not dropped): the parsed AST round-trips
+/// through `Display` with the annotated term still present.
+#[test]
+fn no_pattern_term_is_preserved() {
+    let cmds = UntypedAst
+        .parse_script_str(
+            "(assert (forall ((x Int)) (! (p x) :no-pattern (f x))))",
+        )
+        .expect("parse");
+    let printed = format!("{}", cmds[0]);
+    assert!(
+        printed.contains(":no-pattern"),
+        "expected :no-pattern to survive Display, got: {printed}"
+    );
+    assert!(
+        printed.contains("f x") || printed.contains("(f x)"),
+        "expected the excluded term (f x) to survive Display, got: {printed}"
+    );
+}

--- a/tests/rec.rs
+++ b/tests/rec.rs
@@ -202,10 +202,10 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
     #[cfg(feature = "no-pattern")]
     fn on_attribute_no_pattern(
         &mut self,
-        _patterns: &[Term],
-        patterns_rec: Vec<Self::Out>,
+        _pattern: &Term,
+        pattern_rec: Self::Out,
     ) -> Result<Self::Attr, Self::Err> {
-        Ok(patterns_rec.into_iter().sum::<usize>())
+        Ok(pattern_rec)
     }
 
     fn on_eq(

--- a/tests/rec.rs
+++ b/tests/rec.rs
@@ -199,6 +199,15 @@ impl TermRecursor<Str, Sort, Term> for TermSize {
         Ok(patterns_rec.into_iter().sum::<usize>())
     }
 
+    #[cfg(feature = "no-pattern")]
+    fn on_attribute_no_pattern(
+        &mut self,
+        _patterns: &[Term],
+        patterns_rec: Vec<Self::Out>,
+    ) -> Result<Self::Attr, Self::Err> {
+        Ok(patterns_rec.into_iter().sum::<usize>())
+    }
+
     fn on_eq(
         &mut self,
         _current: &Term,

--- a/tests/rec_memo.rs
+++ b/tests/rec_memo.rs
@@ -211,10 +211,10 @@ impl TermRecursor<Str, Sort, Term> for TouchedTermSize {
     #[cfg(feature = "no-pattern")]
     fn on_attribute_no_pattern(
         &mut self,
-        _patterns: &[Term],
-        patterns_rec: Vec<Self::Out>,
+        _pattern: &Term,
+        pattern_rec: Self::Out,
     ) -> Result<Self::Attr, Self::Err> {
-        Ok(patterns_rec.into_iter().sum::<usize>())
+        Ok(pattern_rec)
     }
 
     fn on_eq(

--- a/tests/rec_memo.rs
+++ b/tests/rec_memo.rs
@@ -208,6 +208,15 @@ impl TermRecursor<Str, Sort, Term> for TouchedTermSize {
         Ok(patterns_rec.into_iter().sum::<usize>())
     }
 
+    #[cfg(feature = "no-pattern")]
+    fn on_attribute_no_pattern(
+        &mut self,
+        _patterns: &[Term],
+        patterns_rec: Vec<Self::Out>,
+    ) -> Result<Self::Attr, Self::Err> {
+        Ok(patterns_rec.into_iter().sum::<usize>())
+    }
+
     fn on_eq(
         &mut self,
         _current: &Term,


### PR DESCRIPTION
*Issue:* #122 

*Description of changes:*  `:no-pattern <term>` is an *anti-trigger* hint — it names a term that must **not** be used as an e-matching trigger. Boogie/Dafny-generated queries use it heavily, so parsing it is needed to consume those benchmarks.

This depends on`yaspar` change that adds `:no-pattern` grammar support and the `on_attribute_no_pattern` callback (yaspar-org/yaspar#9).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

