### PR TITLE
Preserve inferred sort ascriptions when formatting terms

### DIFF
--- a/src/ast/ctx/matching.rs
+++ b/src/ast/ctx/matching.rs
@@ -53,7 +53,10 @@ use std::collections::{HashMap, HashSet};
 /// let h = cons_arm.typed_symbol("h").unwrap();
 /// cons_arm.typed_arm(h).unwrap();
 /// let term = m.typed_matching().unwrap();
-/// assert_eq!(term.to_string(), "(match l ((nil 0) ((cons h t) h)))");
+/// assert_eq!(
+///     term.to_string(),
+///     "(match (as l (List Int)) ((nil 0) ((cons h t) h)))"
+/// );
 /// ```
 pub struct MatchContext<'a, 'b> {
     context: &'a mut Context,

--- a/src/raw/alg.rs
+++ b/src/raw/alg.rs
@@ -17,7 +17,7 @@
 //! `super::instance`, we show a more memory-efficient version using an interning library.
 
 use crate::statics::*;
-use crate::traits::Contains;
+use crate::traits::{Contains, Repr};
 use dashu::base::Sign;
 use dashu::float::DBig;
 use dashu::integer::UBig;
@@ -1406,13 +1406,21 @@ where
 impl<Str, So, T> Display for Term<Str, So, T>
 where
     Str: Display + StrQuote<String> + SymbolQuote<String>,
-    So: Display,
+    So: Display + Contains,
+    So::T: Repr<T = Sort<Str, So>>,
     T: Display,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Term::Constant(c, _) => c.fmt(f),
-            Term::Global(id, _) => id.fmt(f),
+            Term::Global(id, sort) => match (&id.1, sort) {
+                // The symbol table is unavailable here, so preserve enough sort information
+                // for nullary parametric constructors to be parsed again.
+                (None, Some(sort)) if !sort.inner().repr().1.is_empty() => {
+                    write!(f, "(as {} {})", id.0, sort)
+                }
+                _ => id.fmt(f),
+            },
             Term::Local(id) => write!(f, "{}", id.symbol.sym_quote()),
             Term::App(id, args, _) => fmt_app(f, id, args),
             Term::Let(vs, body) => fmt_binder(f, "let", vs, body),

--- a/tests/cvc5.rs
+++ b/tests/cvc5.rs
@@ -2434,7 +2434,7 @@ fn back_from_cvc5_api_uf_application() {
 
 #[test]
 fn back_from_cvc5_api_select_store() {
-    assert_back_eq("(select (store a i v) i)", |tm| {
+    assert_back_eq("(select (store (as a (Array Int Int)) i v) i)", |tm| {
         let int = tm.integer_sort();
         let arr = tm.mk_array_sort(int.clone(), int.clone());
         let a = tm.mk_const(arr, "a");

--- a/tests/cvc5_finite_sets.rs
+++ b/tests/cvc5_finite_sets.rs
@@ -405,7 +405,7 @@ fn back_from_cvc5_api_fset_singleton() {
 
 #[test]
 fn back_from_cvc5_api_fset_union() {
-    assert_back_eq("(set.union a b)", |tm| {
+    assert_back_eq("(set.union (as a (Set Int)) (as b (Set Int)))", |tm| {
         let s = tm.mk_set_sort(tm.integer_sort());
         let a = tm.mk_const(s.clone(), "a");
         let b = tm.mk_const(s, "b");
@@ -415,7 +415,7 @@ fn back_from_cvc5_api_fset_union() {
 
 #[test]
 fn back_from_cvc5_api_fset_inter() {
-    assert_back_eq("(set.inter a b)", |tm| {
+    assert_back_eq("(set.inter (as a (Set Int)) (as b (Set Int)))", |tm| {
         let s = tm.mk_set_sort(tm.integer_sort());
         let a = tm.mk_const(s.clone(), "a");
         let b = tm.mk_const(s, "b");
@@ -425,7 +425,7 @@ fn back_from_cvc5_api_fset_inter() {
 
 #[test]
 fn back_from_cvc5_api_fset_minus() {
-    assert_back_eq("(set.minus a b)", |tm| {
+    assert_back_eq("(set.minus (as a (Set Int)) (as b (Set Int)))", |tm| {
         let s = tm.mk_set_sort(tm.integer_sort());
         let a = tm.mk_const(s.clone(), "a");
         let b = tm.mk_const(s, "b");
@@ -435,7 +435,7 @@ fn back_from_cvc5_api_fset_minus() {
 
 #[test]
 fn back_from_cvc5_api_fset_member() {
-    assert_back_eq("(set.member x a)", |tm| {
+    assert_back_eq("(set.member x (as a (Set Int)))", |tm| {
         let int = tm.integer_sort();
         let s = tm.mk_set_sort(int.clone());
         let x = tm.mk_const(int, "x");
@@ -446,7 +446,7 @@ fn back_from_cvc5_api_fset_member() {
 
 #[test]
 fn back_from_cvc5_api_fset_subset() {
-    assert_back_eq("(set.subset a b)", |tm| {
+    assert_back_eq("(set.subset (as a (Set Int)) (as b (Set Int)))", |tm| {
         let s = tm.mk_set_sort(tm.integer_sort());
         let a = tm.mk_const(s.clone(), "a");
         let b = tm.mk_const(s, "b");
@@ -456,7 +456,7 @@ fn back_from_cvc5_api_fset_subset() {
 
 #[test]
 fn back_from_cvc5_api_fset_card() {
-    assert_back_eq("(set.card a)", |tm| {
+    assert_back_eq("(set.card (as a (Set Int)))", |tm| {
         let s = tm.mk_set_sort(tm.integer_sort());
         let a = tm.mk_const(s, "a");
         tm.mk_term(Kind::SetCard, &[a])
@@ -465,7 +465,7 @@ fn back_from_cvc5_api_fset_card() {
 
 #[test]
 fn back_from_cvc5_api_fset_complement() {
-    assert_back_eq("(set.complement a)", |tm| {
+    assert_back_eq("(set.complement (as a (Set Int)))", |tm| {
         let s = tm.mk_set_sort(tm.integer_sort());
         let a = tm.mk_const(s, "a");
         tm.mk_term(Kind::SetComplement, &[a])
@@ -474,12 +474,15 @@ fn back_from_cvc5_api_fset_complement() {
 
 #[test]
 fn back_from_cvc5_api_fset_nested() {
-    assert_back_eq("(set.union (set.inter a b) c)", |tm| {
-        let s = tm.mk_set_sort(tm.integer_sort());
-        let a = tm.mk_const(s.clone(), "a");
-        let b = tm.mk_const(s.clone(), "b");
-        let c = tm.mk_const(s, "c");
-        let inter = tm.mk_term(Kind::SetInter, &[a, b]);
-        tm.mk_term(Kind::SetUnion, &[inter, c])
-    });
+    assert_back_eq(
+        "(set.union (set.inter (as a (Set Int)) (as b (Set Int))) (as c (Set Int)))",
+        |tm| {
+            let s = tm.mk_set_sort(tm.integer_sort());
+            let a = tm.mk_const(s.clone(), "a");
+            let b = tm.mk_const(s.clone(), "b");
+            let c = tm.mk_const(s, "c");
+            let inter = tm.mk_term(Kind::SetInter, &[a, b]);
+            tm.mk_term(Kind::SetUnion, &[inter, c])
+        },
+    );
 }

--- a/tests/nullary_constructor.rs
+++ b/tests/nullary_constructor.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-use yaspar_ir::ast::{CheckedApi, Context, Typecheck};
+use yaspar_ir::ast::alg::QualifiedIdentifier;
+use yaspar_ir::ast::{CheckedApi, Context, ScopedSortApi, StrAllocator, TermAllocator, Typecheck};
 use yaspar_ir::untyped::UntypedAst;
 
 #[test]
@@ -17,4 +18,33 @@ fn nullary_constructor() {
     // Apply the nullary constructor via the typed API (same path the solver client uses)
     let term = ctx.typed_simp_app("Red", std::iter::empty());
     assert!(term.is_err());
+}
+
+#[test]
+fn displays_inferred_sort_for_parametric_nullary_constructor() {
+    let mut ctx = Context::new();
+    ctx.ensure_logic();
+
+    UntypedAst
+        .parse_script_str(
+            "(declare-sort Val 0)
+             (declare-datatypes ((Option 1))
+               ((par (T) ((None) (Some (value T))))))",
+        )
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
+
+    let val = ctx.wf_sort("Val").unwrap();
+    let option_val = ctx.wf_sort_n("Option", [val]).unwrap();
+    let none = ctx.allocate_symbol("None");
+    let term = ctx.global(QualifiedIdentifier::simple(none), Some(option_val));
+    let formatted = term.to_string();
+
+    assert_eq!(formatted, "(as None (Option Val))");
+    UntypedAst
+        .parse_term_str(&formatted)
+        .unwrap()
+        .type_check(&mut ctx)
+        .unwrap();
 }

--- a/tests/substitutions.rs
+++ b/tests/substitutions.rs
@@ -451,7 +451,10 @@ fn test_gsubst_datatype_tester() {
     let is_nil = ctx.typed_simp_app("is-nil", [l.clone()]).unwrap();
 
     let expanded_inplace = is_nil.gsubst(["is-nil"], &mut ctx);
-    assert_eq!(expanded_inplace.to_string(), "((_ is nil) l)");
+    assert_eq!(
+        expanded_inplace.to_string(),
+        "((_ is nil) (as l (List Int)))"
+    );
     expanded_inplace.type_check(&mut ctx).unwrap();
 }
 
@@ -478,7 +481,7 @@ fn test_gsubst_datatype_tester_in_formula() {
     let expanded_inplace = formula.gsubst(["is-nil", "is-cons"], &mut ctx);
     assert_eq!(
         expanded_inplace.to_string(),
-        "(or ((_ is nil) l) ((_ is cons) l))"
+        "(or ((_ is nil) (as l (List Real))) ((_ is cons) (as l (List Real))))"
     );
     expanded_inplace.type_check(&mut ctx).unwrap();
 }
@@ -539,7 +542,7 @@ fn test_gsubst_multiple_datatype_testers() {
     let expanded_inplace = xor.gsubst(["is-none", "is-some"], &mut ctx);
     assert_eq!(
         expanded_inplace.to_string(),
-        "(xor ((_ is none) opt) ((_ is some) opt))"
+        "(xor ((_ is none) (as opt (Option Bool))) ((_ is some) (as opt (Option Bool))))"
     );
     expanded_inplace.type_check(&mut ctx).unwrap();
 }


### PR DESCRIPTION
*Issue #, if available:* #127

*Description of changes:* Fix parametric datatypes to include sort information when printing terms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.