### PR TITLE
make overloaded-application fallback error lazy in typed_app

### DIFF
--- a/src/raw/tc/app.rs
+++ b/src/raw/tc/app.rs
@@ -784,11 +784,9 @@ where
         )
     } else {
         // 4. if the function is overloaded, we try all signatures.
-        let mut tc_res = Err(format!(
-            "TC: overloaded function {f}{id_meta} does not have a case to match its list of arguments! '{print_struct}'",
-        ));
+        let mut tc_res = None;
         for (sig, _) in sigs {
-            tc_res = type_check_with_func_sig(
+            let attempt = type_check_with_func_sig(
                 &print_struct,
                 env,
                 WithMeta::new(&f, id_meta),
@@ -797,10 +795,24 @@ where
                 sig,
                 app_meta,
             );
-            if tc_res.is_ok() {
+            let ok = attempt.is_ok();
+            tc_res = Some(attempt);
+            if ok {
                 break;
             }
         }
-        tc_res
+        // The fallback error is only constructed if no signature matched (or the
+        // signature list was empty -- not constructible through the public API,
+        // but kept as a graceful Err to preserve the previous behavior exactly).
+        // Laziness matters here: rendering
+        // `print_struct` walks the whole application (all argument subtrees), so
+        // building the message eagerly made every overloaded application cost O(term size)
+        // in time and O(term depth) in native stack -- quadratic and prone to
+        // stack overflow for iteratively built terms.
+        tc_res.unwrap_or_else(|| {
+            Err(format!(
+                "TC: overloaded function {f}{id_meta} does not have a case to match its list of arguments! '{print_struct}'",
+            ))
+        })
     }
 }

--- a/tests/checked.rs
+++ b/tests/checked.rs
@@ -773,3 +773,92 @@ fn test_typed_match_negatives() {
     let bar = context.typed_symbol("bar").unwrap();
     assert!(context.build_matching(bar).is_err());
 }
+
+// Regression tests for the eager overload-error formatting bug: `typed_app`
+// used to render the full application text (via `AppFmt`) into a fallback
+// error string BEFORE trying any signature of an overloaded function. Each
+// application of `+`, `-`, `*`, `<`, `<=`, `>`, `>=` (two signatures each
+// under logic ALL) therefore cost O(term size) time and O(term depth) native
+// stack, making iteratively built terms quadratic overall and crashing with a
+// stack overflow at a few thousand levels of nesting.
+
+/// Builds a deeply left-nested chain `(+ (+ ... (+ x 1) ... 1) 1)` through an
+/// overloaded builtin on a deliberately small thread stack. Before the fix,
+/// the eager error formatting recursed over the whole accumulator on every
+/// application and aborted with a stack overflow at a small fraction of this
+/// depth; after the fix no per-application rendering happens at all.
+#[test]
+fn overloaded_app_deep_chain_no_eager_error_formatting() {
+    let handle = std::thread::Builder::new()
+        .stack_size(1024 * 1024)
+        .spawn(|| {
+            let mut context = Context::new();
+            UntypedAst
+                .parse_script_str("(set-logic ALL)\n(declare-const x Int)")
+                .unwrap()
+                .type_check(&mut context)
+                .unwrap();
+            let one = context.integer(IBig::from(1)).unwrap();
+            let mut acc = context.typed_symbol("x").unwrap();
+            for _ in 0..4_000 {
+                acc = context
+                    .typed_simp_app("+", [acc, one.clone()])
+                    .expect("well-sorted overloaded application must succeed");
+            }
+            let int_sort = context.int_sort();
+            assert_eq!(acc.get_sort(&mut context), int_sort);
+        })
+        .unwrap();
+    handle
+        .join()
+        .expect("deep overloaded chain must not overflow the stack");
+}
+
+/// Overload resolution semantics are unchanged: `+` resolves to the Int
+/// signature for Int arguments and the Real signature for Real arguments.
+#[test]
+fn overloaded_app_still_resolves_signatures() {
+    let mut context = Context::new();
+    UntypedAst
+        .parse_script_str("(set-logic ALL)\n(declare-const i Int)\n(declare-const r Real)")
+        .unwrap()
+        .type_check(&mut context)
+        .unwrap();
+
+    let i = context.typed_symbol("i").unwrap();
+    let int_plus = context.typed_simp_app("+", [i.clone(), i]).unwrap();
+    let int_sort = context.int_sort();
+    assert_eq!(int_plus.get_sort(&mut context), int_sort);
+
+    let r = context.typed_symbol("r").unwrap();
+    let real_plus = context.typed_simp_app("+", [r.clone(), r]).unwrap();
+    let real_sort = context.real_sort();
+    assert_eq!(real_plus.get_sort(&mut context), real_sort);
+}
+
+/// When no signature of an overloaded function matches, the error of the last
+/// attempted signature is still returned (same behavior as before the fix).
+/// Under logic ALL, `+` carries the Int signature then the Real signature, so
+/// last-attempt-wins means the Real error text is the one reported.
+#[test]
+fn overloaded_app_failure_still_reports_error() {
+    let mut context = Context::new();
+    UntypedAst
+        .parse_script_str("(set-logic ALL)\n(declare-const p Bool)")
+        .unwrap()
+        .type_check(&mut context)
+        .unwrap();
+
+    let p = context.typed_symbol("p").unwrap();
+    let err = context
+        .typed_simp_app("+", [p.clone(), p])
+        .expect_err("Bool arguments must not type-check against any + signature");
+    assert!(
+        err.contains("expects sort Real"),
+        "expected the LAST attempted signature's (Real) error, got: {err}"
+    );
+    assert!(
+        !err.contains("does not have a case to match"),
+        "the fallback error must not replace the per-signature error: {err}"
+    );
+}


### PR DESCRIPTION
## Symptom

Building terms iteratively through overloaded builtins, e.g. `acc = (+ acc c)` in a loop, gets slower per call as the term deepens (measured in a downstream consumer: ~250us/node at depth 1,500 rising linearly to ~4ms/node at depth 20,000 - quadratic total) and then aborts with a native stack overflow at roughly depth 4,000 on 1MB thread stacks. No panic, no error - process death.

## Root cause

In the overloaded branch of `typed_app` (`src/raw/tc/app.rs`), the fallback error is constructed eagerly, before any signature is tried:

```rust
let mut tc_res = Err(format!(
    "TC: overloaded function {f}{id_meta} does not have a case to match its list of arguments! '{print_struct}'",
));
for (sig, _) in sigs { ... }
```

`print_struct` is an `AppFmt` whose `Display` renders the full application - every argument subtree, recursively. Under `(set-logic ALL)`, the builtins `+ - * < <= > >=` each carry two signatures (Int and Real), so **every** application of these operators pays O(term size) time and O(term depth) native stack to build an error string that is discarded as soon as the first signature matches (which, for well-sorted terms, it does).

Single-signature operators (`mod`, `div`, `abs`, ...) take the `sigs.len() == 1` path and are unaffected - which is also how the cause was isolated: chaining `mod` is flat (~5us/node at depth 3,000, debug build) while chaining `+` grows linearly per node (437us at depth 500, 2,148us at depth 1,500) and overflows the stack shortly after.

## Fix

Construct the fallback error only after all signatures have failed. Behavior is unchanged:

- a successful match returns the same `Ok` (now with zero formatting work);
- when all signatures fail, the error of the last attempted signature is returned, exactly as before (the old code overwrote `tc_res` on each iteration);
- an empty signature list still produces the "does not have a case to match" message via `unwrap_or_else`. As far as I can tell this path is not constructible through the public API (symbol-table entries are always inserted with at least one signature, and `remove_symbol` removes whole entries), so it is kept as a graceful `Err` purely to preserve the previous behavior byte-for-byte rather than upgraded to a panic - happy to change that if you prefer the invariant enforced.

With the fix, the `+` chain benchmark is flat (~7us/node through depth 3,000, debug build) and the stack overflow is gone.

## Testing

- New regression test `overloaded_app_deep_chain_no_eager_error_formatting`: builds a 4,000-deep `(+ acc 1)` chain on a 1MB stack thread. Verified to abort with a stack overflow on unfixed code and pass with the fix.
- New test `overloaded_app_still_resolves_signatures`: `+` still resolves Int/Real signatures correctly.
- New test `overloaded_app_failure_still_reports_error`: `(+ Bool Bool)` still fails with the per-argument sort error.
- Full suite: 231 tests across 18 binaries pass; `cargo fmt --check` and `cargo clippy --tests` clean.

## Out of scope (pre-existing, noted for completeness)

Two related recursion hazards remain and are untouched by this change: (1) a *genuine* type-check failure on a very deep term still renders the message recursively via `Display` and can overflow (error path only); (2) dropping a very deep term recurses through the `Arc` chain at context teardown. Both are far less exposed than the happy path fixed here and seem better handled separately (iterative formatting / iterative drop).
